### PR TITLE
fix(atlas): preserve large integer ids in resample_like

### DIFF
--- a/src/confusius/atlas/atlas.py
+++ b/src/confusius/atlas/atlas.py
@@ -555,10 +555,6 @@ class Atlas:
             default_value=0.0,
             sitk_threads=sitk_threads,
         )
-        # Pass integer dtypes through unchanged. Casting to float32 first would
-        # collapse Allen structure ids above 2**24 (e.g. 576073732) onto nearby
-        # representable floats, producing ids that no longer exist in the
-        # BrainGlobe structure tree and breaking `get_masks` lookups. See #79.
         resampled_ann = resample_like_da(
             self.annotation,
             reference,

--- a/src/confusius/atlas/atlas.py
+++ b/src/confusius/atlas/atlas.py
@@ -555,31 +555,27 @@ class Atlas:
             default_value=0.0,
             sitk_threads=sitk_threads,
         )
-        resampled_ann = (
-            resample_like_da(
-                self.annotation.astype(np.float32),
-                reference,
-                transform,
-                interpolation="nearest",
-                default_value=0.0,
-                sitk_threads=sitk_threads,
-            )
-            .round()
-            .astype(np.int32)
+        # Pass integer dtypes through unchanged. Casting to float32 first would
+        # collapse Allen structure ids above 2**24 (e.g. 576073732) onto nearby
+        # representable floats, producing ids that no longer exist in the
+        # BrainGlobe structure tree and breaking `get_masks` lookups. See #79.
+        resampled_ann = resample_like_da(
+            self.annotation,
+            reference,
+            transform,
+            interpolation="nearest",
+            default_value=0,
+            sitk_threads=sitk_threads,
         )
         resampled_ann.attrs = self.annotation.attrs.copy()
 
-        resampled_hemi = (
-            resample_like_da(
-                self.hemispheres.astype(np.float32),
-                reference,
-                transform,
-                interpolation="nearest",
-                default_value=0.0,
-                sitk_threads=sitk_threads,
-            )
-            .round()
-            .astype(np.int8)
+        resampled_hemi = resample_like_da(
+            self.hemispheres,
+            reference,
+            transform,
+            interpolation="nearest",
+            default_value=0,
+            sitk_threads=sitk_threads,
         )
 
         new_dataset = xr.Dataset(

--- a/tests/unit/test_atlas/test_atlas.py
+++ b/tests/unit/test_atlas/test_atlas.py
@@ -319,40 +319,6 @@ class TestGetMesh:
             atlas.get_mesh(9999)
 
 
-class TestResampleLike:
-    """Tests for Atlas.resample_like."""
-
-    def test_preserves_large_integer_ids(self, atlas: Atlas) -> None:
-        """Allen structure ids above 2**24 must round-trip through resample_like.
-
-        Float32 has only 24 bits of mantissa, so casting an int32 like 576073732
-        to float32 collapses it to a nearby float that rounds back to a different
-        int (e.g. 576073728), producing a label that does not exist in the
-        BrainGlobe structure tree. See issue #79.
-        """
-        # Re-label child voxels with a large id that loses precision in float32.
-        large_id = 576073732
-        new_annotation = atlas.annotation.copy()
-        new_annotation.values[new_annotation.values == 10] = large_id
-        new_dataset = atlas._dataset.assign(annotation=new_annotation)
-        atlas_with_large = Atlas(
-            new_dataset,
-            atlas._structures,
-            atlas._mesh_to_physical,
-            atlas._rl_midline_um,
-        )
-
-        # Identity transform: resampled annotation must equal source exactly.
-        resampled = atlas_with_large.resample_like(
-            atlas_with_large.annotation, transform=np.eye(4)
-        )
-
-        np.testing.assert_array_equal(
-            resampled.annotation.values, new_annotation.values
-        )
-        assert large_id in np.unique(resampled.annotation.values)
-
-
 class TestAncestors:
     """Tests for Atlas.ancestors, compared against direct treelib traversal."""
 

--- a/tests/unit/test_atlas/test_atlas.py
+++ b/tests/unit/test_atlas/test_atlas.py
@@ -319,6 +319,40 @@ class TestGetMesh:
             atlas.get_mesh(9999)
 
 
+class TestResampleLike:
+    """Tests for Atlas.resample_like."""
+
+    def test_preserves_large_integer_ids(self, atlas: Atlas) -> None:
+        """Allen structure ids above 2**24 must round-trip through resample_like.
+
+        Float32 has only 24 bits of mantissa, so casting an int32 like 576073732
+        to float32 collapses it to a nearby float that rounds back to a different
+        int (e.g. 576073728), producing a label that does not exist in the
+        BrainGlobe structure tree. See issue #79.
+        """
+        # Re-label child voxels with a large id that loses precision in float32.
+        large_id = 576073732
+        new_annotation = atlas.annotation.copy()
+        new_annotation.values[new_annotation.values == 10] = large_id
+        new_dataset = atlas._dataset.assign(annotation=new_annotation)
+        atlas_with_large = Atlas(
+            new_dataset,
+            atlas._structures,
+            atlas._mesh_to_physical,
+            atlas._rl_midline_um,
+        )
+
+        # Identity transform: resampled annotation must equal source exactly.
+        resampled = atlas_with_large.resample_like(
+            atlas_with_large.annotation, transform=np.eye(4)
+        )
+
+        np.testing.assert_array_equal(
+            resampled.annotation.values, new_annotation.values
+        )
+        assert large_id in np.unique(resampled.annotation.values)
+
+
 class TestAncestors:
     """Tests for Atlas.ancestors, compared against direct treelib traversal."""
 


### PR DESCRIPTION
## Summary
- Casting `annotation`/`hemispheres` to float32 before nearest-neighbour resampling collapsed Allen structure ids above `2**24` (e.g. `576073732 → 576073728`) onto neighbouring representable floats. Those synthetic ids are not in the BrainGlobe structure tree, so `get_masks("root")` left ~1.7k voxels at id `0` — visible as small holes/fragments in the brain envelope when overlaid via `add_contours` (#79).
- Resample the integer arrays directly. SimpleITK's nearest-neighbour preserves integer pixel types exactly, so labels round-trip without precision loss.

## Test plan
- [x] New `TestResampleLike.test_preserves_large_integer_ids` covers id `576073732` through identity-transform `resample_like`.
- [x] Full unit test suite (1172 tests) + pre-commit hooks (ruff, ty, codespell, numpydoc) pass.
- [x] Repro on user-provided `4Dscan_4_RS16_20_fus3D` + `3Dscan_4_angio3D.prep.bps`: voxels misclassified by `get_masks("root")` go from 1751 → 0; brain envelope contour is now a single clean curve per slice.

Closes #79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)