### PR TITLE
chore: bump version to v0.0.1-a25

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -32,5 +32,5 @@ keywords:
   - Brain connectivity
   - Python
 license: BSD-3-Clause
-version: 0.0.1-a24
-date-released: '2026-04-09'
+version: 0.0.1-a25
+date-released: '2026-04-19'

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ and tutorials.
 
 If you use ConfUSIus in your research, please cite it using the following reference:
 
-> Le Meur-Diebolt, S., & Cybis Pereira, F. (2026). ConfUSIus (v0.0.1-a24). Zenodo.
+> Le Meur-Diebolt, S., & Cybis Pereira, F. (2026). ConfUSIus (v0.0.1-a25). Zenodo.
 > https://doi.org/10.5281/zenodo.18611124
 
 Or in BibTeX format:
@@ -124,7 +124,7 @@ Or in BibTeX format:
   title     = {ConfUSIus},
   year      = {2026},
   publisher = {Zenodo},
-  version   = {v0.0.1-a24},
+  version   = {v0.0.1-a25},
   doi       = {10.5281/zenodo.18611124},
   url       = {https://doi.org/10.5281/zenodo.18611124}
 }

--- a/docs/citing.md
+++ b/docs/citing.md
@@ -6,7 +6,7 @@ icon: lucide/quote
 
 If you use ConfUSIus in your research, please cite it using the following reference:
 
-> Le Meur-Diebolt, S., & Cybis Pereira, F. (2026). ConfUSIus (v0.0.1-a24). Zenodo.
+> Le Meur-Diebolt, S., & Cybis Pereira, F. (2026). ConfUSIus (v0.0.1-a25). Zenodo.
 > https://doi.org/10.5281/zenodo.18611124
 
 Or in BibTeX format:
@@ -17,7 +17,7 @@ Or in BibTeX format:
   title     = {ConfUSIus},
   year      = {2026},
   publisher = {Zenodo},
-  version   = {v0.0.1-a24},
+  version   = {v0.0.1-a25},
   doi       = {10.5281/zenodo.18611124},
   url       = {https://doi.org/10.5281/zenodo.18611124}
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "confusius"
-version = "0.0.1-a24"
+version = "0.0.1-a25"
 description = "Python package for analysis and visualization of functional ultrasound imaging data."
 readme = "README.md"
 license = "BSD-3-Clause AND Apache-2.0 AND BSD-2-Clause"

--- a/uv.lock
+++ b/uv.lock
@@ -623,7 +623,7 @@ wheels = [
 
 [[package]]
 name = "confusius"
-version = "0.0.1a24"
+version = "0.0.1a25"
 source = { editable = "." }
 dependencies = [
     { name = "brainglobe-atlasapi" },


### PR DESCRIPTION
Version bump for v0.0.1-a25 release.

## Changes
- `pyproject.toml`, `CITATION.cff`, `README.md`, `docs/citing.md`: bump version string
- `uv.lock`: resync

Tag will be created on the merged commit post-merge.