### PR TITLE
fix(extract): support integer masks in unmask

### DIFF
--- a/src/confusius/extract/reconstruction.py
+++ b/src/confusius/extract/reconstruction.py
@@ -94,9 +94,10 @@ def unmask(
     >>> spatial_pose.dims
     ("component", "pose", "z", "y", "x")
     """
-    if isinstance(signals, np.ndarray):
-        n_voxels_mask = int(mask.sum().values)
+    mask_values = mask.values
+    n_voxels_mask = int(np.count_nonzero(mask_values))
 
+    if isinstance(signals, np.ndarray):
         if signals.shape[-1] != n_voxels_mask:
             raise ValueError(
                 f"Last dimension of signals ({signals.shape[-1]}) doesn't match "
@@ -145,6 +146,11 @@ def unmask(
             raise ValueError(
                 f"'space' must be the last dimension, got dims={signals.dims}"
             )
+        if signals.sizes["space"] != n_voxels_mask:
+            raise ValueError(
+                f"Size of 'space' dimension ({signals.sizes['space']}) doesn't match "
+                f"number of masked voxels ({n_voxels_mask})"
+            )
     else:
         raise TypeError(
             f"'signals' must be Numpy array or DataArray, got {type(signals)}"
@@ -160,7 +166,7 @@ def unmask(
 
         output_data = np.full(output_shape, fill_value, dtype=signals.dtype)
 
-        mask_flat = mask.values.flatten()
+        mask_flat = (mask_values != 0).flatten()
         n_extra = int(np.prod([signals.sizes[d] for d in extra_dims]))
         output_flat = output_data.reshape(n_extra, -1)
         signals_flat = signals.values.reshape(n_extra, -1)
@@ -175,7 +181,7 @@ def unmask(
 
         output_data = np.full(output_shape, fill_value, dtype=signals.dtype)
 
-        mask_flat = mask.values.flatten()
+        mask_flat = (mask_values != 0).flatten()
         output_data.flat[mask_flat] = signals.values
 
         coords = {d: mask.coords[d] for d in spatial_dims}

--- a/src/confusius/extract/reconstruction.py
+++ b/src/confusius/extract/reconstruction.py
@@ -28,9 +28,10 @@ def unmask(
           coordinates.
 
     mask : xarray.DataArray
-        Boolean mask used for the original extraction. Provides spatial dimensions
-        and coordinates for reconstruction. Must have the same spatial dimensions
-        and coordinates as the original data.
+        Mask used for the original extraction. Provides spatial dimensions and
+        coordinates for reconstruction. Must be either boolean dtype, or integer dtype
+        with exactly one non-zero value (0 = background, one region id = foreground).
+        Spatial dimensions and coordinates must match the original data.
     new_dims : list of str, optional
         Names for leading dimensions when `signals` is a Numpy array. Must match the
         number of leading dimensions `(ndim - 1)`. If not provided, uses `["dim_0",
@@ -95,6 +96,21 @@ def unmask(
     ("component", "pose", "z", "y", "x")
     """
     mask_values = mask.values
+    if np.issubdtype(mask_values.dtype, np.bool_):
+        pass
+    elif np.issubdtype(mask_values.dtype, np.integer):
+        non_zero = np.unique(mask_values[mask_values != 0])
+        if len(non_zero) > 1:
+            raise TypeError(
+                "mask has integer dtype with multiple distinct non-zero values. "
+                "A mask must be boolean or have exactly one non-zero label "
+                "(0 = background, one region id = foreground)."
+            )
+    else:
+        raise TypeError(
+            f"mask must be boolean dtype or a single-label integer dtype, got {mask_values.dtype}."
+        )
+
     n_voxels_mask = int(np.count_nonzero(mask_values))
 
     if isinstance(signals, np.ndarray):

--- a/tests/unit/test_extract/test_mask.py
+++ b/tests/unit/test_extract/test_mask.py
@@ -212,6 +212,20 @@ class TestUnmask:
         with pytest.raises(ValueError, match="doesn't match"):
             extract.unmask(signals, mask)
 
+    def test_dataarray_space_size_validation(self):
+        """Test that DataArray space size mismatches raise errors."""
+        mask_data = np.zeros((2, 3, 4), dtype=bool)
+        mask_data.flat[:5] = True
+        mask = xr.DataArray(mask_data, dims=["z", "y", "x"])
+
+        signals = xr.DataArray(
+            np.arange(8).reshape(2, 4),
+            dims=["time", "space"],
+        )
+
+        with pytest.raises(ValueError, match="Size of 'space' dimension"):
+            extract.unmask(signals, mask)
+
     def test_fill_value(self):
         """Test custom fill value."""
         mask_data = np.zeros((3, 4, 5), dtype=bool)

--- a/tests/unit/test_extract/test_mask.py
+++ b/tests/unit/test_extract/test_mask.py
@@ -165,6 +165,42 @@ class TestUnmask:
         assert result.values[2, 0, 1, 2] == 29.0
         assert result.values[0, 3, 3, 3] == 0.0
 
+    def test_integer_mask_with_dataarray_signals(self):
+        """Test unmasking DataArray signals with integer mask values."""
+        data = xr.DataArray(
+            np.arange(2 * 3 * 4 * 5).reshape(2, 3, 4, 5),
+            dims=["time", "z", "y", "x"],
+        )
+
+        bool_mask_data = np.zeros((3, 4, 5), dtype=bool)
+        bool_mask_data.flat[[0, 3, 7, 10, 18, 29, 41]] = True
+        int_mask = xr.DataArray(bool_mask_data.astype(np.int32) * 385, dims=["z", "y", "x"])
+
+        signals = extract.extract_with_mask(data, int_mask)
+        restored = extract.unmask(signals, int_mask)
+
+        mask_flat = bool_mask_data.ravel()
+        original_masked = data.values.reshape(2, -1)[:, mask_flat]
+        restored_masked = restored.values.reshape(2, -1)[:, mask_flat]
+
+        np.testing.assert_array_equal(original_masked, restored_masked)
+
+    def test_integer_mask_with_numpy_signals(self):
+        """Test unmasking Numpy signals with integer mask values."""
+        bool_mask_data = np.zeros((2, 3, 4), dtype=bool)
+        bool_mask_data.flat[[0, 2, 5, 7, 11]] = True
+        int_mask = xr.DataArray(bool_mask_data.astype(np.int32) * 9, dims=["z", "y", "x"])
+
+        signals = np.arange(15).reshape(3, 5)
+        result = extract.unmask(signals, int_mask, new_dims=["component"])
+
+        assert result.shape == (3, 2, 3, 4)
+        assert result.dims == ("component", "z", "y", "x")
+
+        mask_flat = bool_mask_data.ravel()
+        restored_masked = result.values.reshape(3, -1)[:, mask_flat]
+        np.testing.assert_array_equal(restored_masked, signals)
+
     def test_shape_validation(self):
         """Test that shape mismatches raise errors."""
         mask_data = np.zeros((5, 6, 7), dtype=bool)

--- a/tests/unit/test_extract/test_mask.py
+++ b/tests/unit/test_extract/test_mask.py
@@ -174,7 +174,10 @@ class TestUnmask:
 
         bool_mask_data = np.zeros((3, 4, 5), dtype=bool)
         bool_mask_data.flat[[0, 3, 7, 10, 18, 29, 41]] = True
-        int_mask = xr.DataArray(bool_mask_data.astype(np.int32) * 385, dims=["z", "y", "x"])
+        int_mask = xr.DataArray(
+            bool_mask_data.astype(np.int32) * 385,
+            dims=["z", "y", "x"],
+        )
 
         signals = extract.extract_with_mask(data, int_mask)
         restored = extract.unmask(signals, int_mask)
@@ -186,10 +189,13 @@ class TestUnmask:
         np.testing.assert_array_equal(original_masked, restored_masked)
 
     def test_integer_mask_with_numpy_signals(self):
-        """Test unmasking Numpy signals with integer mask values."""
+        """Test unmasking NumPy signals with integer mask values."""
         bool_mask_data = np.zeros((2, 3, 4), dtype=bool)
         bool_mask_data.flat[[0, 2, 5, 7, 11]] = True
-        int_mask = xr.DataArray(bool_mask_data.astype(np.int32) * 9, dims=["z", "y", "x"])
+        int_mask = xr.DataArray(
+            bool_mask_data.astype(np.int32) * 9,
+            dims=["z", "y", "x"],
+        )
 
         signals = np.arange(15).reshape(3, 5)
         result = extract.unmask(signals, int_mask, new_dims=["component"])
@@ -224,6 +230,22 @@ class TestUnmask:
         )
 
         with pytest.raises(ValueError, match="Size of 'space' dimension"):
+            extract.unmask(signals, mask)
+
+    def test_float_mask_rejected(self):
+        """Test that float masks are rejected by unmask."""
+        mask = xr.DataArray(np.array([0.0, 1.0, 0.0]), dims=["space"])
+        signals = np.array([1.0])
+
+        with pytest.raises(TypeError, match="single-label integer dtype"):
+            extract.unmask(signals, mask)
+
+    def test_multi_label_integer_mask_rejected(self):
+        """Test that multi-label integer masks are rejected by unmask."""
+        mask = xr.DataArray(np.array([0, 1, 2], dtype=np.int32), dims=["space"])
+        signals = np.array([1.0, 2.0])
+
+        with pytest.raises(TypeError, match="multiple distinct non-zero values"):
             extract.unmask(signals, mask)
 
     def test_fill_value(self):


### PR DESCRIPTION
## Summary
- treat non-zero mask values as foreground in `extract.unmask` by using boolean indexing (`mask != 0`)
- validate `space` length against `np.count_nonzero(mask)` for both NumPy and DataArray signal inputs
- add regression tests covering integer-mask roundtrip behavior for DataArray and NumPy signals

Close #59