### PR TITLE
feat: add `.bps` support

### DIFF
--- a/docs/user-guide/io.md
+++ b/docs/user-guide/io.md
@@ -344,9 +344,9 @@ scope or call [`.compute()`][xarray.DataArray.compute] before discarding it.
 Provenance metadata from the file is stored in `da.attrs`: `scan_mode`, `subject`,
 `session`, `scan`, `project`, `date`, `neuroscan_version`, and `machine_sn`.
 
-#### Loading a `.bps` File
+#### Loading a BPS File
 
-Iconeus' `.bps` files are HDF5 containers produced by Iconeus' Brain Positioning System.
+Iconeus' BPS files are HDF5 containers produced by Iconeus' Brain Positioning System.
 They contain an affine matrix that maps Iconeus brain coordinates `(x_brain, y_brain,
 z_brain, 1)` to Iconeus lab coordinates `(x_lab, y_lab, z_lab, 1)` in meters. Iconeus'
 lab space axes are aligned with the probe: `x_lab = lateral`, `y_lab = elevation`,
@@ -354,7 +354,7 @@ lab space axes are aligned with the probe: `x_lab = lateral`, `y_lab = elevation
 `(z_lab, y_lab, x_lab)` (elevation, depth, lateral) in millimeters, matching the
 convention used throughout the rest of the package.
 
-The affine matrix in the `.bps` file can be loaded with [`confusius.io.load_bps`][confusius.io.load_bps].
+The affine matrix in the BPS file can be loaded with [`confusius.io.load_bps`][confusius.io.load_bps].
 
 ```python
 import confusius as cf
@@ -376,8 +376,8 @@ physical_to_lab = da.attrs["affines"]["physical_to_lab"]
 physical_to_brain = np.linalg.inv(bps) @ physical_to_lab
 ```
 
-In fact, if you pass the `.bps` file using the `bps_path` argument when loading a
-`.scan` file with [`confusius.load`][confusius.load], the `physical_to_brain` affine
+In fact, if you pass the BPS file using the `bps_path` argument when loading a
+SCAN file with [`confusius.load`][confusius.load], the `physical_to_brain` affine
 will be computed automatically and stored in the resulting DataArray's attributes
 `affines` alongside the `physical_to_lab` affines:
 

--- a/docs/user-guide/io.md
+++ b/docs/user-guide/io.md
@@ -363,7 +363,8 @@ bps = cf.io.load_bps("sub-01_task-awake_pwd.bps")
 ```
 
 A `physical_to_brain` matrix between Iconeus' brain space and ConfUSIus' physical space
-can be established by using the `physical_to_lab` affines from the SCAN file:
+can be established and added to the DataArray's attributes by using the
+`physical_to_lab` affines from the SCAN file:
 
 ```python
 import confusius as cf
@@ -374,6 +375,7 @@ bps = cf.io.load_bps("sub-01_task-awake_pwd.bps")
 
 physical_to_lab = da.attrs["affines"]["physical_to_lab"]
 physical_to_brain = np.linalg.inv(bps) @ physical_to_lab
+da.attrs["affines"]["physical_to_brain"] = physical_to_brain
 ```
 
 In fact, if you pass the BPS file using the `bps_path` argument when loading a

--- a/docs/user-guide/io.md
+++ b/docs/user-guide/io.md
@@ -344,6 +344,30 @@ scope or call [`.compute()`][xarray.DataArray.compute] before discarding it.
 Provenance metadata from the file is stored in `da.attrs`: `scan_mode`, `subject`,
 `session`, `scan`, `project`, `date`, `neuroscan_version`, and `machine_sn`.
 
+#### Loading a `.bps` File
+
+If you have an Iconeus `.bps` sidecar (a Brain Positioning System file produced
+alongside the SCAN), pass it via the `bps_path` argument so the resulting DataArray
+carries an extra `physical_to_brain` affine in `da.attrs["affines"]`:
+
+```python
+import confusius as cf
+
+da = cf.load(
+    "sub-01_task-awake_pwd.scan",
+    bps_path="sub-01_task-awake_pwd.bps",
+)
+
+physical_to_brain = da.attrs["affines"]["physical_to_brain"]
+```
+
+`physical_to_brain` maps ConfUSIus physical coordinates `(z, y, x, 1)` (mm) to
+Iconeus brain coordinates `(x_brain, y_brain, z_brain, 1)`. Compose it with
+brain-side affines (e.g. brain-to-CCFv3 from a brain atlas) to register fUSI data
+into atlas space without going through the Iconeus lab frame explicitly. For
+multi-pose files (`3Dscan`, `4Dscan`) the affine has shape `(npose, 4, 4)` and is
+indexed by pose, the same way `physical_to_lab` is.
+
 #### Converting SCAN Data to NIfTI
 
 Since [`load_scan`][confusius.io.load_scan] returns a standard Xarray DataArray with

--- a/docs/user-guide/io.md
+++ b/docs/user-guide/io.md
@@ -367,6 +367,7 @@ can be established by using the `physical_to_lab` affines from the SCAN file:
 
 ```python
 import confusius as cf
+import numpy as np
 
 da = cf.load("sub-01_task-awake_pwd.scan")
 bps = cf.io.load_bps("sub-01_task-awake_pwd.bps")

--- a/docs/user-guide/io.md
+++ b/docs/user-guide/io.md
@@ -346,9 +346,39 @@ Provenance metadata from the file is stored in `da.attrs`: `scan_mode`, `subject
 
 #### Loading a `.bps` File
 
-If you have an Iconeus `.bps` sidecar (a Brain Positioning System file produced
-alongside the SCAN), pass it via the `bps_path` argument so the resulting DataArray
-carries an extra `physical_to_brain` affine in `da.attrs["affines"]`:
+Iconeus' `.bps` files are HDF5 containers produced by Iconeus' Brain Positioning System.
+They contain an affine matrix that maps Iconeus brain coordinates `(x_brain, y_brain,
+z_brain, 1)` to Iconeus lab coordinates `(x_lab, y_lab, z_lab, 1)` in meters. Iconeus'
+lab space axes are aligned with the probe: `x_lab = lateral`, `y_lab = elevation`,
+`z_lab = axial`. We chose to re-express this space as **ConfUSIus-ordered** lab space
+`(z_lab, y_lab, x_lab)` (elevation, depth, lateral) in millimeters, matching the
+convention used throughout the rest of the package.
+
+The affine matrix in the `.bps` file can be loaded with [`confusius.io.load_bps`][confusius.io.load_bps].
+
+```python
+import confusius as cf
+
+bps = cf.io.load_bps("sub-01_task-awake_pwd.bps")
+```
+
+A `physical_to_brain` matrix between Iconeus' brain space and ConfUSIus' physical space
+can be established by using the `physical_to_lab` affines from the SCAN file:
+
+```python
+import confusius as cf
+
+da = cf.load("sub-01_task-awake_pwd.scan")
+bps = cf.io.load_bps("sub-01_task-awake_pwd.bps")
+
+physical_to_lab = da.attrs["affines"]["physical_to_lab"]
+physical_to_brain = np.linalg.inv(bps) @ physical_to_lab
+```
+
+In fact, if you pass the `.bps` file using the `bps_path` argument when loading a
+`.scan` file with [`confusius.load`][confusius.load], the `physical_to_brain` affine
+will be computed automatically and stored in the resulting DataArray's attributes
+`affines` alongside the `physical_to_lab` affines:
 
 ```python
 import confusius as cf
@@ -361,12 +391,10 @@ da = cf.load(
 physical_to_brain = da.attrs["affines"]["physical_to_brain"]
 ```
 
-`physical_to_brain` maps ConfUSIus physical coordinates `(z, y, x, 1)` (mm) to
-Iconeus brain coordinates `(x_brain, y_brain, z_brain, 1)`. Compose it with
-brain-side affines (e.g. brain-to-CCFv3 from a brain atlas) to register fUSI data
-into atlas space without going through the Iconeus lab frame explicitly. For
-multi-pose files (`3Dscan`, `4Dscan`) the affine has shape `(npose, 4, 4)` and is
-indexed by pose, the same way `physical_to_lab` is.
+Compose it with brain-side affines (e.g. brain-to-CCFv3 from a brain atlas) to register
+fUSI data into atlas space directly. For multi-pose files (`3Dscan`, `4Dscan`) the
+affine has shape `(npose, 4, 4)` and is indexed by pose, the same way `physical_to_lab`
+is.
 
 #### Converting SCAN Data to NIfTI
 

--- a/docs/user-guide/io.md
+++ b/docs/user-guide/io.md
@@ -348,11 +348,11 @@ Provenance metadata from the file is stored in `da.attrs`: `scan_mode`, `subject
 
 Iconeus' BPS files are HDF5 containers produced by Iconeus' Brain Positioning System.
 They contain an affine matrix that maps Iconeus brain coordinates `(x_brain, y_brain,
-z_brain, 1)` to Iconeus lab coordinates `(x_lab, y_lab, z_lab, 1)` in meters. Iconeus'
-lab space axes are aligned with the probe: `x_lab = lateral`, `y_lab = elevation`,
-`z_lab = axial`. We chose to re-express this space as **ConfUSIus-ordered** lab space
-`(z_lab, y_lab, x_lab)` (elevation, depth, lateral) in millimeters, matching the
-convention used throughout the rest of the package.
+z_brain, 1)` to Iconeus lab coordinates `(x_lab, y_lab, z_lab, 1)` in meters. The
+Iconeus lab frame is a fixed scanner frame; `probeToLab` carries any rotation of the
+probe within it. We chose to re-express this space as **ConfUSIus-ordered** lab space
+`(z_lab, y_lab, x_lab)` in millimeters, matching the convention used throughout the
+rest of the package.
 
 The affine matrix in the BPS file can be loaded with [`confusius.io.load_bps`][confusius.io.load_bps].
 

--- a/docs/user-guide/io.md
+++ b/docs/user-guide/io.md
@@ -350,7 +350,7 @@ Iconeus' BPS files are HDF5 containers produced by Iconeus' Brain Positioning Sy
 They contain an affine matrix that maps Iconeus brain coordinates `(x_brain, y_brain,
 z_brain, 1)` to Iconeus lab coordinates `(x_lab, y_lab, z_lab, 1)` in meters. The
 Iconeus lab frame is a fixed scanner frame; `probeToLab` carries any rotation of the
-probe within it. We chose to re-express this space as **ConfUSIus-ordered** lab space
+probe within it. ConfUSIus re-expresses this space as **ConfUSIus-ordered** lab space
 `(z_lab, y_lab, x_lab)` in millimeters, matching the convention used throughout the
 rest of the package.
 
@@ -362,15 +362,14 @@ import confusius as cf
 bps = cf.io.load_bps("sub-01_task-awake_pwd.bps")
 ```
 
-A `physical_to_brain` matrix between Iconeus' brain space and ConfUSIus' physical space
-can be established and added to the DataArray's attributes by using the
-`physical_to_lab` affines from the SCAN file:
+Compute `physical_to_brain` (Iconeus brain space from ConfUSIus physical space) from
+the SCAN file `physical_to_lab` affine and store it in the DataArray attributes:
 
 ```python
 import confusius as cf
 import numpy as np
 
-da = cf.load("sub-01_task-awake_pwd.scan")
+da = cf.load("sub-01_task-awake_pwd.source.scan")
 bps = cf.io.load_bps("sub-01_task-awake_pwd.bps")
 
 physical_to_lab = da.attrs["affines"]["physical_to_lab"]
@@ -387,7 +386,7 @@ will be computed automatically and stored in the resulting DataArray's attribute
 import confusius as cf
 
 da = cf.load(
-    "sub-01_task-awake_pwd.scan",
+    "sub-01_task-awake_pwd.source.scan",
     bps_path="sub-01_task-awake_pwd.bps",
 )
 

--- a/src/confusius/io/__init__.py
+++ b/src/confusius/io/__init__.py
@@ -12,6 +12,7 @@ __all__ = [
     "load_echoframe_dat",
     "load_echoframe_metadata",
     "load_nifti",
+    "load_bps",
     "load_scan",
     "save_nifti",
 ]
@@ -25,5 +26,5 @@ from confusius.io.echoframe import (
 )
 from confusius.io.loadsave import load, save
 from confusius.io.nifti import load_nifti, save_nifti
-from confusius.io.scan import load_scan
+from confusius.io.scan import load_bps, load_scan
 from confusius.io.utils import check_path

--- a/src/confusius/io/scan.py
+++ b/src/confusius/io/scan.py
@@ -181,7 +181,7 @@ def _build_physical_to_lab(
     return physical_to_lab
 
 
-def load_bps(bps_path: Path) -> npt.NDArray[np.float64]:
+def load_bps(bps_path: str | Path) -> npt.NDArray[np.float64]:
     """Load a `.bps` file and return a `brain_to_lab` affine in ConfUSIus lab space.
 
     BPS files are HDF5 sidecars produced by Iconeus' brain positioning system. They
@@ -215,7 +215,7 @@ def load_bps(bps_path: Path) -> npt.NDArray[np.float64]:
 
     Parameters
     ----------
-    bps_path : pathlib.Path
+    bps_path : str or pathlib.Path
         Path to the BPS file (`.bps`).
 
     Returns
@@ -224,6 +224,8 @@ def load_bps(bps_path: Path) -> npt.NDArray[np.float64]:
         Affine mapping Iconeus brain coordinates to ConfUSIus-ordered Iconeus lab
         coordinates `(z_lab, y_lab, x_lab, 1)` in millimetres.
     """
+    bps_path = check_path(bps_path, label="bps_path", type="file")
+
     with h5py.File(bps_path, "r") as f:
         brain_to_lab = f["BrainToLab"][:]
 
@@ -297,7 +299,7 @@ def load_scan(
     If `bps_path` is provided, a `physical_to_brain` affine is stored in
     `da.attrs["affines"]["physical_to_brain"]` that maps ConfUSIus physical coordinates
     `(z, y, x)` to Iconeus' brain coordinates. Apply as
-    `da.attrs["affines"]["physical_to_lab"] @ np.array([z, y, x, 1.0])`.
+    `da.attrs["affines"]["physical_to_brain"] @ np.array([z, y, x, 1.0])`.
 
     Provenance attributes are stored in `da.attrs`: BIDS-compatible fields
     (`device_serial_number`, `software_version`) and Iconeus-specific fields
@@ -305,9 +307,6 @@ def load_scan(
     `iconeus_project`, `iconeus_date`).
     """
     path = check_path(path, type="file")
-    # validate bps path here so we fail early
-    if bps_path is not None:
-        bps_path = check_path(bps_path, label="bps_path", type="file")
 
     h5 = h5py.File(path, "r")
 
@@ -361,14 +360,13 @@ def load_scan(
             )
 
         data_array.name = attrs["iconeus_scan"] or path.stem
+        if bps_path is not None:
+            brain_to_lab = load_bps(bps_path)
+            physical_to_brain = np.linalg.inv(brain_to_lab) @ physical_to_lab
+            data_array.attrs["affines"]["physical_to_brain"] = physical_to_brain
     except Exception:
         h5.close()
         raise
-
-    if bps_path is not None:
-        brain_to_lab = load_bps(bps_path)
-        physical_to_brain = np.linalg.inv(brain_to_lab) @ physical_to_lab
-        data_array.attrs["affines"]["physical_to_brain"] = physical_to_brain
 
     return data_array
 

--- a/src/confusius/io/scan.py
+++ b/src/confusius/io/scan.py
@@ -181,18 +181,18 @@ def _build_physical_to_lab(
     return physical_to_lab
 
 
-def _load_bps(bps_path: Path) -> npt.NDArray[np.float64]:
+def load_bps(bps_path: Path) -> npt.NDArray[np.float64]:
     """Load a `.bps` file and return a `brain_to_lab` affine in ConfUSIus lab space.
 
     BPS files are HDF5 sidecars produced by Iconeus' brain positioning system. They
     store a `BrainToLab` affine that maps Iconeus brain coordinates `(x_brain, y_brain,
-    z_brain, 1)` to Iconeus lab coordinates `(x_lab, y_lab, z_lab, 1)` in metres.
+    z_brain, 1)` to Iconeus lab coordinates `(x_lab, y_lab, z_lab, 1)` in meters.
     Iconeus' lab axes are aligned with the probe: `x_lab = lateral`, `y_lab =
     elevation`, `z_lab = axial`.
 
     To compose this affine with the rest of the ConfUSIus pipeline we re-express
     the lab side as **ConfUSIus-ordered** lab space `(z_lab, y_lab, x_lab)`
-    (elevation, depth, lateral) in millimetres, matching the convention used by
+    (elevation, depth, lateral) in millimeters, matching the convention used by
     `physical_to_lab` (see `_build_physical_to_lab`). The brain side is left in
     its original axis order (the brain coordinate units are not declared by the
     BPS format and are therefore not converted).
@@ -366,7 +366,7 @@ def load_scan(
         raise
 
     if bps_path is not None:
-        brain_to_lab = _load_bps(bps_path)
+        brain_to_lab = load_bps(bps_path)
         physical_to_brain = np.linalg.inv(brain_to_lab) @ physical_to_lab
         data_array.attrs["affines"]["physical_to_brain"] = physical_to_brain
 

--- a/src/confusius/io/scan.py
+++ b/src/confusius/io/scan.py
@@ -181,8 +181,63 @@ def _build_physical_to_lab(
     return physical_to_lab
 
 
+def _load_bps(bps_path: Path) -> npt.NDArray[np.float64]:
+    """Load a `.bps` file and return a `brain_to_lab` affine in ConfUSIus lab space.
+
+    BPS files are HDF5 sidecars produced by Iconeus' brain positioning system. They
+    store a `BrainToLab` affine that maps Iconeus brain coordinates `(x_brain, y_brain,
+    z_brain, 1)` to Iconeus lab coordinates `(x_lab, y_lab, z_lab, 1)` in metres.
+    Iconeus' lab axes are aligned with the probe: `x_lab = lateral`, `y_lab =
+    elevation`, `z_lab = axial`.
+
+    To compose this affine with the rest of the ConfUSIus pipeline we re-express
+    the lab side as **ConfUSIus-ordered** lab space `(z_lab, y_lab, x_lab)`
+    (elevation, depth, lateral) in millimetres, matching the convention used by
+    `physical_to_lab` (see `_build_physical_to_lab`). The brain side is left in
+    its original axis order (the brain coordinate units are not declared by the
+    BPS format and are therefore not converted).
+
+    The change of basis from ConfUSIus-ordered millimetre lab coordinates to
+    Iconeus-ordered metre lab coordinates is
+
+    ```
+    confusius_lab_to_iconeus_lab = mm_to_m @ P
+    ```
+
+    where `P = _PHYSICAL_TO_PROBE_PERMUTATION` permutes the axes from ConfUSIus
+    order `(z, y, x)` to probe / Iconeus-lab order `(x, y, z)`, and
+    `mm_to_m = diag(1e-3, 1e-3, 1e-3, 1)` rescales the translation column. The
+    returned affine is then
+
+    ```
+    brain_to_confusius_lab = inv(confusius_lab_to_iconeus_lab) @ BrainToLab
+    ```
+
+    Parameters
+    ----------
+    bps_path : pathlib.Path
+        Path to the BPS file (`.bps`).
+
+    Returns
+    -------
+    (4, 4) numpy.ndarray
+        Affine mapping Iconeus brain coordinates to ConfUSIus-ordered Iconeus lab
+        coordinates `(z_lab, y_lab, x_lab, 1)` in millimetres.
+    """
+    with h5py.File(bps_path, "r") as f:
+        brain_to_lab = f["BrainToLab"][:]
+
+    P = _PHYSICAL_TO_PROBE_PERMUTATION
+    mm_to_m = np.diag([1e-3, 1e-3, 1e-3, 1.0])
+    confusius_lab_to_iconeus_lab = mm_to_m @ P
+
+    brain_to_confusius_lab = np.linalg.inv(confusius_lab_to_iconeus_lab) @ brain_to_lab
+    return brain_to_confusius_lab
+
+
 def load_scan(
     path: str | Path,
+    bps_path: str | Path | None = None,
     chunks: int | tuple[int, ...] | str | None = "auto",
 ) -> xr.DataArray:
     """Load an Iconeus SCAN file as a lazy Xarray DataArray.
@@ -199,6 +254,9 @@ def load_scan(
     ----------
     path : str or pathlib.Path
         Path to the SCAN file (`.scan`).
+    bps_path : str or pathlib.Path, optional
+        Path to the corresponding BPS file (`.bps`). If provided, the BPS transformation
+        matrix will be added as an affine attribute to the returned DataArray.
     chunks : int or tuple[int, ...] or str or None, default: "auto"
         Dask chunk specification passed to `dask.array.from_array`. Accepted forms:
 
@@ -231,10 +289,15 @@ def load_scan(
     Notes
     -----
     The `physical_to_lab` affine stored in `da.attrs["affines"]` maps ConfUSIus physical
-    coordinates `(z, y, x)` to Iconeus lab coordinates (mm). Apply as
-    `da.attrs["affines"]["physical_to_lab"] @ np.array([z, y, x, 1.0])`. For multi-pose
-    files the shape is `(npose, 4, 4)`; index with `da.coords["pose"].values` after
-    `isel`.
+    coordinates `(z, y, x)` to **ConfUSIus-ordered** Iconeus lab coordinates (mm). Apply
+    as `da.attrs["affines"]["physical_to_lab"] @ np.array([z, y, x, 1.0])`. For
+    multi-pose files the shape is `(npose, 4, 4)`; index with `da.coords["pose"].values`
+    after `isel`.
+
+    If `bps_path` is provided, a `physical_to_brain` affine is stored in
+    `da.attrs["affines"]["physical_to_brain"]` that maps ConfUSIus physical coordinates
+    `(z, y, x)` to Iconeus' brain coordinates. Apply as
+    `da.attrs["affines"]["physical_to_lab"] @ np.array([z, y, x, 1.0])`.
 
     Provenance attributes are stored in `da.attrs`: BIDS-compatible fields
     (`device_serial_number`, `software_version`) and Iconeus-specific fields
@@ -242,6 +305,9 @@ def load_scan(
     `iconeus_project`, `iconeus_date`).
     """
     path = check_path(path, type="file")
+    # validate bps path here so we fail early
+    if bps_path is not None:
+        bps_path = check_path(bps_path, label="bps_path", type="file")
 
     h5 = h5py.File(path, "r")
 
@@ -298,6 +364,11 @@ def load_scan(
     except Exception:
         h5.close()
         raise
+
+    if bps_path is not None:
+        brain_to_lab = _load_bps(bps_path)
+        physical_to_brain = np.linalg.inv(brain_to_lab) @ physical_to_lab
+        data_array.attrs["affines"]["physical_to_brain"] = physical_to_brain
 
     return data_array
 

--- a/src/confusius/io/scan.py
+++ b/src/confusius/io/scan.py
@@ -15,22 +15,26 @@ import xarray as xr
 
 from confusius.io.utils import check_path
 
-# Permutation matrix P that maps ConfUSIus physical input (z_conf, y_conf, x_conf, 1)
-# to probe physical (x_probe, y_probe, z_probe, 1):
-#
-#   x_probe =  x_conf      (lateral, same direction)
-#   y_probe =  z_conf      (elevation, same direction)
-#   z_probe = -y_conf      (axial depth, sign flip: y_conf = -z_probe > 0)
-#
-# Its transpose P^T maps probe physical (x_probe, y_probe, z_probe, 1) back to
-# ConfUSIus physical (z_conf, y_conf, x_conf, 1):
-#
-#   z_conf =  y_probe      (elevation)
-#   y_conf = -z_probe      (depth, sign flip)
-#   x_conf =  x_probe      (lateral)
-_PHYSICAL_TO_PROBE_PERMUTATION: npt.NDArray[np.float64] = np.array(
+PHYSICAL_TO_PROBE_PERMUTATION: npt.NDArray[np.float64] = np.array(
     [[0, 0, 1, 0], [1, 0, 0, 0], [0, -1, 0, 0], [0, 0, 0, 1]], dtype=float
 )
+"""Permutation matrix P that maps ConfUSIus physical to probe physical.
+
+ConfUSIus input (z_conf, y_conf, x_conf, 1) is mapped to the probe physical (x_probe,
+y_probe, z_probe, 1):
+
+  x_probe =  x_conf      (lateral, same direction)
+  y_probe =  z_conf      (elevation, same direction)
+  z_probe = -y_conf      (axial depth, sign flip: y_conf = -z_probe > 0)
+
+Its transpose P^T maps probe physical (x_probe, y_probe, z_probe, 1) back to
+ConfUSIus physical (z_conf, y_conf, x_conf, 1):
+
+  z_conf =  y_probe      (elevation)
+  y_conf = -z_probe      (depth, sign flip)
+  x_conf =  x_probe      (lateral)
+
+"""
 
 
 def _read_scan_str(h5: h5py.File, path: str) -> str:
@@ -160,7 +164,7 @@ def _build_physical_to_lab(
     physical_to_lab = P^T @ probeToLab @ P
     ```
 
-    where `P = _PHYSICAL_TO_PROBE_PERMUTATION`. This produces a ConfUSIus-ordered affine
+    where `P = PHYSICAL_TO_PROBE_PERMUTATION`. This produces a ConfUSIus-ordered affine
     whose rotation block is identity for a non-rotated probe, making it directly usable
     in napari and other tools that expect `(z, y, x)` axis order.
 
@@ -175,7 +179,7 @@ def _build_physical_to_lab(
         `physical_to_lab` affine(s) in millimetres. Shape matches input: `(4, 4)` for
         `2Dscan` or `(npose, 4, 4)` for `3Dscan`/`4Dscan`.
     """
-    P = _PHYSICAL_TO_PROBE_PERMUTATION
+    P = PHYSICAL_TO_PROBE_PERMUTATION
     physical_to_lab = P.T @ probe_to_lab @ P
     physical_to_lab[..., :3, 3] *= 1e3
     return physical_to_lab
@@ -204,7 +208,7 @@ def load_bps(bps_path: str | Path) -> npt.NDArray[np.float64]:
     confusius_lab_to_iconeus_lab = mm_to_m @ P
     ```
 
-    where `P = _PHYSICAL_TO_PROBE_PERMUTATION` permutes the axes from ConfUSIus
+    where `P = PHYSICAL_TO_PROBE_PERMUTATION` permutes the axes from ConfUSIus
     order `(z, y, x)` to probe / Iconeus-lab order `(x, y, z)`, and
     `mm_to_m = diag(1e-3, 1e-3, 1e-3, 1)` rescales the translation column. The
     returned affine is then
@@ -229,7 +233,7 @@ def load_bps(bps_path: str | Path) -> npt.NDArray[np.float64]:
     with h5py.File(bps_path, "r") as f:
         brain_to_lab = f["BrainToLab"][:]
 
-    P = _PHYSICAL_TO_PROBE_PERMUTATION
+    P = PHYSICAL_TO_PROBE_PERMUTATION
     mm_to_m = np.diag([1e-3, 1e-3, 1e-3, 1.0])
     confusius_lab_to_iconeus_lab = mm_to_m @ P
 

--- a/src/confusius/io/scan.py
+++ b/src/confusius/io/scan.py
@@ -182,7 +182,7 @@ def _build_physical_to_lab(
 
 
 def load_bps(bps_path: str | Path) -> npt.NDArray[np.float64]:
-    """Load a `.bps` file and return a `brain_to_lab` affine in ConfUSIus lab space.
+    """Load a BPS file and return an affine from Iconeus' brain space to ConfUSIus lab space.
 
     BPS files are HDF5 sidecars produced by Iconeus' brain positioning system. They
     store a `BrainToLab` affine that maps Iconeus brain coordinates `(x_brain, y_brain,

--- a/src/confusius/io/scan.py
+++ b/src/confusius/io/scan.py
@@ -18,7 +18,7 @@ from confusius.io.utils import check_path
 PHYSICAL_TO_PROBE_PERMUTATION: npt.NDArray[np.float64] = np.array(
     [[0, 0, 1, 0], [1, 0, 0, 0], [0, -1, 0, 0], [0, 0, 0, 1]], dtype=float
 )
-"""Permutation matrix P that maps ConfUSIus physical to probe physical.
+"""Permutation matrix that maps ConfUSIus physical to probe physical.
 
 ConfUSIus input (z_conf, y_conf, x_conf, 1) is mapped to the probe physical (x_probe,
 y_probe, z_probe, 1):
@@ -27,8 +27,8 @@ y_probe, z_probe, 1):
   y_probe =  z_conf      (elevation, same direction)
   z_probe = -y_conf      (axial depth, sign flip: y_conf = -z_probe > 0)
 
-Its transpose P^T maps probe physical (x_probe, y_probe, z_probe, 1) back to
-ConfUSIus physical (z_conf, y_conf, x_conf, 1):
+Its transpose maps probe physical (x_probe, y_probe, z_probe, 1) back to ConfUSIus
+physical (z_conf, y_conf, x_conf, 1):
 
   z_conf =  y_probe      (elevation)
   y_conf = -z_probe      (depth, sign flip)
@@ -160,13 +160,13 @@ def _build_physical_to_lab(
     x_lab)` in millimetres, using the same permutation `P` that maps between the two
     physical spaces:
 
-    ```
-    physical_to_lab = P^T @ probeToLab @ P
+    ```python
+    physical_to_lab = PHYSICAL_TO_PROBE_PERMUTATION^T @ probeToLab @ PHYSICAL_TO_PROBE_PERMUTATION
     ```
 
-    where `P = PHYSICAL_TO_PROBE_PERMUTATION`. This produces a ConfUSIus-ordered affine
-    whose rotation block is identity for a non-rotated probe, making it directly usable
-    in napari and other tools that expect `(z, y, x)` axis order.
+    This produces a ConfUSIus-ordered affine whose rotation block is identity for a
+    non-rotated probe, making it directly usable in napari and other tools that expect
+    `(z, y, x)` axis order.
 
     Parameters
     ----------
@@ -179,8 +179,9 @@ def _build_physical_to_lab(
         `physical_to_lab` affine(s) in millimetres. Shape matches input: `(4, 4)` for
         `2Dscan` or `(npose, 4, 4)` for `3Dscan`/`4Dscan`.
     """
-    P = PHYSICAL_TO_PROBE_PERMUTATION
-    physical_to_lab = P.T @ probe_to_lab @ P
+    physical_to_lab = (
+        PHYSICAL_TO_PROBE_PERMUTATION.T @ probe_to_lab @ PHYSICAL_TO_PROBE_PERMUTATION
+    )
     physical_to_lab[..., :3, 3] *= 1e3
     return physical_to_lab
 
@@ -205,13 +206,12 @@ def load_bps(bps_path: str | Path) -> npt.NDArray[np.float64]:
     Iconeus-ordered metre lab coordinates is
 
     ```
-    confusius_lab_to_iconeus_lab = mm_to_m @ P
+    confusius_lab_to_iconeus_lab = mm_to_m @ PHYSICAL_TO_PROBE_PERMUTATION
     ```
 
-    where `P = PHYSICAL_TO_PROBE_PERMUTATION` permutes the axes from ConfUSIus
-    order `(z, y, x)` to probe / Iconeus-lab order `(x, y, z)`, and
-    `mm_to_m = diag(1e-3, 1e-3, 1e-3, 1)` rescales the translation column. The
-    returned affine is then
+    `PHYSICAL_TO_PROBE_PERMUTATION` permutes the axes from ConfUSIus order `(z, y, x)`
+    to probe / Iconeus-lab order `(x, y, z)`, and `mm_to_m = diag(1e-3, 1e-3, 1e-3, 1)`
+    rescales the translation column. The returned affine is then
 
     ```
     brain_to_confusius_lab = inv(confusius_lab_to_iconeus_lab) @ BrainToLab
@@ -233,9 +233,8 @@ def load_bps(bps_path: str | Path) -> npt.NDArray[np.float64]:
     with h5py.File(bps_path, "r") as f:
         brain_to_lab = f["BrainToLab"][:]
 
-    P = PHYSICAL_TO_PROBE_PERMUTATION
     mm_to_m = np.diag([1e-3, 1e-3, 1e-3, 1.0])
-    confusius_lab_to_iconeus_lab = mm_to_m @ P
+    confusius_lab_to_iconeus_lab = mm_to_m @ PHYSICAL_TO_PROBE_PERMUTATION
 
     brain_to_confusius_lab = np.linalg.inv(confusius_lab_to_iconeus_lab) @ brain_to_lab
     return brain_to_confusius_lab

--- a/src/confusius/io/scan.py
+++ b/src/confusius/io/scan.py
@@ -152,12 +152,12 @@ def _build_physical_to_lab(
     """Convert `probeToLab` to a ConfUSIus `physical_to_lab` affine in mm.
 
     `probeToLab` maps probe physical `(x_probe, y_probe, z_probe, 1)` to Iconeus lab
-    space in metres. The Iconeus lab frame is aligned with the probe axes:
-    `x_lab = lateral`, `y_lab = elevation`, `z_lab = axial`.
+    space `(x_lab, y_lab, z_lab, 1)` in metres. The Iconeus lab frame is a fixed scanner
+    frame; `probeToLab` carries any rotation of the probe within it.
 
     We want `physical_to_lab` to map ConfUSIus physical `(z_conf, y_conf, x_conf, 1)`
-    to **ConfUSIus-ordered** lab space `(z_lab, y_lab, x_lab)` (elevation, depth,
-    lateral) in millimetres, using the same permutation `P` that maps between the two
+    (elevation, depth, lateral) to **ConfUSIus-ordered** lab space `(z_lab, y_lab,
+    x_lab)` in millimetres, using the same permutation `P` that maps between the two
     physical spaces:
 
     ```
@@ -191,15 +191,15 @@ def load_bps(bps_path: str | Path) -> npt.NDArray[np.float64]:
     BPS files are HDF5 sidecars produced by Iconeus' brain positioning system. They
     store a `BrainToLab` affine that maps Iconeus brain coordinates `(x_brain, y_brain,
     z_brain, 1)` to Iconeus lab coordinates `(x_lab, y_lab, z_lab, 1)` in meters.
-    Iconeus' lab axes are aligned with the probe: `x_lab = lateral`, `y_lab =
-    elevation`, `z_lab = axial`.
+    The Iconeus lab frame is a fixed scanner frame; `probeToLab` carries any rotation
+    of the probe within it.
 
     To compose this affine with the rest of the ConfUSIus pipeline we re-express
-    the lab side as **ConfUSIus-ordered** lab space `(z_lab, y_lab, x_lab)`
-    (elevation, depth, lateral) in millimeters, matching the convention used by
-    `physical_to_lab` (see `_build_physical_to_lab`). The brain side is left in
-    its original axis order (the brain coordinate units are not declared by the
-    BPS format and are therefore not converted).
+    the lab side as **ConfUSIus-ordered** lab space `(z_lab, y_lab, x_lab)` in
+    millimeters, matching the convention used by `physical_to_lab` (see
+    `_build_physical_to_lab`). The brain side is left in its original axis order
+    (the brain coordinate units are not declared by the BPS format and are
+    therefore not converted).
 
     The change of basis from ConfUSIus-ordered millimetre lab coordinates to
     Iconeus-ordered metre lab coordinates is

--- a/src/confusius/multipose/consolidate.py
+++ b/src/confusius/multipose/consolidate.py
@@ -95,6 +95,65 @@ def _build_consolidated_time_coordinate(
     return xr.DataArray(volume_times, dims=["time"], attrs=time_attrs)
 
 
+def _consolidate_linked_affines(
+    affines: dict[str, Any],
+    affines_key: str,
+    main_per_pose: npt.NDArray[np.float64],
+    main_consolidated: npt.NDArray[np.float64],
+) -> dict[str, npt.NDArray[np.float64]]:
+    """Propagate per-pose affines through pose consolidation.
+
+    The main affine (`affines[affines_key]`) is replaced by `main_consolidated`.
+    Any other affine in `affines` that is shaped like the main per-pose stack is
+    assumed to be a constant left-link of the main affine, i.e. there exists a
+    constant `(4, 4)` matrix `L` such that `A[p] = L @ main_per_pose[p]` for all
+    poses. The consolidated counterpart is then `L @ main_consolidated`. Affines
+    that already have shape `(4, 4)` are passed through unchanged.
+
+    Parameters
+    ----------
+    affines : dict[str, Any]
+        Original `da.attrs["affines"]` mapping.
+    affines_key : str
+        Key of the affine driving the consolidation.
+    main_per_pose : (npose, 4, 4) numpy.ndarray
+        Per-pose stack of the main affine, prior to consolidation.
+    main_consolidated : (4, 4) numpy.ndarray
+        Consolidated form of the main affine.
+
+    Returns
+    -------
+    dict[str, numpy.ndarray]
+        Updated `affines` mapping with the main key replaced by
+        `main_consolidated` and every other linked per-pose affine consolidated
+        accordingly.
+
+    Raises
+    ------
+    ValueError
+        If a per-pose affine other than `affines_key` does not satisfy
+        `A[p] = L @ main_per_pose[p]` for a constant `L` to within numerical
+        tolerance.
+    """
+    new_affines: dict[str, npt.NDArray[np.float64]] = {affines_key: main_consolidated}
+    main_inv0 = np.linalg.inv(main_per_pose[0])
+    for key, value in affines.items():
+        if key == affines_key:
+            continue
+        arr = np.asarray(value)
+        if arr.shape == main_per_pose.shape:
+            link = arr[0] @ main_inv0
+            if not np.allclose(arr, link @ main_per_pose, rtol=1e-6, atol=1e-12):
+                raise ValueError(
+                    f"Affine {key!r} is not a constant left-link of "
+                    f"{affines_key!r}; cannot consolidate."
+                )
+            new_affines[key] = link @ main_consolidated
+        else:
+            new_affines[key] = arr
+    return new_affines
+
+
 def consolidate_poses(
     da: xr.DataArray,
     affines_key: str = "physical_to_lab",
@@ -297,7 +356,10 @@ def consolidate_poses(
     new_affine[:3, 3] = t_perp
 
     other_dims = [d for d in spatial_dims if d != sweep_dim]
-    new_attrs = {**da.attrs, "affines": {affines_key: new_affine}}
+    new_affines = _consolidate_linked_affines(
+        da.attrs.get("affines", {}), affines_key, affine, new_affine
+    )
+    new_attrs = {**da.attrs, "affines": new_affines}
     base_coords: dict[str, Any] = {
         str(sweep_dim): new_sweep,
         **{str(d): da.coords[d] for d in other_dims},

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -97,6 +97,11 @@ _SCAN_PROBE_TO_LAB_2D_SWEEP = np.stack(
     ]
 )
 
+# Synthetic BPS BrainToLab: identity rotation + translation in metres on the Iconeus
+# lab side (xyz = lateral, elevation, axial).
+_SCAN_BRAIN_TO_LAB = np.eye(4, dtype=np.float64)
+_SCAN_BRAIN_TO_LAB[:3, 3] = [0.010, 0.020, 0.030]
+
 
 def _scan_end_referenced_times(n: int, duration: float) -> npt.NDArray[np.float64]:
     """Return regularly spaced end-referenced timestamps."""
@@ -494,6 +499,21 @@ def scan_3d_2d_sweep_path(tmp_path: Path) -> Path:
             probe_to_lab=_SCAN_PROBE_TO_LAB_2D_SWEEP,
             time_data=time_data,
         )
+    return path
+
+
+@pytest.fixture
+def brain_to_lab() -> npt.NDArray[np.float64]:
+    """BrainToLab matrix written into the synthetic `bps_path` fixture."""
+    return _SCAN_BRAIN_TO_LAB.copy()
+
+
+@pytest.fixture
+def bps_path(tmp_path: Path, brain_to_lab: npt.NDArray[np.float64]) -> Path:
+    """Create a synthetic BPS HDF5 file with a known BrainToLab affine."""
+    path = tmp_path / "test.bps"
+    with h5py.File(path, "w") as f:
+        f.create_dataset("BrainToLab", data=brain_to_lab)
     return path
 
 

--- a/tests/unit/test_io/test_scan.py
+++ b/tests/unit/test_io/test_scan.py
@@ -57,20 +57,6 @@ _PROBE_TO_LAB_ROTATED = np.array(
     dtype=np.float64,
 )
 
-# BrainToLab: identity rotation, translation in metres on the Iconeus lab side
-# (xyz = lateral, elevation, axial). Used to build a synthetic .bps fixture.
-_BRAIN_TO_LAB = np.eye(4, dtype=np.float64)
-_BRAIN_TO_LAB[:3, 3] = [0.010, 0.020, 0.030]
-
-
-@pytest.fixture
-def bps_path(tmp_path: Path) -> Path:
-    """Create a synthetic BPS HDF5 file with a known BrainToLab affine."""
-    path = tmp_path / "test.bps"
-    with h5py.File(path, "w") as f:
-        f.create_dataset("BrainToLab", data=_BRAIN_TO_LAB)
-    return path
-
 
 def _end_referenced_times(n: int, duration: float) -> np.ndarray:
     """Return regularly spaced end-referenced timestamps."""
@@ -627,7 +613,7 @@ class TestLoadScanWithBPS:
             assert A.shape == (_NPOSE, 4, 4)
 
     def test_physical_to_brain_maps_origin_to_expected_brain_point(
-        self, scan_2d_path: Path, bps_path: Path
+        self, scan_2d_path: Path, bps_path: Path, brain_to_lab: np.ndarray
     ) -> None:
         """Physical origin (0, 0, 0) mm maps to the analytically expected brain point.
 
@@ -649,7 +635,7 @@ class TestLoadScanWithBPS:
             np.array([lab_zyx_mm[2], lab_zyx_mm[0], -lab_zyx_mm[1]], dtype=np.float64)
             * 1e-3
         )
-        expected_brain = lab_xyz_m - _BRAIN_TO_LAB[:3, 3]
+        expected_brain = lab_xyz_m - brain_to_lab[:3, 3]
 
         result = A @ np.array([0.0, 0.0, 0.0, 1.0])
         np.testing.assert_allclose(result[:3], expected_brain, rtol=1e-10, atol=1e-12)

--- a/tests/unit/test_io/test_scan.py
+++ b/tests/unit/test_io/test_scan.py
@@ -57,6 +57,20 @@ _PROBE_TO_LAB_ROTATED = np.array(
     dtype=np.float64,
 )
 
+# BrainToLab: identity rotation, translation in metres on the Iconeus lab side
+# (xyz = lateral, elevation, axial). Used to build a synthetic .bps fixture.
+_BRAIN_TO_LAB = np.eye(4, dtype=np.float64)
+_BRAIN_TO_LAB[:3, 3] = [0.010, 0.020, 0.030]
+
+
+@pytest.fixture
+def bps_path(tmp_path: Path) -> Path:
+    """Create a synthetic BPS HDF5 file with a known BrainToLab affine."""
+    path = tmp_path / "test.bps"
+    with h5py.File(path, "w") as f:
+        f.create_dataset("BrainToLab", data=_BRAIN_TO_LAB)
+    return path
+
 
 def _end_referenced_times(n: int, duration: float) -> np.ndarray:
     """Return regularly spaced end-referenced timestamps."""
@@ -573,3 +587,74 @@ class TestPhysicalToLab:
         expected[:3, 3] *= 1e3
 
         np.testing.assert_allclose(A, expected, rtol=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# Tests: BPS sidecar (physical_to_brain affine)
+# ---------------------------------------------------------------------------
+
+
+class TestLoadScanWithBPS:
+    """Tests for load_scan when a BPS file is provided via `bps_path`."""
+
+    def test_no_bps_omits_physical_to_brain(self, scan_2d: xr.DataArray) -> None:
+        """Loading without `bps_path` does not add physical_to_brain to attrs."""
+        assert "physical_to_brain" not in scan_2d.attrs["affines"]
+
+    def test_bps_adds_physical_to_brain(
+        self, scan_2d_path: Path, bps_path: Path
+    ) -> None:
+        """Loading with `bps_path` adds physical_to_brain alongside physical_to_lab."""
+        da = load_scan(scan_2d_path, bps_path=bps_path)
+        assert "physical_to_brain" in da.attrs["affines"]
+        assert "physical_to_lab" in da.attrs["affines"]
+
+    def test_physical_to_brain_shape_2d(
+        self, scan_2d_path: Path, bps_path: Path
+    ) -> None:
+        """physical_to_brain has shape (4, 4) for 2Dscan."""
+        da = load_scan(scan_2d_path, bps_path=bps_path)
+        A = np.asarray(da.attrs["affines"]["physical_to_brain"])
+        assert A.shape == (4, 4)
+
+    def test_physical_to_brain_shape_multipose(
+        self, scan_3d_path: Path, scan_4d_path: Path, bps_path: Path
+    ) -> None:
+        """physical_to_brain has shape (npose, 4, 4) for 3Dscan and 4Dscan."""
+        for scan_path in (scan_3d_path, scan_4d_path):
+            da = load_scan(scan_path, bps_path=bps_path)
+            A = np.asarray(da.attrs["affines"]["physical_to_brain"])
+            assert A.shape == (_NPOSE, 4, 4)
+
+    def test_physical_to_brain_maps_origin_to_expected_brain_point(
+        self, scan_2d_path: Path, bps_path: Path
+    ) -> None:
+        """Physical origin (0, 0, 0) mm maps to the analytically expected brain point.
+
+        With BrainToLab = I + translation t (in metres, on the Iconeus xyz lab
+        side), the chain unwinds as:
+
+        - physical (z, y, x) = (0, 0, 0) mm -> ConfUSIus-ordered lab equals the
+          translation column of physical_to_lab in mm.
+        - Convert that lab point to Iconeus-ordered xyz metres, then subtract t to
+          get the brain coordinate (BrainToLab is identity-plus-translation).
+        """
+        da = load_scan(scan_2d_path, bps_path=bps_path)
+        A = np.asarray(da.attrs["affines"]["physical_to_brain"])
+
+        # Lab point corresponding to physical origin, in ConfUSIus zyx mm.
+        lab_zyx_mm = np.asarray(da.attrs["affines"]["physical_to_lab"])[:3, 3]
+        # Convert to Iconeus xyz metres: x_lab=x_conf, y_lab=z_conf, z_lab=-y_conf.
+        lab_xyz_m = (
+            np.array([lab_zyx_mm[2], lab_zyx_mm[0], -lab_zyx_mm[1]], dtype=np.float64)
+            * 1e-3
+        )
+        expected_brain = lab_xyz_m - _BRAIN_TO_LAB[:3, 3]
+
+        result = A @ np.array([0.0, 0.0, 0.0, 1.0])
+        np.testing.assert_allclose(result[:3], expected_brain, rtol=1e-10, atol=1e-12)
+
+    def test_missing_bps_path_raises(self, scan_2d_path: Path, tmp_path: Path) -> None:
+        """A non-existent `bps_path` raises ValueError before opening the SCAN."""
+        with pytest.raises(ValueError):
+            load_scan(scan_2d_path, bps_path=tmp_path / "nonexistent.bps")

--- a/tests/unit/test_io/test_scan.py
+++ b/tests/unit/test_io/test_scan.py
@@ -8,7 +8,7 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from confusius.io.scan import load_scan
+from confusius.io.scan import PHYSICAL_TO_PROBE_PERMUTATION, load_bps, load_scan
 
 _RNG = np.random.default_rng(42)
 
@@ -583,6 +583,37 @@ class TestPhysicalToLab:
 class TestLoadScanWithBPS:
     """Tests for load_scan when a BPS file is provided via `bps_path`."""
 
+    @staticmethod
+    def _expected_brain_to_confusius_lab(
+        brain_to_lab: np.ndarray,
+    ) -> np.ndarray:
+        """Re-express a BrainToLab affine on the lab side in ConfUSIus zyx mm."""
+        mm_to_m = np.diag([1e-3, 1e-3, 1e-3, 1.0])
+        confusius_lab_to_iconeus_lab = mm_to_m @ PHYSICAL_TO_PROBE_PERMUTATION
+        return np.linalg.inv(confusius_lab_to_iconeus_lab) @ brain_to_lab
+
+    @classmethod
+    def _expected_physical_to_brain(
+        cls,
+        probe_to_lab: np.ndarray,
+        brain_to_lab: np.ndarray,
+    ) -> np.ndarray:
+        """Compose fixture-space probe and BPS affines into the expected result."""
+        physical_to_lab = (
+            PHYSICAL_TO_PROBE_PERMUTATION.T
+            @ probe_to_lab
+            @ PHYSICAL_TO_PROBE_PERMUTATION
+        )
+        physical_to_lab[..., :3, 3] *= 1e3
+        brain_to_confusius_lab = cls._expected_brain_to_confusius_lab(brain_to_lab)
+        return np.linalg.inv(brain_to_confusius_lab) @ physical_to_lab
+
+    def test_load_bps_reexpresses_lab_side(self, bps_path: Path, brain_to_lab: np.ndarray) -> None:
+        """load_bps converts BrainToLab to ConfUSIus-ordered lab coordinates."""
+        expected = self._expected_brain_to_confusius_lab(brain_to_lab)
+        result = load_bps(bps_path)
+        np.testing.assert_allclose(result, expected, rtol=1e-10, atol=1e-12)
+
     def test_no_bps_omits_physical_to_brain(self, scan_2d: xr.DataArray) -> None:
         """Loading without `bps_path` does not add physical_to_brain to attrs."""
         assert "physical_to_brain" not in scan_2d.attrs["affines"]
@@ -612,33 +643,35 @@ class TestLoadScanWithBPS:
             A = np.asarray(da.attrs["affines"]["physical_to_brain"])
             assert A.shape == (_NPOSE, 4, 4)
 
-    def test_physical_to_brain_maps_origin_to_expected_brain_point(
+    def test_physical_to_brain_matches_expected_2d_affine(
         self, scan_2d_path: Path, bps_path: Path, brain_to_lab: np.ndarray
     ) -> None:
-        """Physical origin (0, 0, 0) mm maps to the analytically expected brain point.
-
-        With BrainToLab = I + translation t (in metres, on the Iconeus xyz lab
-        side), the chain unwinds as:
-
-        - physical (z, y, x) = (0, 0, 0) mm -> ConfUSIus-ordered lab equals the
-          translation column of physical_to_lab in mm.
-        - Convert that lab point to Iconeus-ordered xyz metres, then subtract t to
-          get the brain coordinate (BrainToLab is identity-plus-translation).
-        """
+        """2Dscan physical_to_brain matches the expected affine from fixture metadata."""
         da = load_scan(scan_2d_path, bps_path=bps_path)
-        A = np.asarray(da.attrs["affines"]["physical_to_brain"])
+        expected = self._expected_physical_to_brain(_PROBE_TO_LAB_SINGLE, brain_to_lab)
+        result = np.asarray(da.attrs["affines"]["physical_to_brain"])
+        np.testing.assert_allclose(result, expected, rtol=1e-10, atol=1e-12)
 
-        # Lab point corresponding to physical origin, in ConfUSIus zyx mm.
-        lab_zyx_mm = np.asarray(da.attrs["affines"]["physical_to_lab"])[:3, 3]
-        # Convert to Iconeus xyz metres: x_lab=x_conf, y_lab=z_conf, z_lab=-y_conf.
-        lab_xyz_m = (
-            np.array([lab_zyx_mm[2], lab_zyx_mm[0], -lab_zyx_mm[1]], dtype=np.float64)
-            * 1e-3
-        )
-        expected_brain = lab_xyz_m - brain_to_lab[:3, 3]
-
-        result = A @ np.array([0.0, 0.0, 0.0, 1.0])
-        np.testing.assert_allclose(result[:3], expected_brain, rtol=1e-10, atol=1e-12)
+    @pytest.mark.parametrize(
+        ("scan_path", "probe_to_lab"),
+        [
+            ("scan_3d_path", _PROBE_TO_LAB_MULTI),
+            ("scan_4d_path", _PROBE_TO_LAB_MULTI),
+        ],
+    )
+    def test_physical_to_brain_matches_expected_multipose_affines(
+        self,
+        request: pytest.FixtureRequest,
+        scan_path: str,
+        probe_to_lab: np.ndarray,
+        bps_path: Path,
+        brain_to_lab: np.ndarray,
+    ) -> None:
+        """3Dscan and 4Dscan physical_to_brain stacks match fixture-derived affines."""
+        da = load_scan(request.getfixturevalue(scan_path), bps_path=bps_path)
+        expected = self._expected_physical_to_brain(probe_to_lab, brain_to_lab)
+        result = np.asarray(da.attrs["affines"]["physical_to_brain"])
+        np.testing.assert_allclose(result, expected, rtol=1e-10, atol=1e-12)
 
     def test_missing_bps_path_raises(self, scan_2d_path: Path, tmp_path: Path) -> None:
         """A non-existent `bps_path` raises ValueError before opening the SCAN."""

--- a/tests/unit/test_io/test_scan.py
+++ b/tests/unit/test_io/test_scan.py
@@ -614,35 +614,6 @@ class TestLoadScanWithBPS:
         result = load_bps(bps_path)
         np.testing.assert_allclose(result, expected, rtol=1e-10, atol=1e-12)
 
-    def test_no_bps_omits_physical_to_brain(self, scan_2d: xr.DataArray) -> None:
-        """Loading without `bps_path` does not add physical_to_brain to attrs."""
-        assert "physical_to_brain" not in scan_2d.attrs["affines"]
-
-    def test_bps_adds_physical_to_brain(
-        self, scan_2d_path: Path, bps_path: Path
-    ) -> None:
-        """Loading with `bps_path` adds physical_to_brain alongside physical_to_lab."""
-        da = load_scan(scan_2d_path, bps_path=bps_path)
-        assert "physical_to_brain" in da.attrs["affines"]
-        assert "physical_to_lab" in da.attrs["affines"]
-
-    def test_physical_to_brain_shape_2d(
-        self, scan_2d_path: Path, bps_path: Path
-    ) -> None:
-        """physical_to_brain has shape (4, 4) for 2Dscan."""
-        da = load_scan(scan_2d_path, bps_path=bps_path)
-        A = np.asarray(da.attrs["affines"]["physical_to_brain"])
-        assert A.shape == (4, 4)
-
-    def test_physical_to_brain_shape_multipose(
-        self, scan_3d_path: Path, scan_4d_path: Path, bps_path: Path
-    ) -> None:
-        """physical_to_brain has shape (npose, 4, 4) for 3Dscan and 4Dscan."""
-        for scan_path in (scan_3d_path, scan_4d_path):
-            da = load_scan(scan_path, bps_path=bps_path)
-            A = np.asarray(da.attrs["affines"]["physical_to_brain"])
-            assert A.shape == (_NPOSE, 4, 4)
-
     def test_physical_to_brain_matches_expected_2d_affine(
         self, scan_2d_path: Path, bps_path: Path, brain_to_lab: np.ndarray
     ) -> None:

--- a/tests/unit/test_multipose/__init__.py
+++ b/tests/unit/test_multipose/__init__.py
@@ -55,7 +55,7 @@ _PROBE_TO_LAB_MULTI = np.stack(
 )
 
 # probeToLab for a single pose with a non-trivial (90° rotation around probe Y-axis)
-# rotation matrix.  Used to verify that _PHYSICAL_TO_PROBE_PERMUTATION permutes columns
+# rotation matrix.  Used to verify that PHYSICAL_TO_PROBE_PERMUTATION permutes columns
 # correctly even when the rotation block is not the identity.
 #
 #   R_y90 = [[ 0, 0, 1, 0],   # x_lab =  z_probe
@@ -856,10 +856,3 @@ def scan_3d_2d_sweep_path(tmp_path: Path) -> Path:
             time_data=time_data,
         )
     return path
-
-
-# ---------------------------------------------------------------------------
-# Tests: consolidate_poses
-# ---------------------------------------------------------------------------
-
-

--- a/tests/unit/test_multipose/test_consolidate.py
+++ b/tests/unit/test_multipose/test_consolidate.py
@@ -130,6 +130,49 @@ class TestConsolidatePoses:
         result = consolidate_poses(scan_3d)
         assert "slice_time" not in result.coords
 
+    def test_physical_to_brain_consolidated_with_bps(
+        self, scan_3d_path: Path, bps_path: Path
+    ) -> None:
+        """Consolidating a 3Dscan loaded with BPS preserves the brain link.
+
+        Per pose, `physical_to_brain[p] = inv(brain_to_lab) @ physical_to_lab[p]`
+        with `inv(brain_to_lab)` constant across poses. After consolidation, the
+        same relationship must hold against the consolidated `physical_to_lab`,
+        i.e. `consolidated_physical_to_brain = inv(brain_to_lab) @
+        consolidated_physical_to_lab`.
+        """
+        da = load_scan(scan_3d_path, bps_path=bps_path)
+        affines = da.attrs["affines"]
+        # Recover the constant `inv(brain_to_lab)` link from any pose.
+        link = affines["physical_to_brain"][0] @ np.linalg.inv(
+            affines["physical_to_lab"][0]
+        )
+
+        result = consolidate_poses(da)
+
+        assert "physical_to_brain" in result.attrs["affines"]
+        expected = link @ result.attrs["affines"]["physical_to_lab"]
+        np.testing.assert_allclose(
+            result.attrs["affines"]["physical_to_brain"], expected, rtol=1e-10
+        )
+
+    def test_unlinked_extra_per_pose_affine_raises(self, scan_3d: xr.DataArray) -> None:
+        """An extra per-pose affine that is not a constant left-link of the main
+        affine must raise ``ValueError`` rather than silently producing a wrong
+        consolidated affine.
+        """
+        ptl = np.asarray(scan_3d.attrs["affines"]["physical_to_lab"]).copy()
+        # Perturb pose 1 only: link derived from pose 0 is identity, so the chain
+        # `link @ physical_to_lab` cannot reproduce the perturbed pose.
+        unlinked = ptl.copy()
+        unlinked[1, :3, 3] += np.array([0.5, 0.0, 0.0])
+        scan_3d.attrs["affines"]["physical_to_unlinked"] = unlinked
+
+        with pytest.raises(
+            ValueError, match="not a constant left-link of 'physical_to_lab'"
+        ):
+            consolidate_poses(scan_3d)
+
     def test_no_pose_dim_raises(self, scan_2d: xr.DataArray) -> None:
         """consolidate_poses raises ValueError when there is no pose dimension."""
         with pytest.raises(ValueError, match="no 'pose' dimension"):

--- a/tests/unit/test_multipose/test_consolidate.py
+++ b/tests/unit/test_multipose/test_consolidate.py
@@ -173,6 +173,19 @@ class TestConsolidatePoses:
         ):
             consolidate_poses(scan_3d)
 
+    def test_static_affine_passed_through(self, scan_3d: xr.DataArray) -> None:
+        """A static `(4, 4)` affine is carried through consolidation unchanged."""
+        static = np.eye(4, dtype=np.float64)
+        static[:3, 3] = [1.0, 2.0, 3.0]
+        scan_3d.attrs["affines"]["physical_to_static"] = static
+
+        result = consolidate_poses(scan_3d)
+
+        assert "physical_to_static" in result.attrs["affines"]
+        np.testing.assert_array_equal(
+            result.attrs["affines"]["physical_to_static"], static
+        )
+
     def test_no_pose_dim_raises(self, scan_2d: xr.DataArray) -> None:
         """consolidate_poses raises ValueError when there is no pose dimension."""
         with pytest.raises(ValueError, match="no 'pose' dimension"):


### PR DESCRIPTION
## Summary

Adds BPS (Iconeus Brain Positioning System) sidecar support to `load_scan` so that fUSI scans can carry the Iconeus brain frame alongside the existing lab frame.

Inspired by the discussion in #58, where the proper `BrainToLab` → ConfUSIus-lab change of basis was worked out. This PR turns that recipe into a supported feature.

## Changes

- **`load_scan(..., bps_path=...)`**: optional `bps_path` argument loads the `.bps` HDF5 sidecar and stores a `physical_to_brain` affine in `da.attrs["affines"]`. The affine maps ConfUSIus physical `(z, y, x, 1)` mm coordinates to Iconeus brain coordinates, and is broadcast across poses for `3Dscan` / `4Dscan` files. Brain-side units are intentionally not converted, the BPS format does not declare them.
- **`load_bps` API**: exposed via `confusius.io` so users can construct the `brain_to_lab` affine independently of `load_scan`.
- **`consolidate_poses` fix**: previously rebuilt `attrs["affines"]` as a single-key dict, silently dropping `physical_to_brain` (and any other linked per-pose affine) on consolidation. Now propagates linked per-pose affines through consolidation as `L @ consolidated_main`, where `L` is the constant left-link recovered from pose 0; raises `ValueError` if a per-pose affine in `attrs["affines"]` is not a constant left-link of the main affine. Closes #74.
- **User guide**: new "Loading a `.bps` File" subsection in `docs/user-guide/io.md`.

## Test plan

- [x] `tests/unit/test_io/test_scan.py::TestLoadScanWithBPS` — 6 tests covering
      attribute presence, affine shape (2D / 3D / 4D), analytic origin-point
      correctness check, and `bps_path` validation.
- [x] `tests/unit/test_multipose/test_consolidate.py::test_physical_to_brain_consolidated_with_bps`
      — verifies `consolidated_physical_to_brain == inv(brain_to_lab) @ consolidated_physical_to_lab`.
- [x] `tests/unit/test_multipose/test_consolidate.py::test_unlinked_extra_per_pose_affine_raises`
      — verifies the new `ValueError` guard.
- [x] Full unit suite passes (`uv run pytest tests/unit`).