### PR TITLE
fix(plotting): accept single Axes in `plot_volume` and `plot_contours`

### DIFF
--- a/src/confusius/plotting/image.py
+++ b/src/confusius/plotting/image.py
@@ -301,9 +301,10 @@ class VolumePlotter:
         The figure containing the axes. If not provided, a new figure will be created
         on the first call to
         [`add_volume`][confusius.plotting.VolumePlotter.add_volume].
-    axes : numpy.ndarray, optional
-        2D array of [`matplotlib.axes.Axes`][matplotlib.axes.Axes]. If not provided,
-        axes will be created on the first call to
+    axes : numpy.ndarray[matplotlib.axes.Axes] or matplotlib.axes.Axes, optional
+        Existing axes to draw into: either a single
+        [`matplotlib.axes.Axes`][matplotlib.axes.Axes] or an array of them. If not
+        provided, axes will be created on the first call to
         [`add_volume`][confusius.plotting.VolumePlotter.add_volume].
     black_bg : bool, default: True
         Whether to set the figure background to black.
@@ -312,19 +313,36 @@ class VolumePlotter:
         upward.
     xincrease : bool, default: True
         Whether the x-axis increases to the right.
+
+    Attributes
+    ----------
+    slice_mode : str
+        The dimension along which slices are taken.
+    figure : matplotlib.figure.Figure or None
+        The figure. `None` until the first call to
+        [`add_volume`][confusius.plotting.VolumePlotter.add_volume] when no figure
+        is provided at construction time.
+    axes : numpy.ndarray or None
+        Array of [`matplotlib.axes.Axes`][matplotlib.axes.Axes]. `None` until the
+        first call to [`add_volume`][confusius.plotting.VolumePlotter.add_volume]
+        when no axes are provided at construction time.
     """
+
+    axes: "npt.NDArray[Any] | None"
 
     def __init__(
         self,
         slice_mode: str = "z",
         figure: "Figure | None" = None,
-        axes: "npt.NDArray[Any] | None" = None,
+        axes: "npt.NDArray[Any] | Axes | None" = None,
         *,
         black_bg: bool = True,
         yincrease: bool = False,
         xincrease: bool = True,
     ):
         self.slice_mode = slice_mode
+        if axes is not None and not isinstance(axes, np.ndarray):
+            axes = np.asarray([axes])
         self.axes = axes
         self._user_provided_axes = axes is not None
         if figure is None and axes is not None:
@@ -1089,7 +1107,7 @@ def plot_contours(
     xincrease: bool = True,
     black_bg: bool = True,
     figure: "Figure | None" = None,
-    axes: "npt.NDArray[Any] | None" = None,
+    axes: "npt.NDArray[Any] | Axes | None" = None,
     **kwargs,
 ) -> VolumePlotter:
     """Plot mask contours as a grid of 2D slice panels.
@@ -1136,9 +1154,11 @@ def plot_contours(
         Whether to set the figure background to black.
     figure : matplotlib.figure.Figure, optional
         Existing figure to draw into. If not provided, a new figure is created.
-    axes : numpy.ndarray, optional
-        Existing 2D array of [`matplotlib.axes.Axes`][matplotlib.axes.Axes] to draw
-        into. If not provided, new axes are created inside `figure`.
+    axes : numpy.ndarray or matplotlib.axes.Axes, optional
+        Existing axes to draw into: either a single
+        [`matplotlib.axes.Axes`][matplotlib.axes.Axes] or a 2D array of them. A single
+        `Axes` is wrapped automatically. If not provided, new axes are created inside
+        `figure`.
     **kwargs
         Additional keyword arguments passed to
         [`matplotlib.axes.Axes.plot`][matplotlib.axes.Axes.plot].
@@ -1224,7 +1244,7 @@ def plot_volume(
     xincrease: bool = True,
     black_bg: bool = True,
     figure: "Figure | None" = None,
-    axes: "npt.NDArray[Any] | None" = None,
+    axes: "npt.NDArray[Any] | Axes | None" = None,
     nrows: int | None = None,
     ncols: int | None = None,
     dpi: int | None = None,
@@ -1293,10 +1313,12 @@ def plot_volume(
         Whether to set the figure background to black.
     figure : matplotlib.figure.Figure, optional
         Existing figure to draw into. If not provided, a new figure is created.
-    axes : numpy.ndarray, optional
-        Existing 2D array of [`matplotlib.axes.Axes`][matplotlib.axes.Axes] to draw
-        into. Must contain at least as many elements as there are slices. If not
-        provided, new axes are created inside `figure`.
+    axes : numpy.ndarray or matplotlib.axes.Axes, optional
+        Existing axes to draw into: either a single
+        [`matplotlib.axes.Axes`][matplotlib.axes.Axes] or a 2D array of them. Must
+        contain at least as many elements as there are slices. A single `Axes` is
+        wrapped automatically and limits the plot to one slice. If not provided, new
+        axes are created inside `figure`.
     nrows : int, optional
         Number of rows in the subplot grid. If not provided, computed automatically.
     ncols : int, optional

--- a/src/confusius/plotting/image.py
+++ b/src/confusius/plotting/image.py
@@ -342,7 +342,7 @@ class VolumePlotter:
     ):
         self.slice_mode = slice_mode
         if axes is not None and not isinstance(axes, np.ndarray):
-            axes = np.asarray([axes])
+            axes = np.asarray([[axes]])
         self.axes = axes
         self._user_provided_axes = axes is not None
         if figure is None and axes is not None:
@@ -969,6 +969,16 @@ class VolumePlotter:
                 x_range = float(np.max(x_vals_all) - np.min(x_vals_all))
                 y_range = float(np.max(y_vals_all) - np.min(y_vals_all))
             self._ensure_figure(n_slices, x_range=x_range, y_range=y_range)
+
+            if self._user_provided_axes:
+                assert self.axes is not None
+                if n_slices != self.axes.size:
+                    raise ValueError(
+                        f"Number of slices ({n_slices}) must match number of axes "
+                        f"({self.axes.size}). Got {n_slices} slice_coords but axes has "
+                        f"shape {self.axes.shape}."
+                    )
+
             plot_indices = self._init_sequential_layout(actual_coords)
 
         if self.axes is None:
@@ -1316,7 +1326,7 @@ def plot_volume(
     axes : numpy.ndarray or matplotlib.axes.Axes, optional
         Existing axes to draw into: either a single
         [`matplotlib.axes.Axes`][matplotlib.axes.Axes] or a 2D array of them. Must
-        contain at least as many elements as there are slices. A single `Axes` is
+        contain exactly as many elements as there are slices. A single `Axes` is
         wrapped automatically and limits the plot to one slice. If not provided, new
         axes are created inside `figure`.
     nrows : int, optional

--- a/tests/unit/test_plotting/test_image.py
+++ b/tests/unit/test_plotting/test_image.py
@@ -477,6 +477,25 @@ class TestPlotContours:
         with pytest.raises(ValueError, match="3D"):
             plot_contours(mask, slice_mode="y")
 
+    def test_single_axes_object_accepted(self, matplotlib_pyplot):
+        """plot_contours accepts a bare Axes object, not only an ndarray of Axes.
+
+        Regression test for issue #66: previously raised
+        AttributeError: 'Axes' object has no attribute 'flat'.
+        """
+        import matplotlib.pyplot as plt
+
+        mask = xr.DataArray(
+            np.array([[[0, 0, 0, 0], [0, 1, 1, 0], [0, 1, 1, 0], [0, 0, 0, 0]]]),
+            dims=["z", "y", "x"],
+            coords={"z": [0.0], "y": [0.0, 0.5, 1.0, 1.5], "x": [0.0, 0.5, 1.0, 1.5]},
+        )
+        fig, ax = plt.subplots()
+
+        plotter = plot_contours(mask, slice_mode="z", axes=ax)
+
+        assert plotter.figure is fig
+
     def test_all_zero_mask_returns_without_figure(self, matplotlib_pyplot):
         """plot_contours returns early without creating a figure for all-zero mask."""
         mask = xr.DataArray(

--- a/tests/unit/test_plotting/test_image.py
+++ b/tests/unit/test_plotting/test_image.py
@@ -180,6 +180,28 @@ class TestPlotVolume:
         assert plotter.axes is axes
         assert plotter.figure is fig
 
+    def test_single_axes_object_accepted(self, sample_3d_volume, matplotlib_pyplot):
+        """plot_volume accepts a bare Axes object, not only an ndarray of Axes.
+
+        Regression test for issue #66: previously raised
+        AttributeError: 'Axes' object has no attribute 'flat'.
+        """
+        import matplotlib.pyplot as plt
+
+        fig, ax = plt.subplots()
+        z_coord = sample_3d_volume.coords["z"].values[0]
+
+        plotter = plot_volume(
+            sample_3d_volume,
+            slice_mode="z",
+            slice_coords=[z_coord],
+            axes=ax,
+            show_colorbar=False,
+        )
+
+        assert plotter.figure is fig
+        assert len(ax.collections) == 1
+
     def test_axes_count_mismatch_raises(self, sample_3d_volume, matplotlib_pyplot):
         """plot_volume raises ValueError when axes count doesn't match slices."""
         import matplotlib.pyplot as plt

--- a/tests/unit/test_plotting/test_image.py
+++ b/tests/unit/test_plotting/test_image.py
@@ -496,6 +496,20 @@ class TestPlotContours:
 
         assert plotter.figure is fig
 
+    def test_axes_count_mismatch_raises(self, matplotlib_pyplot):
+        """plot_contours raises ValueError when axes count doesn't match slices."""
+        import matplotlib.pyplot as plt
+
+        mask = xr.DataArray(
+            np.ones((3, 4, 4), dtype=int),
+            dims=["z", "y", "x"],
+            coords={"z": [0.0, 1.0, 2.0], "y": [0.0, 0.5, 1.0, 1.5], "x": [0.0, 0.5, 1.0, 1.5]},
+        )
+        fig, ax = plt.subplots()
+
+        with pytest.raises(ValueError, match="must match number of axes"):
+            plot_contours(mask, slice_mode="z", axes=ax)
+
     def test_all_zero_mask_returns_without_figure(self, matplotlib_pyplot):
         """plot_contours returns early without creating a figure for all-zero mask."""
         mask = xr.DataArray(


### PR DESCRIPTION
## Summary

- Normalize a bare `matplotlib.axes.Axes` passed as `axes` to a 1-element ndarray on entry into `VolumePlotter.__init__`, so `axes.flat[0].figure` no longer raises `AttributeError: 'Axes' object has no attribute 'flat'`.
- Update type hints and docstrings for `VolumePlotter`, `plot_volume`, and `plot_contours` to document the accepted `Axes | ndarray` input.
- Add an `Attributes` section to the `VolumePlotter` docstring.

Closes #66, closes #67.