### PR TITLE
fix(extract): compute Dask-backed labels before flox reduce

### DIFF
--- a/src/confusius/extract/labels.py
+++ b/src/confusius/extract/labels.py
@@ -92,7 +92,10 @@ def _flox_reduce(
 
     # flox names the output groupby dimension after the variable name of the `by` array.
     data_stacked = data.stack(space=spatial_dims)
-    labels_stacked = labels_aligned.stack(space=spatial_dims).rename("region")
+    # Compute labels eagerly: flox cannot determine unique group values from a
+    # Dask-backed array without expected_groups. Labels are spatial-only and
+    # always small enough to materialise.
+    labels_stacked = labels_aligned.stack(space=spatial_dims).rename("region").compute()
     result = flox.xarray.xarray_reduce(data_stacked, labels_stacked, func=reduction)
     return result.isel(region=result.region.values != 0)  # Drop background.
 

--- a/tests/unit/test_extract/test_labels.py
+++ b/tests/unit/test_extract/test_labels.py
@@ -236,3 +236,27 @@ class TestWithLabels:
         data_eager = xr.DataArray(data_vals, dims=["time", "z", "y", "x"])
         expected = extract.extract_with_labels(data_eager, labels)
         np.testing.assert_allclose(result.values, expected.values)
+
+    def test_dask_backed_labels(self):
+        """Test that Dask-backed labels do not raise and produce correct results.
+
+        Regression test for: flox raises ValueError when the groupby array is a
+        Dask array and expected_groups is not provided.
+        """
+        rng = np.random.default_rng(0)
+        data_vals = rng.random((10, 3, 4, 5))
+        labels_data = np.zeros((3, 4, 5), dtype=int)
+        labels_data[0, :, :] = 1
+        labels_data[1, :, :] = 2
+
+        data = xr.DataArray(data_vals, dims=["time", "z", "y", "x"])
+        labels_dask = xr.DataArray(
+            da.from_array(labels_data, chunks=(1, 2, 3)),
+            dims=["z", "y", "x"],
+        )
+
+        result = extract.extract_with_labels(data, labels_dask)
+
+        labels_eager = xr.DataArray(labels_data, dims=["z", "y", "x"])
+        expected = extract.extract_with_labels(data, labels_eager)
+        np.testing.assert_allclose(result.values, expected.values)


### PR DESCRIPTION
## Summary

- `extract_with_labels` raised `ValueError: Please provide expected_groups if not grouping by a numpy array.` when `labels` was a Dask-backed array (e.g. loaded via `cf.load()`).
- Root cause: `labels_stacked` was passed directly to `flox.xarray.xarray_reduce` while still being a Dask array. flox cannot scan unique group values across chunks without `expected_groups`.
- Fix: call `.compute()` on `labels_stacked` before the flox call. Labels are spatial-only and always small enough to materialise eagerly.

Closes #64