### PR TITLE
fix(extract): align near-equal mask coordinates

### DIFF
--- a/src/confusius/extract/mask.py
+++ b/src/confusius/extract/mask.py
@@ -1,5 +1,6 @@
 """Extraction of signals using boolean masks."""
 
+import numpy as np
 import xarray as xr
 
 from confusius.validation import validate_mask
@@ -89,7 +90,24 @@ def extract_with_mask(data: xr.DataArray, mask: xr.DataArray) -> xr.DataArray:
     else:
         template = data
 
-    mask_aligned = mask.reindex_like(template)
+    coord_updates = {
+        dim: template.coords[dim]
+        for dim in spatial_dims
+        if dim in mask.coords and dim in template.coords
+    }
+    # validate_mask() already checked that shared spatial coords match within
+    # tolerance; snap them onto the template coords here so reindex_like()
+    # performs exact label alignment instead of introducing NaNs.
+    mask_aligned = mask.assign_coords(coord_updates).reindex_like(template)
+
+    if (
+        np.issubdtype(mask_aligned.dtype, np.floating)
+        and np.isnan(mask_aligned.values).any()
+    ):
+        raise ValueError(
+            "mask could not be aligned to data coordinates. If coordinates are nearly "
+            "equal, ensure they describe the same voxel grid before extraction."
+        )
 
     if "space" in data.dims and set(spatial_dims) == {"space"}:
         mask_flat = mask_aligned.values.astype(bool)

--- a/src/confusius/extract/mask.py
+++ b/src/confusius/extract/mask.py
@@ -1,6 +1,5 @@
 """Extraction of signals using boolean masks."""
 
-import numpy as np
 import xarray as xr
 
 from confusius.validation import validate_mask
@@ -100,10 +99,7 @@ def extract_with_mask(data: xr.DataArray, mask: xr.DataArray) -> xr.DataArray:
     # performs exact label alignment instead of introducing NaNs.
     mask_aligned = mask.assign_coords(coord_updates).reindex_like(template)
 
-    if (
-        np.issubdtype(mask_aligned.dtype, np.floating)
-        and np.isnan(mask_aligned.values).any()
-    ):
+    if bool(mask_aligned.isnull().any()):
         raise ValueError(
             "mask could not be aligned to data coordinates. If coordinates are nearly "
             "equal, ensure they describe the same voxel grid before extraction."

--- a/tests/unit/test_extract/test_mask.py
+++ b/tests/unit/test_extract/test_mask.py
@@ -110,6 +110,47 @@ class TestWithMask:
             [[0, 2, 3], [5, 7, 8], [10, 12, 13], [15, 17, 18]],
         )
 
+    def test_near_equal_coords_extract_expected_voxels(self):
+        """Test near-equal coordinates still extract the expected masked voxels."""
+        data = xr.DataArray(
+            np.random.default_rng(0).normal(size=(3, 2, 3, 4)),
+            dims=["time", "z", "y", "x"],
+            coords={
+                "z": np.array([0.0, 1.0]),
+                "y": np.array([0.0, 1.0, 2.0]),
+                "x": np.array([0.0, 1.0, 2.0, 3.0]),
+            },
+        )
+
+        mask = xr.DataArray(
+            np.array(
+                [
+                    [[1, 0, 1, 0], [0, 1, 0, 0], [1, 0, 0, 0]],
+                    [[0, 1, 0, 1], [0, 0, 1, 0], [0, 0, 0, 1]],
+                ],
+                dtype=np.int32,
+            ),
+            dims=["z", "y", "x"],
+            coords={
+                "z": np.array([0.0, np.nextafter(1.0, 2.0)]),
+                "y": np.array(
+                    [0.0, np.nextafter(1.0, 2.0), np.nextafter(2.0, 3.0)]
+                ),
+                "x": np.array(
+                    [
+                        0.0,
+                        np.nextafter(1.0, 2.0),
+                        np.nextafter(2.0, 3.0),
+                        np.nextafter(3.0, 4.0),
+                    ]
+                ),
+            },
+        )
+
+        signals = extract.extract_with_mask(data, mask)
+
+        assert signals.sizes["space"] == int(np.count_nonzero(mask.values))
+
     def test_unstack_coords_are_ordered_after_extract(self):
         """Test unstack produces ordered spatial coordinates after extract."""
         data = xr.DataArray(

--- a/tests/unit/test_extract/test_mask.py
+++ b/tests/unit/test_extract/test_mask.py
@@ -151,6 +151,30 @@ class TestWithMask:
 
         assert signals.sizes["space"] == int(np.count_nonzero(mask.values))
 
+    def test_alignment_with_missing_values_raises(self, monkeypatch):
+        """Test extraction fails if aligned mask still contains missing values."""
+        data = xr.DataArray(
+            np.arange(6).reshape(2, 3),
+            dims=["time", "space"],
+            coords={"space": [0, 1, 2]},
+        )
+        mask = xr.DataArray([True, False, True], dims=["space"], coords={"space": [0, 1, 2]})
+
+        original_reindex_like = xr.DataArray.reindex_like
+
+        def broken_reindex_like(self, other):
+            aligned = original_reindex_like(self, other)
+            return xr.DataArray(
+                np.array([True, np.nan, False], dtype=object),
+                dims=aligned.dims,
+                coords=aligned.coords,
+            )
+
+        monkeypatch.setattr(xr.DataArray, "reindex_like", broken_reindex_like)
+
+        with pytest.raises(ValueError, match="could not be aligned"):
+            extract.extract_with_mask(data, mask)
+
     def test_unstack_coords_are_ordered_after_extract(self):
         """Test unstack produces ordered spatial coordinates after extract."""
         data = xr.DataArray(


### PR DESCRIPTION
## Summary
- snap validated mask coordinates onto the data template before `reindex_like` so near-equal voxel grids align exactly
- prevent silent full-volume extraction when masks survive tolerant validation but fail exact label alignment
- add a regression test covering near-equal coordinates from a NIfTI-like roundtrip

Close #63.