### PR TITLE
fix(extract): stabilize mask extraction roundtrips

### DIFF
--- a/src/confusius/extract/mask.py
+++ b/src/confusius/extract/mask.py
@@ -96,7 +96,7 @@ def extract_with_mask(data: xr.DataArray, mask: xr.DataArray) -> xr.DataArray:
         return data.isel(space=mask_flat)
 
     data_flat = data.stack(space=spatial_dims)
-    mask_flat = mask_aligned.stack(space=spatial_dims).astype(bool)
+    mask_flat = mask_aligned.values.ravel().astype(bool)
     # Rebuild the space index from the selected voxel coordinates so unstack() uses the
     # reduced grid implied by the extracted mask.
-    return data_flat.isel(space=mask_flat.values).set_xindex(spatial_dims)
+    return data_flat.isel(space=mask_flat).set_xindex(spatial_dims)

--- a/src/confusius/extract/mask.py
+++ b/src/confusius/extract/mask.py
@@ -96,5 +96,7 @@ def extract_with_mask(data: xr.DataArray, mask: xr.DataArray) -> xr.DataArray:
         return data.isel(space=mask_flat)
 
     data_flat = data.stack(space=spatial_dims)
-    mask_flat = mask_aligned.values.flatten().astype(bool)
-    return data_flat.isel(space=mask_flat)
+    mask_flat = mask_aligned.stack(space=spatial_dims).astype(bool)
+    # Rebuild the space index from the selected voxel coordinates so unstack() uses the
+    # reduced grid implied by the extracted mask.
+    return data_flat.isel(space=mask_flat.values).set_xindex(spatial_dims)

--- a/src/confusius/extract/reconstruction.py
+++ b/src/confusius/extract/reconstruction.py
@@ -176,13 +176,14 @@ def unmask(
     spatial_shape = tuple(mask.sizes[d] for d in spatial_dims)
     extra_dims = [d for d in signals.dims if d != "space"]
 
+    mask_flat = (mask_values != 0).flatten()
+
     if extra_dims:
         output_shape = tuple(signals.sizes[d] for d in extra_dims) + spatial_shape
         output_dims = extra_dims + spatial_dims
 
         output_data = np.full(output_shape, fill_value, dtype=signals.dtype)
 
-        mask_flat = (mask_values != 0).flatten()
         n_extra = int(np.prod([signals.sizes[d] for d in extra_dims]))
         output_flat = output_data.reshape(n_extra, -1)
         signals_flat = signals.values.reshape(n_extra, -1)
@@ -197,7 +198,6 @@ def unmask(
 
         output_data = np.full(output_shape, fill_value, dtype=signals.dtype)
 
-        mask_flat = (mask_values != 0).flatten()
         output_data.flat[mask_flat] = signals.values
 
         coords = {d: mask.coords[d] for d in spatial_dims}

--- a/src/confusius/plotting/image.py
+++ b/src/confusius/plotting/image.py
@@ -2,6 +2,7 @@
 
 import warnings
 from collections import defaultdict
+from collections.abc import Hashable
 from typing import TYPE_CHECKING, Any, Literal, Sequence, cast
 
 import napari
@@ -243,9 +244,7 @@ def _get_distinct_colors(n_colors: int) -> list[tuple[float, float, float]]:
 
 
 def _extract_slices(
-    data: xr.DataArray,
-    slice_mode: str,
-    slice_coords: Sequence[float],
+    data: xr.DataArray, slice_mode: str, slice_coords: Sequence[float]
 ) -> tuple[list[xr.DataArray], list[float]]:
     """Extract 2D slices from `data` along `slice_mode`.
 
@@ -264,6 +263,25 @@ def _extract_slices(
         slices.append(slice_da)
         actual_coords.append(actual_coord)
     return slices, actual_coords
+
+
+def _sort_coords_for_plot(
+    data: xr.DataArray,
+    dims: Sequence[Hashable],
+) -> xr.DataArray:
+    """Sort non-monotonic coordinate axes before plotting.
+
+    Sorting avoids ambiguous geometry in plotting backends that assume ordered
+    coordinates (e.g. `pcolormesh` edge construction, contour interpolation, and napari
+    array indexing with scale/translate).
+    """
+    sorted_data = data
+    for dim in dims:
+        if dim not in sorted_data.coords:
+            continue
+        if not sorted_data.get_index(dim).is_monotonic_increasing:
+            sorted_data = sorted_data.sortby(dim)
+    return sorted_data
 
 
 class VolumePlotter:
@@ -566,6 +584,8 @@ class VolumePlotter:
                 f"Available dimensions: {list(data.dims)}."
             )
 
+        data = _sort_coords_for_plot(data, data.dims)
+
         if data.ndim != 3:
             raise ValueError(
                 f"Data must be 3D, but got shape {data.shape} with dims "
@@ -863,6 +883,8 @@ class VolumePlotter:
 
         if mask.ndim != 3:
             raise ValueError(f"mask must be 3D, got shape {mask.shape}")
+
+        mask = _sort_coords_for_plot(mask, mask.dims)
 
         unique_labels = sorted(
             [label for label in np.unique(mask.values) if label != 0]
@@ -1467,6 +1489,8 @@ def plot_napari(
     all_dims = list(data.dims)
     time_dim = "time" if "time" in all_dims else None
     spatial_dims = [d for d in all_dims if d != time_dim]
+
+    data = _sort_coords_for_plot(data, spatial_dims)
 
     if dim_order is not None and set(dim_order) != set(spatial_dims):
         raise ValueError(

--- a/src/confusius/plotting/image.py
+++ b/src/confusius/plotting/image.py
@@ -269,11 +269,13 @@ def _sort_coords_for_plot(
     data: xr.DataArray,
     dims: Sequence[Hashable],
 ) -> xr.DataArray:
-    """Sort non-monotonic coordinate axes before plotting.
+    """Sort coordinate axes into increasing order before plotting.
 
-    Sorting avoids ambiguous geometry in plotting backends that assume ordered
-    coordinates (e.g. `pcolormesh` edge construction, contour interpolation, and napari
-    array indexing with scale/translate).
+    Any plotted coordinate axis that is not already monotonic increasing,
+    including monotonic-decreasing axes, is sorted to avoid ambiguous
+    geometry in plotting backends that assume ordered coordinates (e.g.
+    `pcolormesh` edge construction, contour interpolation, and napari array
+    indexing with scale/translate).
     """
     sorted_data = data
     for dim in dims:

--- a/tests/unit/test_extract/test_mask.py
+++ b/tests/unit/test_extract/test_mask.py
@@ -110,6 +110,40 @@ class TestWithMask:
             [[0, 2, 3], [5, 7, 8], [10, 12, 13], [15, 17, 18]],
         )
 
+    def test_unstack_coords_are_ordered_after_extract(self):
+        """Test unstack produces ordered spatial coordinates after extract."""
+        data = xr.DataArray(
+            np.arange(2 * 2 * 3 * 4).reshape(2, 2, 3, 4),
+            dims=["time", "z", "y", "x"],
+            coords={
+                "z": [0.0, 1.0],
+                "y": [2.0, 0.0, 1.0],
+                "x": [3.0, 1.0, 2.0, 0.0],
+            },
+        )
+        mask = xr.DataArray(
+            np.array(
+                [
+                    [[1, 0, 1, 0], [0, 1, 0, 1], [1, 0, 0, 0]],
+                    [[0, 1, 0, 0], [0, 0, 1, 0], [1, 0, 0, 1]],
+                ],
+                dtype=bool,
+            ),
+            dims=["z", "y", "x"],
+            coords={
+                "z": [0.0, 1.0],
+                "y": [2.0, 0.0, 1.0],
+                "x": [3.0, 1.0, 2.0, 0.0],
+            },
+        )
+
+        signals = extract.extract_with_mask(data, mask)
+        unstacked = signals.unstack("space")
+
+        assert np.all(np.diff(unstacked.coords["z"].values) > 0)
+        assert np.all(np.diff(unstacked.coords["y"].values) > 0)
+        assert np.all(np.diff(unstacked.coords["x"].values) > 0)
+
 
 class TestUnmask:
     """Tests for extract.unmask function."""
@@ -288,3 +322,40 @@ class TestRoundTrip:
 
         non_mask_flat = ~mask_flat
         assert np.all(restored.values.reshape(10, -1)[:, non_mask_flat] == 0.0)
+
+    def test_unmask_dataarray_and_ndarray_match(self):
+        """Test DataArray and ndarray unmask paths reconstruct the same volume."""
+        data = xr.DataArray(
+            np.random.randn(3, 2, 3, 4),
+            dims=["time", "z", "y", "x"],
+            coords={
+                "z": [0.0, 1.0],
+                "y": [2.0, 0.0, 1.0],
+                "x": [3.0, 1.0, 2.0, 0.0],
+            },
+        )
+        mask = xr.DataArray(
+            np.array(
+                [
+                    [[1, 0, 1, 0], [0, 1, 0, 1], [1, 0, 0, 0]],
+                    [[0, 1, 0, 0], [0, 0, 1, 0], [1, 0, 0, 1]],
+                ],
+                dtype=bool,
+            ),
+            dims=["z", "y", "x"],
+            coords={
+                "z": [0.0, 1.0],
+                "y": [2.0, 0.0, 1.0],
+                "x": [3.0, 1.0, 2.0, 0.0],
+            },
+        )
+
+        signals = extract.extract_with_mask(data, mask)
+        restored_da = extract.unmask(signals, mask, fill_value=np.nan)
+        restored_np = extract.unmask(signals.values, mask, fill_value=np.nan)
+
+        np.testing.assert_allclose(
+            restored_da.values,
+            restored_np.values,
+            equal_nan=True,
+        )

--- a/tests/unit/test_plotting/test_image.py
+++ b/tests/unit/test_plotting/test_image.py
@@ -310,6 +310,31 @@ class TestPlotVolume:
         # Verify the slice was plotted
         assert len(plotter.axes[0, 0].collections) == 1
 
+    def test_non_monotonic_coords_are_sorted_before_plotting(
+        self, sample_3d_volume, matplotlib_pyplot
+    ):
+        """plot_volume sorts non-monotonic spatial coordinates before plotting."""
+        data = sample_3d_volume.copy().isel(y=[2, 0, 1], x=[3, 1, 2, 0])
+
+        z_coord = float(data.coords["z"].values[0])
+        plotter = plot_volume(
+            data, slice_mode="z", slice_coords=[z_coord], show_colorbar=False
+        )
+        ax = plotter.axes[0, 0]
+
+        y_sorted = np.sort(data.coords["y"].values.astype(float))
+        x_sorted = np.sort(data.coords["x"].values.astype(float))
+
+        dy = y_sorted[1] - y_sorted[0]
+        dx = x_sorted[1] - x_sorted[0]
+
+        assert ax.get_xlim() == pytest.approx(
+            (x_sorted[0] - dx / 2, x_sorted[-1] + dx / 2)
+        )
+        assert ax.get_ylim() == pytest.approx(
+            (y_sorted[-1] + dy / 2, y_sorted[0] - dy / 2)
+        )
+
 
 class TestCentersToEdges:
     """Tests for _centers_to_edges helper function."""
@@ -614,6 +639,29 @@ class TestPlotNapari:
         npt.assert_allclose(
             np.asarray(layer.data), np.abs(sample_4d_volume_complex.data)
         )
+        viewer.close()
+
+    def test_non_monotonic_coords_are_sorted_before_napari(
+        self, sample_3d_volume, make_napari_viewer
+    ) -> None:
+        """plot_napari sorts non-monotonic spatial coordinates before display."""
+        data = sample_3d_volume.copy().isel(y=[2, 0, 1], x=[3, 1, 2, 0])
+
+        viewer = make_napari_viewer()
+        _, layer = plot_napari(
+            data,
+            viewer=viewer,
+            show_colorbar=False,
+            show_scale_bar=False,
+        )
+
+        y_sorted = np.sort(data.coords["y"].values.astype(float))
+        x_sorted = np.sort(data.coords["x"].values.astype(float))
+        npt.assert_allclose(
+            layer.translate, [1.0, float(y_sorted[0]), float(x_sorted[0])], rtol=1e-5
+        )
+        assert np.all(np.diff(layer.metadata["xarray"].coords["y"].values) > 0)
+        assert np.all(np.diff(layer.metadata["xarray"].coords["x"].values) > 0)
         viewer.close()
 
 


### PR DESCRIPTION
## Summary
- rebuild extracted `space` indexing so `extract_with_mask(...).unstack("space")` produces a stable reduced-grid volume
- keep `unmask` compatible with both DataArray and ndarray signal inputs after extraction
- sort coordinates during plotting as a separate robustness layer for arrays coming from other sources

Close #60