### PR TITLE
fix(plotting): respect coordinate ordering in plot_volume axis limits

### DIFF
--- a/src/confusius/plotting/image.py
+++ b/src/confusius/plotting/image.py
@@ -709,10 +709,10 @@ class VolumePlotter:
 
             # Expand stored limits to encompass overlaid volumes with different extents.
             current_xlim = self._update_stored_lim(
-                self._axis_xlims, axis_idx, (float(x_vals.min()), float(x_vals.max()))
+                self._axis_xlims, axis_idx, (float(x_vals[0]), float(x_vals[-1]))
             )
             current_ylim = self._update_stored_lim(
-                self._axis_ylims, axis_idx, (float(y_vals.min()), float(y_vals.max()))
+                self._axis_ylims, axis_idx, (float(y_vals[0]), float(y_vals[-1]))
             )
             self._set_ax_lims(ax, current_xlim, current_ylim)
 


### PR DESCRIPTION
## Summary

When `plot_volume` is called with an xarray whose coordinates have been reversed (e.g. via `isel(y=slice(None, None, -1))`), the output is identical to the non-reversed case because axis limits were computed using `min()`/`max()` of coordinate values rather than their first/last elements.

Since coordinate values are the same regardless of ordering, `min()` and `max()` return identical results — but `x_vals[0]` and `x_vals[-1]` correctly reflect the actual data layout.

## Changes

- Replace `x_vals.min()/x_vals.max()` with `x_vals[0]/x_vals[-1]` in axis limit computation
- Same fix for y-axis (`y_vals`)

Fixes #54.