### PR TITLE
fix: `plot_volume` respects coordinates order

### DIFF
--- a/src/confusius/plotting/image.py
+++ b/src/confusius/plotting/image.py
@@ -418,10 +418,16 @@ class VolumePlotter:
         axis_idx: int,
         new_lim: tuple[float, float],
     ) -> tuple[float, float]:
-        """Expand the stored limit for `axis_idx` to encompass `new_lim`."""
+        """Expand the stored limit for `axis_idx` to encompass `new_lim`.
+
+        Preserves the direction (increasing vs. decreasing) implied by `new_lim`
+        so that reversed coordinate arrays keep their orientation.
+        """
         if axis_idx in store:
             prev = store[axis_idx]
-            new_lim = (min(prev[0], new_lim[0]), max(prev[1], new_lim[1]))
+            lo = min(prev[0], prev[1], new_lim[0], new_lim[1])
+            hi = max(prev[0], prev[1], new_lim[0], new_lim[1])
+            new_lim = (lo, hi) if new_lim[0] <= new_lim[1] else (hi, lo)
         store[axis_idx] = new_lim
         return new_lim
 
@@ -708,11 +714,12 @@ class VolumePlotter:
                 ax.axis("off")
 
             # Expand stored limits to encompass overlaid volumes with different extents.
+            # Use first/last (not min/max) so reversed coordinate arrays keep direction.
             current_xlim = self._update_stored_lim(
-                self._axis_xlims, axis_idx, (float(x_vals.min()), float(x_vals.max()))
+                self._axis_xlims, axis_idx, (float(x_vals[0]), float(x_vals[-1]))
             )
             current_ylim = self._update_stored_lim(
-                self._axis_ylims, axis_idx, (float(y_vals.min()), float(y_vals.max()))
+                self._axis_ylims, axis_idx, (float(y_vals[0]), float(y_vals[-1]))
             )
             self._set_ax_lims(ax, current_xlim, current_ylim)
 
@@ -995,8 +1002,8 @@ class VolumePlotter:
                 # matplotlib limits, which may include padding.
                 x_edges = _centers_to_edges(x_coords)
                 y_edges = _centers_to_edges(y_coords)
-                xlim = (float(x_edges.min()), float(x_edges.max()))
-                ylim = (float(y_edges.min()), float(y_edges.max()))
+                xlim = (float(x_edges[0]), float(x_edges[-1]))
+                ylim = (float(y_edges[0]), float(y_edges[-1]))
                 self._set_ax_lims(ax, xlim, ylim)
                 self._style_ax(ax)
                 ax.set_xlabel(_build_axis_label(mask, dim_col), color=self._text_color)

--- a/tests/unit/test_plotting/test_image.py
+++ b/tests/unit/test_plotting/test_image.py
@@ -251,9 +251,7 @@ class TestPlotVolume:
             (y_centers[0] - dy / 2, y_centers[-1] + dy / 2)
         )
 
-    def test_reversed_y_coord_flips_ylim(
-        self, sample_3d_volume, matplotlib_pyplot
-    ):
+    def test_reversed_y_coord_flips_ylim(self, sample_3d_volume, matplotlib_pyplot):
         """Reversing y coords via isel flips the y-axis orientation."""
         z_coord = sample_3d_volume.coords["z"].values[0]
 
@@ -265,7 +263,8 @@ class TestPlotVolume:
         )
         ylim_normal = plotter_normal.axes[0, 0].get_ylim()
 
-        reversed_volume = sample_3d_volume.isel(y=slice(None, None, -1))
+        reversed_volume = sample_3d_volume.copy()
+        reversed_volume.coords["y"] = reversed_volume.coords["y"][::-1]
         plotter_reversed = plot_volume(
             reversed_volume,
             slice_mode="z",
@@ -281,7 +280,8 @@ class TestPlotVolume:
     ):
         """Overlaying volumes keeps the direction of the most recently added volume."""
         z_coord = sample_3d_volume.coords["z"].values[0]
-        reversed_volume = sample_3d_volume.isel(y=slice(None, None, -1))
+        reversed_volume = sample_3d_volume.copy()
+        reversed_volume.coords["y"] = reversed_volume.coords["y"][::-1]
 
         plotter = plot_volume(
             sample_3d_volume,

--- a/tests/unit/test_plotting/test_image.py
+++ b/tests/unit/test_plotting/test_image.py
@@ -251,6 +251,48 @@ class TestPlotVolume:
             (y_centers[0] - dy / 2, y_centers[-1] + dy / 2)
         )
 
+    def test_reversed_y_coord_flips_ylim(
+        self, sample_3d_volume, matplotlib_pyplot
+    ):
+        """Reversing y coords via isel flips the y-axis orientation."""
+        z_coord = sample_3d_volume.coords["z"].values[0]
+
+        plotter_normal = plot_volume(
+            sample_3d_volume,
+            slice_mode="z",
+            slice_coords=[z_coord],
+            show_colorbar=False,
+        )
+        ylim_normal = plotter_normal.axes[0, 0].get_ylim()
+
+        reversed_volume = sample_3d_volume.isel(y=slice(None, None, -1))
+        plotter_reversed = plot_volume(
+            reversed_volume,
+            slice_mode="z",
+            slice_coords=[z_coord],
+            show_colorbar=False,
+        )
+        ylim_reversed = plotter_reversed.axes[0, 0].get_ylim()
+
+        assert ylim_reversed == pytest.approx((ylim_normal[1], ylim_normal[0]))
+
+    def test_overlay_preserves_reversed_direction(
+        self, sample_3d_volume, matplotlib_pyplot
+    ):
+        """Overlaying volumes keeps the direction of the most recently added volume."""
+        z_coord = sample_3d_volume.coords["z"].values[0]
+        reversed_volume = sample_3d_volume.isel(y=slice(None, None, -1))
+
+        plotter = plot_volume(
+            sample_3d_volume,
+            slice_mode="z",
+            slice_coords=[z_coord],
+            show_colorbar=False,
+        )
+        plotter.add_volume(reversed_volume, slice_coords=[z_coord])
+        ylim = plotter.axes[0, 0].get_ylim()
+        assert ylim[0] < ylim[1]
+
     def test_existing_figure_used(self, sample_3d_volume, matplotlib_pyplot):
         """plot_volume uses the provided figure to create new axes inside it."""
         import matplotlib.pyplot as plt


### PR DESCRIPTION
- Close #54 

## Summary
- Reversing a `DataArray` via `isel(y=slice(None, None, -1))` was a no-op visually in `plot_volume`.
- `VolumePlotter` now records per-axis limits as `(first, last)` edges and `_update_stored_lim` preserves the direction of the incoming limit when merging overlays.

## Test plan
- [x] New regression tests: `test_reversed_y_coord_flips_ylim`, `test_overlay_preserves_reversed_direction` (fail on `main`, pass after fix)