### PR TITLE
fix(spatial): simplify `smooth_volume` dimension selection

### DIFF
--- a/src/confusius/spatial/smooth.py
+++ b/src/confusius/spatial/smooth.py
@@ -1,7 +1,6 @@
 """Spatial smoothing functions for fUSI volumetric data."""
 
 import warnings
-from collections.abc import Sequence
 
 import numpy as np
 import scipy.ndimage
@@ -34,7 +33,6 @@ def _gaussian_smooth(
 def smooth_volume(
     data: xr.DataArray,
     fwhm: float | dict[str, float],
-    dims: Sequence[str] | None = None,
     ensure_finite: bool = False,
 ) -> xr.DataArray:
     """Smooth a DataArray spatially using a Gaussian kernel.
@@ -47,21 +45,18 @@ def smooth_volume(
     ----------
     data : xarray.DataArray
         Input data to smooth. Can have any number of dimensions, including a `time`
-        dimension (which is never smoothed by default).
+        dimension.
 
         !!! warning "Chunking along smoothed dimensions is not supported"
-            Dimensions in `dims` must NOT be chunked. Chunk only along other dimensions,
-            e.g. `data.chunk({"time": 10})`.
+            Dimensions selected for smoothing must NOT be chunked. Chunk only along other
+            dimensions, e.g. `data.chunk({"time": 10})` when smoothing spatial axes.
 
     fwhm : float or dict[str, float]
         Full width at half maximum of the Gaussian kernel in physical unit. A scalar
-        applies the same FWHM to all smoothed dimensions. A dict maps dimension names to
-        per-dimension FWHM values, e.g. `{"z": 0.5, "y": 0.2, "x": 0.2}`. All keys must
-        be present in the set of smoothed dimensions.
-    dims : sequence of str, optional
-        Dimensions to smooth. Defaults to all dimensions except `"time"`. All specified
-        dimensions must have uniform coordinate spacing; a `ValueError` is raised
-        otherwise.
+        applies the same FWHM to all dimensions except `"time"`. A dict maps dimension
+        names to per-dimension FWHM values, e.g. `{"z": 0.5, "y": 0.2, "x": 0.2}`;
+        only the listed dimensions are smoothed. Dimensions of length 1 are left
+        untouched.
     ensure_finite : bool, default: False
         Whether to replace non-finite values (`NaN`, `Inf`) with zero before filtering.
         This prevents `NaN`s from propagating to neighbouring voxels through the
@@ -76,10 +71,9 @@ def smooth_volume(
     Raises
     ------
     ValueError
-        If any dimension in `dims` is not present in the DataArray, had non-uniform or
-        undefined coordinate spacing, or is chunked (for Dask-backed arrays).
-    ValueError
-        If `fwhm` is a dict and any key is not in the set of smoothed dims.
+        If `fwhm` is a dict and any key is not present in the DataArray, or if any
+        smoothed dimension has non-uniform or undefined coordinate spacing, or is
+        chunked (for Dask-backed arrays).
 
     Notes
     -----
@@ -122,7 +116,7 @@ def smooth_volume(
 
     Smooth only selected dimensions:
 
-    >>> smoothed = smooth_volume(data, fwhm=0.3, dims=["z", "x"])
+    >>> smoothed = smooth_volume(data, fwhm={"z": 0.3, "x": 0.3})
 
     Suppress NaN propagation when some voxels are masked:
 
@@ -130,25 +124,19 @@ def smooth_volume(
     """
     all_dims = [str(d) for d in data.dims]
 
-    if dims is None:
-        smooth_dims = [d for d in all_dims if d != "time"]
-    else:
-        smooth_dims = list(dims)
-        invalid = [d for d in smooth_dims if d not in all_dims]
-        if invalid:
-            raise ValueError(
-                f"Dimensions {invalid} are not present in the DataArray. "
-                f"Available dimensions: {all_dims}."
-            )
-
     if isinstance(fwhm, dict):
-        unknown = [k for k in fwhm if k not in smooth_dims]
-        if unknown:
-            raise ValueError(
-                f"FWHM keys {unknown} are not in the set of smoothed dimensions "
-                f"{smooth_dims}. Either add them to 'dims' or remove them from "
-                f"'fwhm'."
-            )
+        smooth_dims = list(fwhm)
+    else:
+        smooth_dims = [d for d in all_dims if d != "time"]
+
+    invalid = [d for d in smooth_dims if d not in all_dims]
+    if invalid:
+        raise ValueError(
+            f"Dimensions {invalid} are not present in the DataArray. "
+            f"Available dimensions: {all_dims}."
+        )
+
+    smooth_dims = [dim for dim in smooth_dims if data.sizes[dim] > 1]
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", UserWarning)
@@ -162,7 +150,7 @@ def smooth_volume(
                 f"Dimension '{dim}' has non-uniform or undefined coordinate spacing. "
                 "Gaussian smoothing requires regularly sampled coordinates. "
                 "Check that the coordinate spacing is uniform, or exclude this "
-                "dimension from 'dims'."
+                "dimension from 'fwhm'."
             )
         smooth_spacing[dim] = s
 
@@ -176,16 +164,11 @@ def smooth_volume(
                     f"dimensions are not split: data.chunk({{'{dim}': -1}})."
                 )
 
-    if isinstance(fwhm, dict):
-        fwhm_per_dim = {dim: fwhm.get(dim, 0.0) for dim in smooth_dims}
-    else:
-        fwhm_per_dim = {dim: float(fwhm) for dim in smooth_dims}
-
     # Non-smoothed dims get sigma=0 (identity, no filtering applied).
     sigmas = []
     for dim in all_dims:
         if dim in smooth_dims:
-            fwhm_val = fwhm_per_dim[dim]
+            fwhm_val = float(fwhm[dim]) if isinstance(fwhm, dict) else float(fwhm)
             sigma_vox = fwhm_val * _FWHM_TO_SIGMA / smooth_spacing[dim]
             sigmas.append(sigma_vox)
         else:

--- a/src/confusius/spatial/smooth.py
+++ b/src/confusius/spatial/smooth.py
@@ -149,8 +149,9 @@ def smooth_volume(
             raise ValueError(
                 f"Dimension '{dim}' has non-uniform or undefined coordinate spacing. "
                 "Gaussian smoothing requires regularly sampled coordinates. "
-                "Check that the coordinate spacing is uniform, or exclude this "
-                "dimension from 'fwhm'."
+                "Check that the coordinate spacing is uniform, or pass 'fwhm' as a "
+                "dict to explicitly select only the dimensions to smooth, e.g. "
+                f"fwhm={{'{dim}': value}} to include or omit '{dim}'."
             )
         smooth_spacing[dim] = s
 

--- a/tests/unit/test_spatial/test_smooth.py
+++ b/tests/unit/test_spatial/test_smooth.py
@@ -62,17 +62,52 @@ class TestSmoothVolume:
         np.testing.assert_allclose(smoothed.values, expected, rtol=1e-10)
 
     def test_selected_dims_only(self, sample_3d_volume):
-        """Smoothing only selected dims should leave the rest unchanged."""
+        """A dict FWHM should smooth only the listed dimensions."""
         vol = sample_3d_volume
         fwhm = 0.4
 
-        smoothed = smooth_volume(vol, fwhm=fwhm, dims=["z", "x"])
+        smoothed = smooth_volume(vol, fwhm={"z": fwhm, "x": fwhm})
 
         fwhm_to_sigma = 1.0 / (2.0 * np.sqrt(2.0 * np.log(2.0)))
         expected_sigmas = [
             fwhm * fwhm_to_sigma / _spacing(vol, "z"),
             0.0,  # y not smoothed.
             fwhm * fwhm_to_sigma / _spacing(vol, "x"),
+        ]
+        expected = scipy.ndimage.gaussian_filter(vol.values.astype(float), expected_sigmas)
+
+        np.testing.assert_allclose(smoothed.values, expected, rtol=1e-10)
+
+    def test_fwhm_dict_infers_smoothed_dims(self, sample_3d_volume):
+        """A dict FWHM should define the smoothed dimensions."""
+        vol = sample_3d_volume
+        fwhm_dict = {"z": 0.6, "x": 0.4}
+
+        smoothed = smooth_volume(vol, fwhm=fwhm_dict)
+
+        fwhm_to_sigma = 1.0 / (2.0 * np.sqrt(2.0 * np.log(2.0)))
+        expected_sigmas = [
+            fwhm_dict["z"] * fwhm_to_sigma / _spacing(vol, "z"),
+            0.0,
+            fwhm_dict["x"] * fwhm_to_sigma / _spacing(vol, "x"),
+        ]
+        expected = scipy.ndimage.gaussian_filter(vol.values.astype(float), expected_sigmas)
+
+        np.testing.assert_allclose(smoothed.values, expected, rtol=1e-10)
+
+    def test_fwhm_dict_can_smooth_time(self, sample_4d_volume):
+        """A dict FWHM should be able to target non-spatial dimensions like time."""
+        vol = sample_4d_volume
+        fwhm_dict = {"time": 1.0}
+
+        smoothed = smooth_volume(vol, fwhm=fwhm_dict)
+
+        fwhm_to_sigma = 1.0 / (2.0 * np.sqrt(2.0 * np.log(2.0)))
+        expected_sigmas = [
+            fwhm_dict["time"] * fwhm_to_sigma / _spacing(vol, "time"),
+            0.0,
+            0.0,
+            0.0,
         ]
         expected = scipy.ndimage.gaussian_filter(vol.values.astype(float), expected_sigmas)
 
@@ -94,6 +129,32 @@ class TestSmoothVolume:
         vol = sample_3d_volume
         smoothed = smooth_volume(vol, fwhm=0.0)
         np.testing.assert_allclose(smoothed.values, vol.values, rtol=1e-10)
+
+    def test_singleton_dim_is_not_smoothed(self):
+        """Length-1 dimensions should be ignored instead of requiring spacing."""
+        data = np.zeros((5, 1, 7))
+        data[2, 0, 3] = 1.0
+        vol = xr.DataArray(
+            data,
+            dims=["z", "y", "x"],
+            coords={
+                "z": np.arange(5) * 0.2,
+                "y": [0.0],
+                "x": np.arange(7) * 0.1,
+            },
+        )
+
+        smoothed = smooth_volume(vol, fwhm=0.4)
+
+        fwhm_to_sigma = 1.0 / (2.0 * np.sqrt(2.0 * np.log(2.0)))
+        expected_sigmas = [
+            0.4 * fwhm_to_sigma / _spacing(vol, "z"),
+            0.0,
+            0.4 * fwhm_to_sigma / _spacing(vol, "x"),
+        ]
+        expected = scipy.ndimage.gaussian_filter(vol.values.astype(float), expected_sigmas)
+
+        np.testing.assert_allclose(smoothed.values, expected, rtol=1e-10)
 
     def test_fwhm_correct_on_impulse(self):
         """Smoothing a Dirac delta should produce a blob with the requested FWHM.
@@ -161,7 +222,7 @@ class TestSmoothVolume:
     def test_raises_invalid_dim(self, sample_3d_volume):
         """Should raise ValueError for dimensions not in the DataArray."""
         with pytest.raises(ValueError, match="not present in the DataArray"):
-            smooth_volume(sample_3d_volume, fwhm=0.3, dims=["z", "nonexistent"])
+            smooth_volume(sample_3d_volume, fwhm={"z": 0.3, "nonexistent": 0.3})
 
     def test_raises_nonuniform_spacing(self):
         """Should raise ValueError if a smoothed dim has non-uniform spacing."""
@@ -181,8 +242,8 @@ class TestSmoothVolume:
             smooth_volume(vol, fwhm=0.3)
 
     def test_raises_unknown_fwhm_key(self, sample_3d_volume):
-        """Should raise ValueError if fwhm dict contains unknown dim names."""
-        with pytest.raises(ValueError, match="not in the set of smoothed dimensions"):
+        """Should raise ValueError if fwhm dict contains dim names not in the array."""
+        with pytest.raises(ValueError, match="not present in the DataArray"):
             smooth_volume(sample_3d_volume, fwhm={"z": 0.3, "w": 0.2})
 
     def test_raises_chunked_spatial_dim(self, sample_3d_volume):


### PR DESCRIPTION
## Summary
- fix `smooth_volume` so length-1 dimensions are ignored instead of raising spacing errors
- simplify dimension selection by removing `dims` and letting dict `fwhm` values define the exact axes to smooth
- update smoothing tests to cover singleton dimensions, dict-selected axes, and dict-based time smoothing
