### PR TITLE
fix(io): handle scalar-time NIfTI metadata and bool mask export

### DIFF
--- a/src/confusius/bids/__init__.py
+++ b/src/confusius/bids/__init__.py
@@ -27,6 +27,8 @@ Examples
 """
 
 from confusius.bids.coordinates import (
+    DIM_TO_SLICE_ENCODING_DIRECTION,
+    SLICE_ENCODING_DIRECTION_TO_DIM,
     create_bids_slice_timing_from_coordinate,
     create_slice_time_coordinate_from_bids,
 )
@@ -51,6 +53,8 @@ __all__ = [
     "FUSIBIDSMetadata",
     "validate_metadata",
     # Coordinates
+    "SLICE_ENCODING_DIRECTION_TO_DIM",
+    "DIM_TO_SLICE_ENCODING_DIRECTION",
     "create_bids_slice_timing_from_coordinate",
     "create_slice_time_coordinate_from_bids",
 ]

--- a/src/confusius/bids/coordinates.py
+++ b/src/confusius/bids/coordinates.py
@@ -27,10 +27,6 @@ DIM_TO_SLICE_ENCODING_DIRECTION: Final[dict[str, str]] = {
 }
 """Mapping from ConfUSIus dimension names to fUSI-BIDS `SliceEncodingDirection` values."""
 
-# Backward-compatible aliases for internal/private usage.
-_SLICE_ENCODING_DIRECTION_TO_DIM = SLICE_ENCODING_DIRECTION_TO_DIM
-_DIM_TO_SLICE_ENCODING_DIRECTION = DIM_TO_SLICE_ENCODING_DIRECTION
-
 
 def create_slice_time_coordinate_from_bids(
     volume_times: npt.ArrayLike,
@@ -77,13 +73,13 @@ def create_slice_time_coordinate_from_bids(
     >>> coord.shape
     (2, 4)
     """
-    if slice_encoding_direction not in _SLICE_ENCODING_DIRECTION_TO_DIM:
+    if slice_encoding_direction not in SLICE_ENCODING_DIRECTION_TO_DIM:
         raise ValueError(
             f"Invalid SliceEncodingDirection: {slice_encoding_direction}. "
-            f"Must be one of: {list(_SLICE_ENCODING_DIRECTION_TO_DIM.keys())}"
+            f"Must be one of: {list(SLICE_ENCODING_DIRECTION_TO_DIM.keys())}"
         )
 
-    dim_name = _SLICE_ENCODING_DIRECTION_TO_DIM[slice_encoding_direction]
+    dim_name = SLICE_ENCODING_DIRECTION_TO_DIM[slice_encoding_direction]
     slice_timing_arr = np.asarray(slice_timing)
     volume_times_arr = np.asarray(volume_times)
 
@@ -147,10 +143,10 @@ def create_bids_slice_timing_from_coordinate(
         )
 
     spatial_dim = list(set(slice_time_coord.dims) - {"time"})[0]
-    if spatial_dim not in _DIM_TO_SLICE_ENCODING_DIRECTION:
+    if spatial_dim not in DIM_TO_SLICE_ENCODING_DIRECTION:
         raise ValueError(
             f"slice_time coordinate must have one of spatial dimensions "
-            f"{list(_DIM_TO_SLICE_ENCODING_DIRECTION.keys())}, got: {slice_time_coord.dims}"
+            f"{list(DIM_TO_SLICE_ENCODING_DIRECTION.keys())}, got: {slice_time_coord.dims}"
         )
 
     volume_times_arr = np.asarray(volume_times)
@@ -174,4 +170,4 @@ def create_bids_slice_timing_from_coordinate(
             "volume-onset-relative offsets."
         )
 
-    return relative_slice_timing[0], _DIM_TO_SLICE_ENCODING_DIRECTION[str(spatial_dim)]
+    return relative_slice_timing[0], DIM_TO_SLICE_ENCODING_DIRECTION[str(spatial_dim)]

--- a/src/confusius/bids/coordinates.py
+++ b/src/confusius/bids/coordinates.py
@@ -10,7 +10,7 @@ import numpy as np
 import numpy.typing as npt
 import xarray as xr
 
-_SLICE_ENCODING_DIRECTION_TO_DIM: Final[dict[str, str]] = {
+SLICE_ENCODING_DIRECTION_TO_DIM: Final[dict[str, str]] = {
     "i": "x",
     "i-": "x",
     "j": "y",
@@ -20,12 +20,16 @@ _SLICE_ENCODING_DIRECTION_TO_DIM: Final[dict[str, str]] = {
 }
 """Mapping from fUSI-BIDS `SliceEncodingDirection` values to ConfUSIus dimension names."""
 
-_DIM_TO_SLICE_ENCODING_DIRECTION: Final[dict[str, str]] = {
+DIM_TO_SLICE_ENCODING_DIRECTION: Final[dict[str, str]] = {
     "x": "i",
     "y": "j",
     "z": "k",
 }
 """Mapping from ConfUSIus dimension names to fUSI-BIDS `SliceEncodingDirection` values."""
+
+# Backward-compatible aliases for internal/private usage.
+_SLICE_ENCODING_DIRECTION_TO_DIM = SLICE_ENCODING_DIRECTION_TO_DIM
+_DIM_TO_SLICE_ENCODING_DIRECTION = DIM_TO_SLICE_ENCODING_DIRECTION
 
 
 def create_slice_time_coordinate_from_bids(

--- a/src/confusius/io/nifti.py
+++ b/src/confusius/io/nifti.py
@@ -429,6 +429,16 @@ def _create_temporal_coords_from_nifti(
     remaining_attrs : dict[str, Any]
         Copy of `attrs` with all consumed temporal fields removed.
     """
+
+    def _convert_sidecar_seconds_to_time_unit(value: Any) -> npt.NDArray[np.floating]:
+        converted = convert_time_values(
+            value,
+            from_unit="s",
+            to_unit=time_unit,
+            raise_on_unknown=True,
+        )
+        return np.asarray(converted, dtype=np.float64)
+
     attrs = dict(attrs)
     n_time = img.shape[3]
     sampling_period_nifti = extractor.get_repetition_time()
@@ -441,16 +451,27 @@ def _create_temporal_coords_from_nifti(
     # BIDS always uses onset timing.
     time_attrs["volume_acquisition_reference"] = "start"
     if "volume_acquisition_duration" in attrs:
-        time_attrs["volume_acquisition_duration"] = attrs.pop(
-            "volume_acquisition_duration"
-        )
+        volume_duration = float(attrs.pop("volume_acquisition_duration"))
+        if time_unit is not None:
+            volume_duration = float(
+                _convert_sidecar_seconds_to_time_unit(volume_duration)
+            )
+        time_attrs["volume_acquisition_duration"] = volume_duration
 
     if "volume_timing" in attrs:
-        time_values = np.asarray(attrs.pop("volume_timing"))
+        time_values = np.asarray(attrs.pop("volume_timing"), dtype=np.float64)
+        if time_unit is not None:
+            time_values = _convert_sidecar_seconds_to_time_unit(time_values)
     elif "repetition_time" in attrs:
         sampling_period_sidecar = float(attrs.pop("repetition_time"))
         delay = float(attrs.pop("delay_after_trigger", 0.0))
         delay_time = float(attrs.pop("delay_time", 0.0))
+        if time_unit is not None:
+            sampling_period_sidecar = float(
+                _convert_sidecar_seconds_to_time_unit(sampling_period_sidecar)
+            )
+            delay = float(_convert_sidecar_seconds_to_time_unit(delay))
+            delay_time = float(_convert_sidecar_seconds_to_time_unit(delay_time))
         if (
             sampling_period_nifti is not None
             and sampling_period_nifti > 0

--- a/src/confusius/io/nifti.py
+++ b/src/confusius/io/nifti.py
@@ -22,6 +22,8 @@ from confusius._utils import (
     get_representative_step,
 )
 from confusius.bids import (
+    DIM_TO_SLICE_ENCODING_DIRECTION,
+    SLICE_ENCODING_DIRECTION_TO_DIM,
     create_bids_slice_timing_from_coordinate,
     create_slice_time_coordinate_from_bids,
     from_bids,
@@ -67,19 +69,6 @@ _CONFUSIUS_TO_NIFTI_TIME_UNITS: dict[str, str] = {
     v: k for k, v in _NIFTI_TO_CONFUSIUS_TIME_UNITS.items()
 }
 """Mapping from ConfUSIus time unit strings to NIfTI conventions."""
-
-_SLICE_TIME_DIM_TO_DIRECTION: dict[str, str] = {"x": "i", "y": "j", "z": "k"}
-"""Mapping from slice-time spatial dimension names to BIDS directions."""
-
-_SLICE_TIME_DIRECTION_TO_DIM: dict[str, str] = {
-    "i": "x",
-    "i-": "x",
-    "j": "y",
-    "j-": "y",
-    "k": "z",
-    "k-": "z",
-}
-"""Mapping from BIDS slice-time directions to spatial dimension names."""
 
 _TIME_ATTRS_TO_SECONDS: frozenset[str] = frozenset(
     {
@@ -582,7 +571,7 @@ def _create_scalar_temporal_coords_from_nifti(
 
     if "slice_timing" in attrs and "slice_encoding_direction" in attrs:
         slice_encoding_direction = str(attrs.pop("slice_encoding_direction"))
-        if slice_encoding_direction not in _SLICE_TIME_DIRECTION_TO_DIM:
+        if slice_encoding_direction not in SLICE_ENCODING_DIRECTION_TO_DIM:
             return coords, attrs
 
         slice_timing = convert_time_values(
@@ -597,7 +586,7 @@ def _create_scalar_temporal_coords_from_nifti(
         if slice_encoding_direction.endswith("-"):
             slice_timing = slice_timing[::-1]
 
-        spatial_dim = _SLICE_TIME_DIRECTION_TO_DIM[slice_encoding_direction]
+        spatial_dim = SLICE_ENCODING_DIRECTION_TO_DIM[slice_encoding_direction]
         coords["slice_time"] = xr.DataArray(
             time_value + slice_timing,
             dims=[spatial_dim],
@@ -875,7 +864,7 @@ def _extract_nifti_slice_timing_metadata(data_array: xr.DataArray) -> dict[str, 
     slice_time_coord = data_array.coords["slice_time"]
     if len(slice_time_coord.dims) == 1:
         spatial_dim = slice_time_coord.dims[0]
-        if spatial_dim not in _SLICE_TIME_DIM_TO_DIRECTION:
+        if spatial_dim not in DIM_TO_SLICE_ENCODING_DIRECTION:
             return {}
 
         if "time" not in data_array.coords:
@@ -954,7 +943,7 @@ def _extract_nifti_slice_timing_metadata(data_array: xr.DataArray) -> dict[str, 
 
         return {
             "SliceTiming": (slice_time_seconds - volume_onset_seconds).tolist(),
-            "SliceEncodingDirection": _SLICE_TIME_DIM_TO_DIRECTION[spatial_dim],
+            "SliceEncodingDirection": DIM_TO_SLICE_ENCODING_DIRECTION[spatial_dim],
         }
 
     if len(slice_time_coord.dims) != 2 or "time" not in slice_time_coord.dims:
@@ -967,7 +956,7 @@ def _extract_nifti_slice_timing_metadata(data_array: xr.DataArray) -> dict[str, 
         return {}
 
     spatial_dims = [dim for dim in slice_time_coord.dims if dim != "time"]
-    if len(spatial_dims) != 1 or spatial_dims[0] not in _SLICE_TIME_DIM_TO_DIRECTION:
+    if len(spatial_dims) != 1 or spatial_dims[0] not in DIM_TO_SLICE_ENCODING_DIRECTION:
         return {}
 
     if "time" not in data_array.coords:

--- a/src/confusius/io/nifti.py
+++ b/src/confusius/io/nifti.py
@@ -430,15 +430,6 @@ def _create_temporal_coords_from_nifti(
         Copy of `attrs` with all consumed temporal fields removed.
     """
 
-    def _convert_sidecar_seconds_to_time_unit(value: Any) -> npt.NDArray[np.floating]:
-        converted = convert_time_values(
-            value,
-            from_unit="s",
-            to_unit=time_unit,
-            raise_on_unknown=True,
-        )
-        return np.asarray(converted, dtype=np.float64)
-
     attrs = dict(attrs)
     n_time = img.shape[3]
     sampling_period_nifti = extractor.get_repetition_time()
@@ -454,24 +445,68 @@ def _create_temporal_coords_from_nifti(
         volume_duration = float(attrs.pop("volume_acquisition_duration"))
         if time_unit is not None:
             volume_duration = float(
-                _convert_sidecar_seconds_to_time_unit(volume_duration)
+                np.asarray(
+                    convert_time_values(
+                        volume_duration,
+                        from_unit="s",
+                        to_unit=time_unit,
+                        raise_on_unknown=True,
+                    ),
+                    dtype=np.float64,
+                )
             )
         time_attrs["volume_acquisition_duration"] = volume_duration
 
     if "volume_timing" in attrs:
         time_values = np.asarray(attrs.pop("volume_timing"), dtype=np.float64)
         if time_unit is not None:
-            time_values = _convert_sidecar_seconds_to_time_unit(time_values)
+            time_values = np.asarray(
+                convert_time_values(
+                    time_values,
+                    from_unit="s",
+                    to_unit=time_unit,
+                    raise_on_unknown=True,
+                ),
+                dtype=np.float64,
+            )
     elif "repetition_time" in attrs:
         sampling_period_sidecar = float(attrs.pop("repetition_time"))
         delay = float(attrs.pop("delay_after_trigger", 0.0))
         delay_time = float(attrs.pop("delay_time", 0.0))
         if time_unit is not None:
             sampling_period_sidecar = float(
-                _convert_sidecar_seconds_to_time_unit(sampling_period_sidecar)
+                np.asarray(
+                    convert_time_values(
+                        sampling_period_sidecar,
+                        from_unit="s",
+                        to_unit=time_unit,
+                        raise_on_unknown=True,
+                    ),
+                    dtype=np.float64,
+                )
             )
-            delay = float(_convert_sidecar_seconds_to_time_unit(delay))
-            delay_time = float(_convert_sidecar_seconds_to_time_unit(delay_time))
+            delay = float(
+                np.asarray(
+                    convert_time_values(
+                        delay,
+                        from_unit="s",
+                        to_unit=time_unit,
+                        raise_on_unknown=True,
+                    ),
+                    dtype=np.float64,
+                )
+            )
+            delay_time = float(
+                np.asarray(
+                    convert_time_values(
+                        delay_time,
+                        from_unit="s",
+                        to_unit=time_unit,
+                        raise_on_unknown=True,
+                    ),
+                    dtype=np.float64,
+                )
+            )
         if (
             sampling_period_nifti is not None
             and sampling_period_nifti > 0

--- a/src/confusius/io/nifti.py
+++ b/src/confusius/io/nifti.py
@@ -71,6 +71,16 @@ _CONFUSIUS_TO_NIFTI_TIME_UNITS: dict[str, str] = {
 _SLICE_TIME_DIM_TO_DIRECTION: dict[str, str] = {"x": "i", "y": "j", "z": "k"}
 """Mapping from slice-time spatial dimension names to BIDS directions."""
 
+_SLICE_TIME_DIRECTION_TO_DIM: dict[str, str] = {
+    "i": "x",
+    "i-": "x",
+    "j": "y",
+    "j-": "y",
+    "k": "z",
+    "k-": "z",
+}
+"""Mapping from BIDS slice-time directions to spatial dimension names."""
+
 _TIME_ATTRS_TO_SECONDS: frozenset[str] = frozenset(
     {
         "clutter_filter_window_duration",
@@ -501,6 +511,102 @@ def _create_temporal_coords_from_nifti(
     return coords, attrs
 
 
+def _create_scalar_temporal_coords_from_nifti(
+    extractor: "_NiftiHeaderExtractor",
+    attrs: dict[str, Any],
+) -> tuple[dict[str, xr.DataArray], dict[str, Any]]:
+    """Create scalar temporal coordinates for non-temporal NIfTI payloads.
+
+    When a NIfTI payload has no `time` dimension but the sidecar still carries timing
+    metadata (for example after saving a 3D snapshot with a scalar `time`
+    coordinate), this helper reconstructs scalar temporal coordinates and removes the
+    consumed timing fields from attrs.
+
+    Parameters
+    ----------
+    extractor : _NiftiHeaderExtractor
+        Header extractor for the loaded image.
+    attrs : dict[str, Any]
+        DataArray attributes, typically merged from the NIfTI header and sidecar.
+
+    Returns
+    -------
+    coords : dict[str, xarray.DataArray]
+        Scalar temporal coordinate DataArrays keyed by name. Empty dict when no scalar
+        timing can be reconstructed.
+    remaining_attrs : dict[str, Any]
+        Copy of `attrs` with consumed temporal fields removed.
+    """
+    attrs = dict(attrs)
+    _, time_unit = extractor.get_unit_strings()
+
+    time_attrs: dict[str, Any] = {"volume_acquisition_reference": "start"}
+    if time_unit is not None:
+        time_attrs["units"] = time_unit
+    if "volume_acquisition_duration" in attrs:
+        time_attrs["volume_acquisition_duration"] = attrs.pop(
+            "volume_acquisition_duration"
+        )
+
+    time_value: float | None = None
+    if "volume_timing" in attrs:
+        volume_timing = np.asarray(attrs.pop("volume_timing"), dtype=np.float64)
+        if volume_timing.ndim != 1 or volume_timing.size == 0:
+            warnings.warn(
+                "`volume_timing` metadata is not a non-empty 1D array. Omitting scalar "
+                "`time` coordinate reconstruction.",
+                stacklevel=find_stack_level(),
+            )
+            return {}, attrs
+        if volume_timing.size > 1:
+            warnings.warn(
+                "`volume_timing` has multiple entries but the image has no `time` "
+                "dimension. Using the first timestamp for scalar `time`.",
+                stacklevel=find_stack_level(),
+            )
+        time_value = float(volume_timing[0])
+    elif "repetition_time" in attrs:
+        attrs.pop("repetition_time")
+        time_value = float(attrs.pop("delay_after_trigger", 0.0))
+        attrs.pop("delay_time", None)
+    elif "delay_after_trigger" in attrs:
+        time_value = float(attrs.pop("delay_after_trigger"))
+        attrs.pop("delay_time", None)
+
+    if time_value is None:
+        return {}, attrs
+
+    coords: dict[str, xr.DataArray] = {
+        "time": xr.DataArray(np.float64(time_value), attrs=time_attrs)
+    }
+
+    if "slice_timing" in attrs and "slice_encoding_direction" in attrs:
+        slice_encoding_direction = str(attrs.pop("slice_encoding_direction"))
+        if slice_encoding_direction not in _SLICE_TIME_DIRECTION_TO_DIM:
+            return coords, attrs
+
+        slice_timing = convert_time_values(
+            attrs.pop("slice_timing"),
+            from_unit="s",
+            to_unit=coords["time"].attrs.get("units", "s"),
+            raise_on_unknown=True,
+        )
+        slice_timing = np.asarray(slice_timing, dtype=np.float64)
+        if slice_timing.ndim != 1:
+            return coords, attrs
+        if slice_encoding_direction.endswith("-"):
+            slice_timing = slice_timing[::-1]
+
+        spatial_dim = _SLICE_TIME_DIRECTION_TO_DIM[slice_encoding_direction]
+        coords["slice_time"] = xr.DataArray(
+            time_value + slice_timing,
+            dims=[spatial_dim],
+            attrs={"units": coords["time"].attrs.get("units", "s")},
+        )
+
+    return coords, attrs
+
+
 def _get_volume_acquisition_reference(
     attrs: dict[str, Any], *, coord_name: str, warn_on_missing: bool = False
 ) -> Literal["start", "center", "end"]:
@@ -659,7 +765,10 @@ def load_nifti(
         )
         coords = {**spatial_coords, **temporal_coords}
     else:
-        coords = spatial_coords
+        scalar_temporal_coords, attrs = _create_scalar_temporal_coords_from_nifti(
+            extractor=extractor, attrs=attrs
+        )
+        coords = {**spatial_coords, **scalar_temporal_coords}
 
     nifti_name = path.with_suffix("").stem if path.suffix == ".gz" else path.stem
     data_array = xr.DataArray(
@@ -677,7 +786,7 @@ def _infer_repetition_time(
     Parameters
     ----------
     timings : ndarray
-        Time values, at least one element.
+        Time values. Scalars are treated as a single-element coordinate.
 
     Returns
     -------
@@ -685,8 +794,9 @@ def _infer_repetition_time(
         Uniform repetition time (spacing between volumes) when sampling is regular
         within `rtol=1e-5`, or `None` for a single volume or irregular sampling.
     delay : float
-        Onset time of the first volume (`times[0]`).
+        Onset time of the first volume (`timings[0]`).
     """
+    timings = np.atleast_1d(np.asarray(timings, dtype=np.float64))
     delay = float(timings[0])
     if len(timings) < 2:
         return None, delay
@@ -738,9 +848,14 @@ def _infer_frame_acquisition_duration(
 def _extract_nifti_slice_timing_metadata(data_array: xr.DataArray) -> dict[str, Any]:
     """Extract BIDS slice timing metadata from a `slice_time` coordinate.
 
-    `SliceTiming` is exported only when the 2D absolute slice timestamps are consistent
-    across volumes after converting to onset-relative offsets, since BIDS cannot
-    represent per-volume variation.
+    `SliceTiming` is exported from either:
+
+    - a 2D absolute `slice_time` coordinate with dims `(time, spatial_dim)` when
+      onset-relative offsets are constant across volumes, or
+    - a 1D absolute `slice_time` coordinate with dim `(spatial_dim,)` when a scalar
+      `time` coordinate is available.
+
+    BIDS cannot represent per-volume variation in slice offsets.
 
     Parameters
     ----------
@@ -758,9 +873,94 @@ def _extract_nifti_slice_timing_metadata(data_array: xr.DataArray) -> dict[str, 
         return {}
 
     slice_time_coord = data_array.coords["slice_time"]
+    if len(slice_time_coord.dims) == 1:
+        spatial_dim = slice_time_coord.dims[0]
+        if spatial_dim not in _SLICE_TIME_DIM_TO_DIRECTION:
+            return {}
+
+        if "time" not in data_array.coords:
+            warnings.warn(
+                "Cannot infer onset-relative SliceTiming from a 1D `slice_time` "
+                "coordinate without a `time` coordinate. Omitting BIDS SliceTiming "
+                "export.",
+                stacklevel=find_stack_level(),
+            )
+            return {}
+
+        time_values_seconds = np.atleast_1d(
+            np.asarray(
+                convert_time_values(
+                    data_array.coords["time"].values,
+                    data_array.coords["time"].attrs.get("units"),
+                    "s",
+                    raise_on_unknown=True,
+                ),
+                dtype=np.float64,
+            )
+        )
+        if time_values_seconds.size != 1:
+            warnings.warn(
+                "A 1D `slice_time` coordinate can only be exported when `time` is "
+                "scalar. Use a 2D `(time, spatial_dim)` coordinate for time series "
+                "data. Omitting BIDS SliceTiming export.",
+                stacklevel=find_stack_level(),
+            )
+            return {}
+
+        frame_acquisition_duration = _infer_frame_acquisition_duration(
+            data_array.coords["time"].attrs,
+            time_values_seconds,
+        )
+        time_reference = _get_volume_acquisition_reference(
+            data_array.coords["time"].attrs,
+            coord_name="time",
+        )
+        if frame_acquisition_duration is None:
+            warnings.warn(
+                "Cannot infer frame acquisition duration for a 1D `slice_time` "
+                "coordinate. Omitting BIDS SliceTiming export.",
+                stacklevel=find_stack_level(),
+            )
+            return {}
+
+        volume_onset_seconds = float(
+            convert_time_reference(
+                time_values_seconds,
+                frame_acquisition_duration,
+                from_reference=time_reference,
+                to_reference="start",
+            )[0]
+        )
+        slice_time_seconds = np.asarray(
+            convert_time_values(
+                slice_time_coord.values,
+                slice_time_coord.attrs.get("units"),
+                "s",
+                raise_on_unknown=True,
+            ),
+            dtype=np.float64,
+        )
+        slice_duration = slice_time_coord.attrs.get("volume_acquisition_duration")
+        slice_reference = slice_time_coord.attrs.get(
+            "volume_acquisition_reference", "start"
+        )
+        if isinstance(slice_duration, int | float) and slice_duration > 0:
+            slice_time_seconds = convert_time_reference(
+                slice_time_seconds,
+                float(slice_duration),
+                from_reference=slice_reference,
+                to_reference="start",
+            )
+
+        return {
+            "SliceTiming": (slice_time_seconds - volume_onset_seconds).tolist(),
+            "SliceEncodingDirection": _SLICE_TIME_DIM_TO_DIRECTION[spatial_dim],
+        }
+
     if len(slice_time_coord.dims) != 2 or "time" not in slice_time_coord.dims:
         warnings.warn(
-            "`slice_time` must be a 2D coordinate with dims `(time, spatial_dim)` to "
+            "`slice_time` must be either a 2D coordinate with dims `(time, "
+            "spatial_dim)` or a 1D spatial coordinate paired with scalar `time` to "
             "be exported as BIDS SliceTiming. Omitting SliceTiming export.",
             stacklevel=find_stack_level(),
         )
@@ -906,7 +1106,8 @@ def _prepare_data_for_nifti(
     -------
     data : numpy.ndarray
         Array reordered to NIfTI axis order `(x, y, z, time, ...)`, with singleton
-        spatial axes inserted for any missing spatial dimensions.
+        spatial axes inserted for any missing spatial dimensions. Boolean arrays are
+        cast to `uint8` because NIfTI does not support `bool` payload dtypes.
     current_dims : tuple[str, ...]
         Original dimension names from `data_array`, preserved so later header logic can
         decide whether a time zoom should be written and where extra dimensions belong.
@@ -928,6 +1129,9 @@ def _prepare_data_for_nifti(
     for insert_pos, dim in enumerate(("x", "y", "z")):
         if dim not in current_dims:
             data = np.expand_dims(data, axis=insert_pos)
+
+    if np.issubdtype(data.dtype, np.bool_):
+        data = data.astype(np.uint8, copy=False)
 
     return data, current_dims
 
@@ -1021,6 +1225,9 @@ def _build_nifti_timing_metadata(
             time_unit,
             "s",
             raise_on_unknown=True,
+        )
+        time_values_seconds = np.atleast_1d(
+            np.asarray(time_values_seconds, dtype=np.float64)
         )
         frame_acquisition_duration = _infer_frame_acquisition_duration(
             time_attrs, time_values_seconds

--- a/src/confusius/io/nifti.py
+++ b/src/confusius/io/nifti.py
@@ -445,29 +445,23 @@ def _create_temporal_coords_from_nifti(
         volume_duration = float(attrs.pop("volume_acquisition_duration"))
         if time_unit is not None:
             volume_duration = float(
-                np.asarray(
-                    convert_time_values(
-                        volume_duration,
-                        from_unit="s",
-                        to_unit=time_unit,
-                        raise_on_unknown=True,
-                    ),
-                    dtype=np.float64,
+                convert_time_values(
+                    volume_duration,
+                    from_unit="s",
+                    to_unit=time_unit,
+                    raise_on_unknown=True,
                 )
             )
         time_attrs["volume_acquisition_duration"] = volume_duration
 
     if "volume_timing" in attrs:
-        time_values = np.asarray(attrs.pop("volume_timing"), dtype=np.float64)
+        time_values = np.asarray(attrs.pop("volume_timing"))
         if time_unit is not None:
-            time_values = np.asarray(
-                convert_time_values(
-                    time_values,
-                    from_unit="s",
-                    to_unit=time_unit,
-                    raise_on_unknown=True,
-                ),
-                dtype=np.float64,
+            time_values = convert_time_values(
+                time_values,
+                from_unit="s",
+                to_unit=time_unit,
+                raise_on_unknown=True,
             )
     elif "repetition_time" in attrs:
         sampling_period_sidecar = float(attrs.pop("repetition_time"))
@@ -475,36 +469,27 @@ def _create_temporal_coords_from_nifti(
         delay_time = float(attrs.pop("delay_time", 0.0))
         if time_unit is not None:
             sampling_period_sidecar = float(
-                np.asarray(
-                    convert_time_values(
-                        sampling_period_sidecar,
-                        from_unit="s",
-                        to_unit=time_unit,
-                        raise_on_unknown=True,
-                    ),
-                    dtype=np.float64,
+                convert_time_values(
+                    sampling_period_sidecar,
+                    from_unit="s",
+                    to_unit=time_unit,
+                    raise_on_unknown=True,
                 )
             )
             delay = float(
-                np.asarray(
-                    convert_time_values(
-                        delay,
-                        from_unit="s",
-                        to_unit=time_unit,
-                        raise_on_unknown=True,
-                    ),
-                    dtype=np.float64,
+                convert_time_values(
+                    delay,
+                    from_unit="s",
+                    to_unit=time_unit,
+                    raise_on_unknown=True,
                 )
             )
             delay_time = float(
-                np.asarray(
-                    convert_time_values(
-                        delay_time,
-                        from_unit="s",
-                        to_unit=time_unit,
-                        raise_on_unknown=True,
-                    ),
-                    dtype=np.float64,
+                convert_time_values(
+                    delay_time,
+                    from_unit="s",
+                    to_unit=time_unit,
+                    raise_on_unknown=True,
                 )
             )
         if (
@@ -592,21 +577,18 @@ def _create_scalar_temporal_coords_from_nifti(
         frame_duration = float(attrs.pop("volume_acquisition_duration"))
         if time_unit is not None:
             frame_duration = float(
-                np.asarray(
-                    convert_time_values(
-                        frame_duration,
-                        from_unit="s",
-                        to_unit=time_unit,
-                        raise_on_unknown=True,
-                    ),
-                    dtype=np.float64,
+                convert_time_values(
+                    frame_duration,
+                    from_unit="s",
+                    to_unit=time_unit,
+                    raise_on_unknown=True,
                 )
             )
         time_attrs["volume_acquisition_duration"] = frame_duration
 
     time_value: float | None = None
     if "volume_timing" in attrs:
-        volume_timing = np.asarray(attrs.pop("volume_timing"), dtype=np.float64)
+        volume_timing = np.asarray(attrs.pop("volume_timing"))
         if volume_timing.ndim != 1 or volume_timing.size == 0:
             warnings.warn(
                 "`volume_timing` metadata is not a non-empty 1D array. Omitting scalar "
@@ -634,14 +616,11 @@ def _create_scalar_temporal_coords_from_nifti(
 
     if time_unit is not None:
         time_value = float(
-            np.asarray(
-                convert_time_values(
-                    time_value,
-                    from_unit="s",
-                    to_unit=time_unit,
-                    raise_on_unknown=True,
-                ),
-                dtype=np.float64,
+            convert_time_values(
+                time_value,
+                from_unit="s",
+                to_unit=time_unit,
+                raise_on_unknown=True,
             )
         )
 
@@ -661,7 +640,6 @@ def _create_scalar_temporal_coords_from_nifti(
             to_unit=coords["time"].attrs.get("units", "s"),
             raise_on_unknown=True,
         )
-        slice_timing = np.asarray(slice_timing, dtype=np.float64)
         if slice_timing.ndim != 1:
             return coords, attrs
         if slice_encoding_direction.endswith("-"):
@@ -866,7 +844,7 @@ def _infer_repetition_time(
     delay : float
         Onset time of the first volume (`timings[0]`).
     """
-    timings = np.atleast_1d(np.asarray(timings, dtype=np.float64))
+    timings = np.atleast_1d(timings)
     delay = float(timings[0])
     if len(timings) < 2:
         return None, delay
@@ -958,14 +936,11 @@ def _extract_nifti_slice_timing_metadata(data_array: xr.DataArray) -> dict[str, 
             return {}
 
         time_values_seconds = np.atleast_1d(
-            np.asarray(
-                convert_time_values(
-                    data_array.coords["time"].values,
-                    data_array.coords["time"].attrs.get("units"),
-                    "s",
-                    raise_on_unknown=True,
-                ),
-                dtype=np.float64,
+            convert_time_values(
+                data_array.coords["time"].values,
+                data_array.coords["time"].attrs.get("units"),
+                "s",
+                raise_on_unknown=True,
             )
         )
         if time_values_seconds.size != 1:
@@ -1001,14 +976,11 @@ def _extract_nifti_slice_timing_metadata(data_array: xr.DataArray) -> dict[str, 
                 to_reference="start",
             )[0]
         )
-        slice_time_seconds = np.asarray(
-            convert_time_values(
-                slice_time_coord.values,
-                slice_time_coord.attrs.get("units"),
-                "s",
-                raise_on_unknown=True,
-            ),
-            dtype=np.float64,
+        slice_time_seconds = convert_time_values(
+            slice_time_coord.values,
+            slice_time_coord.attrs.get("units"),
+            "s",
+            raise_on_unknown=True,
         )
         slice_duration = slice_time_coord.attrs.get("volume_acquisition_duration")
         slice_reference = slice_time_coord.attrs.get(
@@ -1296,9 +1268,7 @@ def _build_nifti_timing_metadata(
             "s",
             raise_on_unknown=True,
         )
-        time_values_seconds = np.atleast_1d(
-            np.asarray(time_values_seconds, dtype=np.float64)
-        )
+        time_values_seconds = np.atleast_1d(time_values_seconds)
         frame_acquisition_duration = _infer_frame_acquisition_duration(
             time_attrs, time_values_seconds
         )
@@ -1637,10 +1607,7 @@ def _build_nifti_sidecar_metadata(
         for key in _TIME_ATTRS_TO_SECONDS:
             value = sidecar_attrs.get(key)
             if isinstance(value, int | float | np.integer | np.floating):
-                converted_value = convert_time_values(value, from_unit, "s")
-                sidecar_attrs[key] = float(
-                    np.asarray(converted_value, dtype=np.float64)
-                )
+                sidecar_attrs[key] = float(convert_time_values(value, from_unit, "s"))
 
     extra_affines = {
         k: np.asarray(v).tolist()

--- a/src/confusius/io/nifti.py
+++ b/src/confusius/io/nifti.py
@@ -533,9 +533,20 @@ def _create_scalar_temporal_coords_from_nifti(
     if time_unit is not None:
         time_attrs["units"] = time_unit
     if "volume_acquisition_duration" in attrs:
-        time_attrs["volume_acquisition_duration"] = attrs.pop(
-            "volume_acquisition_duration"
-        )
+        frame_duration = float(attrs.pop("volume_acquisition_duration"))
+        if time_unit is not None:
+            frame_duration = float(
+                np.asarray(
+                    convert_time_values(
+                        frame_duration,
+                        from_unit="s",
+                        to_unit=time_unit,
+                        raise_on_unknown=True,
+                    ),
+                    dtype=np.float64,
+                )
+            )
+        time_attrs["volume_acquisition_duration"] = frame_duration
 
     time_value: float | None = None
     if "volume_timing" in attrs:
@@ -565,14 +576,28 @@ def _create_scalar_temporal_coords_from_nifti(
     if time_value is None:
         return {}, attrs
 
+    if time_unit is not None:
+        time_value = float(
+            np.asarray(
+                convert_time_values(
+                    time_value,
+                    from_unit="s",
+                    to_unit=time_unit,
+                    raise_on_unknown=True,
+                ),
+                dtype=np.float64,
+            )
+        )
+
     coords: dict[str, xr.DataArray] = {
         "time": xr.DataArray(np.float64(time_value), attrs=time_attrs)
     }
 
     if "slice_timing" in attrs and "slice_encoding_direction" in attrs:
-        slice_encoding_direction = str(attrs.pop("slice_encoding_direction"))
+        slice_encoding_direction = str(attrs["slice_encoding_direction"])
         if slice_encoding_direction not in SLICE_ENCODING_DIRECTION_TO_DIM:
             return coords, attrs
+        attrs.pop("slice_encoding_direction")
 
         slice_timing = convert_time_values(
             attrs.pop("slice_timing"),

--- a/tests/unit/test_io/test_nifti.py
+++ b/tests/unit/test_io/test_nifti.py
@@ -417,6 +417,63 @@ class TestLoadNifti:
             "volume_acquisition_duration"
         ] == pytest.approx(1.75)
 
+    def test_load_nifti_sidecar_timing_converts_to_header_time_units(
+        self, tmp_path: Path
+    ) -> None:
+        """Sidecar `RepetitionTime`/`DelayAfterTrigger` follow header time units."""
+        data = np.random.default_rng(0).random((2, 3, 4, 5)).astype(np.float32)
+        path = tmp_path / "time_units_sidecar_rt.nii.gz"
+        img = nib.Nifti1Image(data, np.eye(4))
+        img.header.set_zooms((1.0, 1.0, 1.0, 1000.0))
+        img.header.set_xyzt_units(xyz="mm", t="msec")
+        img.to_filename(path)
+
+        with open(tmp_path / "time_units_sidecar_rt.json", "w") as f:
+            json.dump(
+                {
+                    "RepetitionTime": 1.0,
+                    "DelayAfterTrigger": 0.25,
+                    "DelayTime": 0.5,
+                },
+                f,
+            )
+
+        loaded = load_nifti(path)
+
+        assert loaded.coords["time"].attrs["units"] == "ms"
+        np.testing.assert_allclose(
+            loaded.coords["time"].values,
+            [250.0, 1250.0, 2250.0, 3250.0, 4250.0],
+        )
+        assert loaded.coords["time"].attrs["volume_acquisition_duration"] == pytest.approx(
+            500.0
+        )
+
+    def test_load_nifti_volume_timing_sidecar_converts_to_header_time_units(
+        self, tmp_path: Path
+    ) -> None:
+        """Sidecar `VolumeTiming` follows header time units when present."""
+        data = np.random.default_rng(0).random((2, 3, 4, 5)).astype(np.float32)
+        path = tmp_path / "time_units_sidecar_volume_timing.nii.gz"
+        img = nib.Nifti1Image(data, np.eye(4))
+        img.header.set_xyzt_units(xyz="mm", t="msec")
+        img.to_filename(path)
+
+        with open(tmp_path / "time_units_sidecar_volume_timing.json", "w") as f:
+            json.dump({"VolumeTiming": [0.0, 1.5, 2.8, 4.6, 6.0]}, f)
+
+        with pytest.warns(
+            UserWarning,
+            match="FrameAcquisitionDuration is REQUIRED when VolumeTiming is used",
+        ):
+            loaded = load_nifti(path)
+
+        assert loaded.coords["time"].attrs["units"] == "ms"
+        np.testing.assert_allclose(
+            loaded.coords["time"].values,
+            [0.0, 1500.0, 2800.0, 4600.0, 6000.0],
+        )
+
     def test_load_nifti_validation_runtime_error_warns(self, tmp_path: Path) -> None:
         """Unexpected sidecar validation failures degrade to a warning when loading."""
         data = np.random.default_rng(0).random((4, 3, 2)).astype(np.float32)

--- a/tests/unit/test_io/test_nifti.py
+++ b/tests/unit/test_io/test_nifti.py
@@ -170,6 +170,42 @@ class TestLoadNifti:
             + np.array([0.0, 0.1, 0.2, 0.3]),
         )
 
+    def test_load_nifti_reconstructs_scalar_time_and_slice_time_from_sidecar(
+        self, tmp_path: Path
+    ) -> None:
+        """3D payloads with timing sidecar metadata reconstruct scalar temporal coords."""
+        data = np.random.default_rng(0).random((5, 4, 3)).astype(np.float32)
+        path = tmp_path / "scalar_time_sidecar.nii.gz"
+        nib.Nifti1Image(data, np.eye(4)).to_filename(path)
+
+        with open(tmp_path / "scalar_time_sidecar.json", "w") as f:
+            json.dump(
+                {
+                    "VolumeTiming": [2.05],
+                    "FrameAcquisitionDuration": 0.4,
+                    "SliceTiming": [0.0, 0.1, 0.2],
+                    "SliceEncodingDirection": "k",
+                },
+                f,
+            )
+
+        loaded = load_nifti(path)
+
+        assert loaded.coords["time"].dims == ()
+        assert loaded.coords["time"].item() == pytest.approx(2.05)
+        assert loaded.coords["time"].attrs["volume_acquisition_reference"] == "start"
+        assert loaded.coords["time"].attrs["volume_acquisition_duration"] == pytest.approx(
+            0.4
+        )
+        assert "volume_timing" not in loaded.attrs
+        assert "volume_acquisition_duration" not in loaded.attrs
+
+        assert loaded.coords["slice_time"].dims == ("z",)
+        np.testing.assert_allclose(
+            loaded.coords["slice_time"].values,
+            np.array([2.05, 2.15, 2.25]),
+        )
+
     def test_load_nifti_derives_volume_duration_from_repetition_time_and_delay_time(
         self, tmp_path: Path
     ) -> None:
@@ -828,6 +864,37 @@ class TestSaveNifti:
         assert sidecar["VolumeTiming"] == [10.0]
         assert "FrameAcquisitionDuration" not in sidecar
 
+    def test_save_scalar_time_coordinate_without_time_dim(
+        self, tmp_path, sample_4d_volume
+    ) -> None:
+        """Saving a 3D slice with scalar `time` coord writes single-volume timing."""
+        da = sample_4d_volume.isel(time=0).copy()
+        output_path = tmp_path / "scalar_time_coord.nii.gz"
+
+        with pytest.warns(UserWarning, match="FrameAcquisitionDuration is REQUIRED"):
+            save_nifti(da, output_path)
+
+        sidecar_path = tmp_path / "scalar_time_coord.json"
+        with open(sidecar_path) as f:
+            sidecar = json.load(f)
+
+        assert sidecar["VolumeTiming"] == [10.0]
+        assert "RepetitionTime" not in sidecar
+
+    def test_save_boolean_data_writes_uint8(self, tmp_path, sample_3d_volume) -> None:
+        """Boolean payloads are stored as uint8 because NIfTI does not support bool."""
+        threshold = float(sample_3d_volume.mean().item())
+        da = sample_3d_volume.drop_vars("time") > threshold
+        output_path = tmp_path / "bool_payload.nii.gz"
+
+        save_nifti(da, output_path)
+
+        loaded = nib.load(output_path)
+        assert loaded.get_data_dtype() == np.dtype(np.uint8)
+        np.testing.assert_array_equal(
+            np.asarray(loaded.dataobj), da.values.transpose(2, 1, 0).astype(np.uint8)
+        )
+
     def test_save_nifti2_writes_nifti2_image(self, tmp_path, sample_3d_volume) -> None:
         """Saving with `nifti_version=2` produces a NIfTI-2 image."""
         da = sample_3d_volume.drop_vars("time")
@@ -990,6 +1057,30 @@ class TestSaveNifti:
 
         assert "SliceTiming" not in sidecar
         assert "SliceEncodingDirection" not in sidecar
+
+    def test_save_serializes_1d_slice_time_with_scalar_time_coordinate(
+        self, tmp_path, sample_4d_volume
+    ) -> None:
+        """A 1D absolute `slice_time` is exported for scalar-time 3D snapshots."""
+        da = sample_4d_volume.isel(time=0).copy()
+        da.coords["time"].attrs["volume_acquisition_duration"] = 0.25
+        da.coords["time"].attrs["volume_acquisition_reference"] = "start"
+        da = da.assign_coords(
+            slice_time=xr.DataArray(
+                da.coords["time"].item() + np.array([0.0, 0.1, 0.2, 0.3]),
+                dims=("z",),
+                attrs={"units": "s"},
+            )
+        )
+
+        output_path = tmp_path / "slice_time_1d_scalar_time.nii.gz"
+        save_nifti(da, output_path)
+
+        with open(tmp_path / "slice_time_1d_scalar_time.json") as f:
+            sidecar = json.load(f)
+
+        assert sidecar["SliceTiming"] == pytest.approx([0.0, 0.1, 0.2, 0.3])
+        assert sidecar["SliceEncodingDirection"] == "k"
 
     def test_save_nifti_validation_runtime_error_warns(
         self, tmp_path, sample_4d_volume

--- a/tests/unit/test_io/test_nifti.py
+++ b/tests/unit/test_io/test_nifti.py
@@ -206,6 +206,65 @@ class TestLoadNifti:
             np.array([2.05, 2.15, 2.25]),
         )
 
+    def test_load_nifti_scalar_time_sidecar_converts_to_header_time_units(
+        self, tmp_path: Path
+    ) -> None:
+        """Scalar sidecar timings are converted from seconds to header time units."""
+        data = np.random.default_rng(0).random((5, 4, 3)).astype(np.float32)
+        path = tmp_path / "scalar_time_ms_units.nii.gz"
+        img = nib.Nifti1Image(data, np.eye(4))
+        img.header.set_xyzt_units(xyz="mm", t="msec")
+        img.to_filename(path)
+
+        with open(tmp_path / "scalar_time_ms_units.json", "w") as f:
+            json.dump(
+                {
+                    "VolumeTiming": [2.05],
+                    "FrameAcquisitionDuration": 0.4,
+                    "SliceTiming": [0.0, 0.1, 0.2],
+                    "SliceEncodingDirection": "k",
+                },
+                f,
+            )
+
+        loaded = load_nifti(path)
+
+        assert loaded.coords["time"].attrs["units"] == "ms"
+        assert loaded.coords["time"].item() == pytest.approx(2050.0)
+        assert loaded.coords["time"].attrs["volume_acquisition_duration"] == pytest.approx(
+            400.0
+        )
+        np.testing.assert_allclose(
+            loaded.coords["slice_time"].values,
+            np.array([2050.0, 2150.0, 2250.0]),
+        )
+
+    def test_load_nifti_scalar_time_invalid_slice_direction_preserves_fields(
+        self, tmp_path: Path
+    ) -> None:
+        """Invalid scalar `SliceEncodingDirection` leaves slice fields untouched."""
+        data = np.random.default_rng(0).random((5, 4, 3)).astype(np.float32)
+        path = tmp_path / "scalar_time_invalid_slice_direction.nii.gz"
+        nib.Nifti1Image(data, np.eye(4)).to_filename(path)
+
+        with open(tmp_path / "scalar_time_invalid_slice_direction.json", "w") as f:
+            json.dump(
+                {
+                    "VolumeTiming": [2.05],
+                    "SliceTiming": [0.0, 0.1, 0.2],
+                    "SliceEncodingDirection": "invalid",
+                },
+                f,
+            )
+
+        with pytest.warns(UserWarning, match="SliceEncodingDirection"):
+            loaded = load_nifti(path)
+
+        assert loaded.coords["time"].item() == pytest.approx(2.05)
+        assert "slice_time" not in loaded.coords
+        assert "slice_timing" in loaded.attrs
+        assert "slice_encoding_direction" in loaded.attrs
+
     def test_load_nifti_derives_volume_duration_from_repetition_time_and_delay_time(
         self, tmp_path: Path
     ) -> None:

--- a/tests/unit/test_io/test_nifti.py
+++ b/tests/unit/test_io/test_nifti.py
@@ -265,6 +265,128 @@ class TestLoadNifti:
         assert "slice_timing" in loaded.attrs
         assert "slice_encoding_direction" in loaded.attrs
 
+    def test_load_nifti_scalar_time_multiple_volume_timing_warns(
+        self, tmp_path: Path
+    ) -> None:
+        """Scalar reconstruction uses the first timestamp when `VolumeTiming` is longer."""
+        data = np.random.default_rng(0).random((5, 4, 3)).astype(np.float32)
+        path = tmp_path / "scalar_time_multiple_volume_timing.nii.gz"
+        nib.Nifti1Image(data, np.eye(4)).to_filename(path)
+
+        with open(tmp_path / "scalar_time_multiple_volume_timing.json", "w") as f:
+            json.dump({"VolumeTiming": [2.05, 3.05]}, f)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            loaded = load_nifti(path)
+
+        assert any("multiple entries" in str(w.message) for w in caught)
+        assert loaded.coords["time"].item() == pytest.approx(2.05)
+
+    def test_load_nifti_scalar_time_invalid_volume_timing_omits_time_coordinate(
+        self, tmp_path: Path
+    ) -> None:
+        """Non-1D scalar `VolumeTiming` metadata is ignored after warning."""
+        data = np.random.default_rng(0).random((5, 4, 3)).astype(np.float32)
+        path = tmp_path / "scalar_time_invalid_volume_timing.nii.gz"
+        nib.Nifti1Image(data, np.eye(4)).to_filename(path)
+
+        with open(tmp_path / "scalar_time_invalid_volume_timing.json", "w") as f:
+            json.dump({"VolumeTiming": [[2.05]]}, f)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            loaded = load_nifti(path)
+
+        assert any("VolumeTiming" in str(w.message) for w in caught)
+        assert any("not a non-empty 1D array" in str(w.message) for w in caught)
+        assert "time" not in loaded.coords
+
+    def test_load_nifti_scalar_delay_after_trigger_without_repetition_time(
+        self, tmp_path: Path
+    ) -> None:
+        """Scalar reconstruction can fall back to `DelayAfterTrigger` alone."""
+        data = np.random.default_rng(0).random((5, 4, 3)).astype(np.float32)
+        path = tmp_path / "scalar_delay_after_trigger_only.nii.gz"
+        nib.Nifti1Image(data, np.eye(4)).to_filename(path)
+
+        with open(tmp_path / "scalar_delay_after_trigger_only.json", "w") as f:
+            json.dump({"DelayAfterTrigger": 1.25}, f)
+
+        with pytest.warns(
+            UserWarning,
+            match="recommends providing either RepetitionTime or VolumeTiming",
+        ):
+            loaded = load_nifti(path)
+
+        assert loaded.coords["time"].item() == pytest.approx(1.25)
+
+    def test_load_nifti_scalar_time_invalid_slice_timing_shape_skips_slice_coordinate(
+        self, tmp_path: Path
+    ) -> None:
+        """Non-1D scalar `SliceTiming` metadata is ignored after scalar time recovery."""
+        data = np.random.default_rng(0).random((5, 4, 3)).astype(np.float32)
+        path = tmp_path / "scalar_time_invalid_slice_timing_shape.nii.gz"
+        nib.Nifti1Image(data, np.eye(4)).to_filename(path)
+
+        with open(tmp_path / "scalar_time_invalid_slice_timing_shape.json", "w") as f:
+            json.dump(
+                {
+                    "VolumeTiming": [2.05],
+                    "SliceTiming": [[0.0, 0.1, 0.2]],
+                    "SliceEncodingDirection": "k",
+                },
+                f,
+            )
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            loaded = load_nifti(path)
+
+        assert any("SliceTiming" in str(w.message) for w in caught)
+        assert loaded.coords["time"].item() == pytest.approx(2.05)
+        assert "slice_time" not in loaded.coords
+
+    def test_load_nifti_delay_time_greater_than_repetition_time_warns(
+        self, tmp_path: Path
+    ) -> None:
+        """Loading warns when `DelayTime` prevents inferring a positive duration."""
+        data = np.random.default_rng(0).random((2, 3, 4, 5)).astype(np.float32)
+        path = tmp_path / "delay_time_too_large.nii.gz"
+        img = nib.Nifti1Image(data, np.eye(4))
+        img.header.set_zooms((1.0, 1.0, 1.0, 1.0))
+        img.to_filename(path)
+
+        with open(tmp_path / "delay_time_too_large.json", "w") as f:
+            json.dump({"RepetitionTime": 1.0, "DelayTime": 1.5}, f)
+
+        with pytest.warns(UserWarning, match="cannot be inferred"):
+            loaded = load_nifti(path)
+
+        assert "volume_acquisition_duration" not in loaded.coords["time"].attrs
+
+    def test_load_nifti_scalar_time_reverse_slice_direction_reverses_slice_order(
+        self, tmp_path: Path
+    ) -> None:
+        """Scalar `SliceEncodingDirection` with trailing `-` reverses slice timing."""
+        data = np.random.default_rng(0).random((5, 4, 3)).astype(np.float32)
+        path = tmp_path / "scalar_time_reverse_slice_direction.nii.gz"
+        nib.Nifti1Image(data, np.eye(4)).to_filename(path)
+
+        with open(tmp_path / "scalar_time_reverse_slice_direction.json", "w") as f:
+            json.dump(
+                {
+                    "VolumeTiming": [2.0],
+                    "SliceTiming": [0.0, 1.0, 2.0],
+                    "SliceEncodingDirection": "k-",
+                },
+                f,
+            )
+
+        loaded = load_nifti(path)
+
+        np.testing.assert_allclose(loaded.coords["slice_time"].values, [4.0, 3.0, 2.0])
+
     def test_load_nifti_derives_volume_duration_from_repetition_time_and_delay_time(
         self, tmp_path: Path
     ) -> None:
@@ -1140,6 +1262,296 @@ class TestSaveNifti:
 
         assert sidecar["SliceTiming"] == pytest.approx([0.0, 0.1, 0.2, 0.3])
         assert sidecar["SliceEncodingDirection"] == "k"
+
+    def test_save_1d_slice_time_requires_scalar_time_coordinate(self, tmp_path) -> None:
+        """A 1D `slice_time` on time-series data is rejected for BIDS export."""
+        da = xr.DataArray(
+            np.zeros((2, 4, 3, 2), dtype=np.float32),
+            dims=["time", "z", "y", "x"],
+            coords={
+                "time": xr.DataArray(
+                    [0.0, 1.0],
+                    dims=["time"],
+                    attrs={"units": "s", "volume_acquisition_reference": "start"},
+                ),
+                "z": np.arange(4, dtype=float),
+                "y": np.arange(3, dtype=float),
+                "x": np.arange(2, dtype=float),
+                "slice_time": xr.DataArray(
+                    [0.0, 0.1, 0.2, 0.3], dims=["z"], attrs={"units": "s"}
+                ),
+            },
+        )
+
+        output_path = tmp_path / "slice_time_1d_requires_scalar.nii.gz"
+        with pytest.warns(UserWarning, match="A 1D `slice_time` coordinate can only"):
+            save_nifti(da, output_path)
+
+        with open(tmp_path / "slice_time_1d_requires_scalar.json") as f:
+            sidecar = json.load(f)
+
+        assert "SliceTiming" not in sidecar
+
+    def test_save_1d_slice_time_without_time_coordinate_warns(self, tmp_path) -> None:
+        """A 1D `slice_time` without `time` cannot be exported to BIDS."""
+        da = xr.DataArray(
+            np.zeros((4, 3, 2), dtype=np.float32),
+            dims=["z", "y", "x"],
+            coords={
+                "z": np.arange(4, dtype=float),
+                "y": np.arange(3, dtype=float),
+                "x": np.arange(2, dtype=float),
+                "slice_time": xr.DataArray(
+                    [0.0, 0.1, 0.2, 0.3], dims=["z"], attrs={"units": "s"}
+                ),
+            },
+        )
+
+        output_path = tmp_path / "slice_time_1d_no_time.nii.gz"
+        with pytest.warns(UserWarning, match="without a `time` coordinate"):
+            save_nifti(da, output_path)
+
+        with open(tmp_path / "slice_time_1d_no_time.json") as f:
+            sidecar = json.load(f)
+
+        assert "SliceTiming" not in sidecar
+
+    def test_save_1d_slice_time_without_frame_duration_warns(self, tmp_path) -> None:
+        """A scalar-time snapshot without frame duration cannot export `SliceTiming`."""
+        da = xr.DataArray(
+            np.zeros((4, 3, 2), dtype=np.float32),
+            dims=["z", "y", "x"],
+            coords={
+                "time": xr.DataArray(10.0, attrs={"units": "s"}),
+                "z": np.arange(4, dtype=float),
+                "y": np.arange(3, dtype=float),
+                "x": np.arange(2, dtype=float),
+                "slice_time": xr.DataArray(
+                    [10.0, 10.1, 10.2, 10.3], dims=["z"], attrs={"units": "s"}
+                ),
+            },
+        )
+
+        output_path = tmp_path / "slice_time_1d_no_duration.nii.gz"
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            save_nifti(da, output_path)
+
+        assert any(
+            "Cannot infer frame acquisition duration for a 1D `slice_time` coordinate"
+            in str(w.message)
+            for w in caught
+        )
+
+        with open(tmp_path / "slice_time_1d_no_duration.json") as f:
+            sidecar = json.load(f)
+
+        assert "SliceTiming" not in sidecar
+
+    def test_save_1d_slice_time_converts_slice_reference_to_start(self, tmp_path) -> None:
+        """A 1D `slice_time` honors its own acquisition reference metadata."""
+        da = xr.DataArray(
+            np.zeros((2, 3, 2), dtype=np.float32),
+            dims=["z", "y", "x"],
+            coords={
+                "time": xr.DataArray(
+                    10.0,
+                    attrs={
+                        "units": "s",
+                        "volume_acquisition_duration": 0.25,
+                        "volume_acquisition_reference": "start",
+                    },
+                ),
+                "z": np.arange(2, dtype=float),
+                "y": np.arange(3, dtype=float),
+                "x": np.arange(2, dtype=float),
+                "slice_time": xr.DataArray(
+                    [10.2, 10.3],
+                    dims=["z"],
+                    attrs={
+                        "units": "s",
+                        "volume_acquisition_duration": 0.2,
+                        "volume_acquisition_reference": "end",
+                    },
+                ),
+            },
+        )
+
+        output_path = tmp_path / "slice_time_1d_end_reference.nii.gz"
+        save_nifti(da, output_path)
+
+        with open(tmp_path / "slice_time_1d_end_reference.json") as f:
+            sidecar = json.load(f)
+
+        assert sidecar["SliceTiming"] == pytest.approx([0.0, 0.1])
+
+    def test_save_invalid_1d_slice_time_dimension_is_skipped(self, tmp_path) -> None:
+        """A 1D `slice_time` on a non-spatial dimension is skipped silently."""
+        da = xr.DataArray(
+            np.zeros((2, 4, 3, 2), dtype=np.float32),
+            dims=["channel", "z", "y", "x"],
+            coords={
+                "time": xr.DataArray(
+                    10.0,
+                    attrs={
+                        "units": "s",
+                        "volume_acquisition_duration": 0.25,
+                        "volume_acquisition_reference": "start",
+                    },
+                ),
+                "channel": [0, 1],
+                "z": np.arange(4, dtype=float),
+                "y": np.arange(3, dtype=float),
+                "x": np.arange(2, dtype=float),
+                "slice_time": xr.DataArray(
+                    [10.0, 10.1], dims=["channel"], attrs={"units": "s"}
+                ),
+            },
+        )
+
+        output_path = tmp_path / "slice_time_1d_invalid_dim.nii.gz"
+        save_nifti(da, output_path)
+
+        with open(tmp_path / "slice_time_1d_invalid_dim.json") as f:
+            sidecar = json.load(f)
+
+        assert "SliceTiming" not in sidecar
+
+    def test_save_invalid_2d_slice_time_shape_warns(self, tmp_path, sample_4d_volume) -> None:
+        """A non-1D/non-2D `slice_time` is rejected with a warning."""
+        da = sample_4d_volume.copy()
+        da.coords["time"].attrs["volume_acquisition_reference"] = "start"
+        da = da.assign_coords(
+            slice_time=xr.DataArray(
+                np.zeros(
+                    (
+                        sample_4d_volume.sizes["time"],
+                        sample_4d_volume.sizes["z"],
+                        sample_4d_volume.sizes["y"],
+                    )
+                ),
+                dims=("time", "z", "y"),
+                attrs={"units": "s"},
+            )
+        )
+
+        output_path = tmp_path / "slice_time_invalid_shape.nii.gz"
+        with pytest.warns(UserWarning, match="must be either a 2D coordinate"):
+            save_nifti(da, output_path)
+
+        with open(tmp_path / "slice_time_invalid_shape.json") as f:
+            sidecar = json.load(f)
+
+        assert "SliceTiming" not in sidecar
+
+    def test_save_2d_slice_time_on_non_spatial_dim_is_skipped(self, tmp_path) -> None:
+        """A 2D `slice_time` with a non-spatial companion dimension is skipped."""
+        da = xr.DataArray(
+            np.zeros((2, 2, 4, 3, 2), dtype=np.float32),
+            dims=["channel", "time", "z", "y", "x"],
+            coords={
+                "channel": [0, 1],
+                "time": xr.DataArray(
+                    [0.0, 1.0],
+                    dims=["time"],
+                    attrs={"units": "s", "volume_acquisition_reference": "start"},
+                ),
+                "z": np.arange(4, dtype=float),
+                "y": np.arange(3, dtype=float),
+                "x": np.arange(2, dtype=float),
+                "slice_time": xr.DataArray(
+                    np.zeros((2, 2)), dims=("time", "channel"), attrs={"units": "s"}
+                ),
+            },
+        )
+
+        output_path = tmp_path / "slice_time_2d_non_spatial_dim.nii.gz"
+        save_nifti(da, output_path)
+
+        with open(tmp_path / "slice_time_2d_non_spatial_dim.json") as f:
+            sidecar = json.load(f)
+
+        assert "SliceTiming" not in sidecar
+
+    def test_save_2d_slice_time_without_time_coordinate_warns(self, tmp_path) -> None:
+        """A 2D `slice_time` without a `time` coordinate cannot be exported."""
+        da = xr.DataArray(
+            np.zeros((2, 4, 3, 2), dtype=np.float32),
+            dims=["time", "z", "y", "x"],
+            coords={
+                "z": np.arange(4, dtype=float),
+                "y": np.arange(3, dtype=float),
+                "x": np.arange(2, dtype=float),
+                "slice_time": xr.DataArray(
+                    np.zeros((2, 4)), dims=("time", "z"), attrs={"units": "s"}
+                ),
+            },
+        )
+
+        output_path = tmp_path / "slice_time_2d_no_time_coord.nii.gz"
+        with pytest.warns(UserWarning, match="without a `time` coordinate"):
+            save_nifti(da, output_path)
+
+        with open(tmp_path / "slice_time_2d_no_time_coord.json") as f:
+            sidecar = json.load(f)
+
+        assert "SliceTiming" not in sidecar
+
+    def test_save_2d_slice_time_without_frame_duration_warns(self, tmp_path) -> None:
+        """A single-volume 2D `slice_time` needs an explicit frame duration."""
+        da = xr.DataArray(
+            np.zeros((1, 4, 3, 2), dtype=np.float32),
+            dims=["time", "z", "y", "x"],
+            coords={
+                "time": xr.DataArray(
+                    [10.0],
+                    dims=["time"],
+                    attrs={"units": "s", "volume_acquisition_reference": "start"},
+                ),
+                "z": np.arange(4, dtype=float),
+                "y": np.arange(3, dtype=float),
+                "x": np.arange(2, dtype=float),
+                "slice_time": xr.DataArray(
+                    np.zeros((1, 4)) + np.array([10.0, 10.1, 10.2, 10.3]),
+                    dims=("time", "z"),
+                    attrs={"units": "s"},
+                ),
+            },
+        )
+
+        output_path = tmp_path / "slice_time_2d_no_duration.nii.gz"
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            save_nifti(da, output_path)
+
+        assert any(
+            "Cannot infer frame acquisition duration for a 2D `slice_time` coordinate"
+            in str(w.message)
+            for w in caught
+        )
+
+    def test_save_invalid_time_reference_raises(self, tmp_path) -> None:
+        """Saving rejects invalid `volume_acquisition_reference` values."""
+        da = xr.DataArray(
+            np.zeros((4, 3, 2), dtype=np.float32),
+            dims=["z", "y", "x"],
+            coords={
+                "time": xr.DataArray(
+                    10.0,
+                    attrs={
+                        "units": "s",
+                        "volume_acquisition_duration": 0.25,
+                        "volume_acquisition_reference": "middle",
+                    },
+                ),
+                "z": np.arange(4, dtype=float),
+                "y": np.arange(3, dtype=float),
+                "x": np.arange(2, dtype=float),
+            },
+        )
+
+        with pytest.raises(ValueError, match="Unknown time volume_acquisition_reference"):
+            save_nifti(da, tmp_path / "invalid_time_reference.nii.gz")
 
     def test_save_nifti_validation_runtime_error_warns(
         self, tmp_path, sample_4d_volume


### PR DESCRIPTION
## Summary
- fix scalar `time` save-path handling by normalizing timing arrays to 1D before TR inference, preventing crashes on 3D arrays with scalar time metadata
- write boolean NIfTI payloads as `uint8` so mask exports are nibabel-compatible
- improve scalar-time roundtrip ergonomics for 3D NIfTI payloads by reconstructing scalar `time` (and scalar `slice_time` when present) from sidecar metadata
- support exporting 1D spatial `slice_time` coordinates for scalar-time snapshots in addition to existing 2D `(time, spatial_dim)` export
- add targeted regression tests for scalar-time save/load, 1D slice-time export/load, and bool mask export

Fixes #71