### PR TITLE
feat(datasets): add Pepe Mariani 2026 fUSI template fetcher

### DIFF
--- a/docs/user-guide/datasets.md
+++ b/docs/user-guide/datasets.md
@@ -8,8 +8,8 @@ The [`confusius.datasets`][confusius.datasets] module provides fetchers for publ
 available atlases, templates, and fUSI datasets distributed in
 [fUSI-BIDS](https://bids.neuroimaging.io/) format. Each fetcher downloads the dataset
 on first call, caches it locally for offline reuse, and returns either the path to the
-root directory, or a more specific object (e.g., an [`Atlas`][confusius.atlas.Atlas]
-instance for atlases]).
+root directory, or a more specific object (e.g., a DataArray for templates or an
+[`Atlas`][confusius.atlas.Atlas] instance for atlases]).
 
 !!! tip "Try before you buy"
     Fetchers generally accept filters (subjects, sessions, tasks, derivatives, etc.) so
@@ -81,18 +81,19 @@ list_datasets()
 
 ```text
                 Available Datasets
-┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━┓
-┃ Fetch function            ┃     Size ┃ On disk ┃
-┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━┩
-│ fetch_cybis_pereira_2026  │    12 GB │    ✗    │
-│ fetch_nunez_elizalde_2022 │ 6.503 GB │    ✗    │
-└───────────────────────────┴──────────┴─────────┘
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━┓
+┃ Fetch function                   ┃     Size ┃ On disk ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━┩
+│ fetch_cybis_pereira_2026         │    12 GB │    ✗    │
+│ fetch_nunez_elizalde_2022        │ 6.503 GB │    ✗    │
+│ fetch_template_pepe_mariani_2026 │ 5.252 MB │    ✗    │
+└──────────────────────────────────┴──────────┴─────────┘
 ```
 
 The sizes shown are for the **full** dataset. Filtered fetches are typically a small
 fraction of this (see the examples below).
 
-## Available Datasets
+## Available fUSI-BIDS Datasets
 
 === "Nunez-Elizalde 2022"
 
@@ -203,6 +204,29 @@ bids_root = fetch_nunez_elizalde_2022(subjects=["CR020"], refresh=True)
 
 Existing local files are never re-downloaded—`refresh=True` only adds what is missing.
 
+## Available Templates
+
+=== "Pepe Mariani 2026"
+
+    A mouse fUSI template derived from Pepe, Mariani et al. (2026)[^pepe_mariani2026] and
+    distributed as a single ConfUSIus-compatible NIfTI on
+    [OSF (43tu9)](https://osf.io/43tu9/). Total size: **~5.5 MB**.
+
+    Use [`fetch_template_pepe_mariani_2026`][confusius.datasets.fetch_template_pepe_mariani_2026] to
+    download and load the template directly:
+
+    ```python
+    from confusius.atlas import Atlas
+    from confusius.datasets import fetch_template_pepe_mariani_2026
+
+    template = fetch_template_pepe_mariani_2026()
+    atlas = Atlas.from_brainglobe("allen_mouse_100um")
+    resampled_atlas = atlas.resample_like(
+        template,
+        template.attrs["affines"]["physical_to_sform"],
+    )
+    ```
+
 ## API Reference
 
 See the [`confusius.datasets` API reference][confusius.datasets] for the full list of
@@ -217,3 +241,8 @@ parameters and return types.
     Cybis Pereira, F. et al. (2026). A vascular code for speed in the spatial
     navigation system. *Cell Reports*, 45(1).
     <https://doi.org/10.1016/j.celrep.2025.116791>
+
+[^pepe_mariani2026]:
+    Pepe, C. et al. (2026). Structural and dynamic embedding of the mouse
+    functional connectome revealed by functional ultrasound imaging (fUSI).
+    <https://doi.org/10.64898/2026.02.05.704055>

--- a/docs/user-guide/datasets.md
+++ b/docs/user-guide/datasets.md
@@ -84,9 +84,9 @@ list_datasets()
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━┓
 ┃ Fetch function                   ┃     Size ┃ On disk ┃
 ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━┩
-│ fetch_cybis_pereira_2026         │    12 GB │    ✗    │
-│ fetch_nunez_elizalde_2022        │ 6.503 GB │    ✗    │
-│ fetch_template_pepe_mariani_2026 │ 5.252 MB │    ✗    │
+│ fetch_cybis_pereira_2026         │ 12.88 GB │    ✗    │
+│ fetch_nunez_elizalde_2022        │ 6.983 GB │    ✗    │
+│ fetch_template_pepe_mariani_2026 │ 5.508 MB │    ✗    │
 └──────────────────────────────────┴──────────┴─────────┘
 ```
 

--- a/src/confusius/datasets/__init__.py
+++ b/src/confusius/datasets/__init__.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 from ._cybis_pereira_2026 import fetch_cybis_pereira_2026
 from ._nunez_elizalde_2022 import fetch_nunez_elizalde_2022
+from ._pepe_mariani_2026 import fetch_template_pepe_mariani_2026
 from ._registry import list_datasets
 from ._utils import get_datasets_dir
 
 __all__ = [
     "fetch_cybis_pereira_2026",
     "fetch_nunez_elizalde_2022",
+    "fetch_template_pepe_mariani_2026",
     "get_datasets_dir",
     "list_datasets",
 ]

--- a/src/confusius/datasets/_pepe_mariani_2026.py
+++ b/src/confusius/datasets/_pepe_mariani_2026.py
@@ -1,0 +1,99 @@
+"""Fetcher for the Pepe, Mariani et al. (2026) fUSI template."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pooch
+import requests
+import xarray as xr
+
+from confusius.io.loadsave import load
+
+from ._pooch import quiet_pooch_logger, retrieve_with_retries
+from ._utils import get_datasets_dir
+
+_OSF_PROJECT_ID = "43tu9"
+_TEMPLATE_ROOT = "pepe-mariani-2026-template"
+_FILENAME = "pepe-mariani-2026-fusi-template.nii.gz"
+_TOTAL_SIZE_BYTES = 5_507_550
+
+
+def resolve_template_url(project_id: str = _OSF_PROJECT_ID) -> str:
+    """Return the direct OSF download URL for the exported template.
+
+    Parameters
+    ----------
+    project_id : str, default: "43tu9"
+        OSF project identifier.
+
+    Returns
+    -------
+    str
+        Direct download URL for `pepe-mariani-2026-fusi-template.nii.gz`.
+
+    Raises
+    ------
+    RuntimeError
+        If the template file is not present in the OSF project storage root.
+    """
+    response = requests.get(
+        f"https://api.osf.io/v2/nodes/{project_id}/files/osfstorage/"
+    )
+    response.raise_for_status()
+
+    for item in response.json()["data"]:
+        if item["attributes"]["name"] == _FILENAME:
+            return item["links"]["download"]
+
+    raise RuntimeError(f"Could not find {_FILENAME!r} in OSF project {project_id}.")
+
+
+def fetch_template_pepe_mariani_2026(
+    data_dir: str | Path | None = None,
+    refresh: bool = False,
+) -> xr.DataArray:
+    """Fetch the Pepe, Mariani et al. (2026) mouse fUSI template.
+
+    Downloads the template from OSF on first call, caches it locally, and returns the
+    loaded NIfTI as an Xarray DataArray.
+
+    Parameters
+    ----------
+    data_dir : str or pathlib.Path, optional
+        Directory in which to cache the template. Defaults to the platform cache
+        directory (e.g. `~/.cache/confusius` on Linux, `~/Library/Caches/confusius` on
+        macOS, `%LOCALAPPDATA%\\confusius\\Cache` on Windows), overridable via the
+        `CONFUSIUS_DATA` environment variable.
+    refresh : bool, default: False
+        Whether to redownload the template even if it is already cached.
+
+    Returns
+    -------
+    xarray.DataArray
+        Template with `physical_to_sform` affine transform required for resampling to
+        the Allen Mouse Brain atlas space.
+
+    References
+    ----------
+    [^1]:
+        Pepe, C. et al. (2026). Structural and dynamic embedding of the mouse
+        functional connectome revealed by functional ultrasound imaging (fUSI).
+        [https://doi.org/10.64898/2026.02.05.704055](https://doi.org/10.64898/2026.02.05.704055)
+
+    [^2]:
+        Template hosted on OSF: [https://osf.io/43tu9/](https://osf.io/43tu9/)
+    """
+    dataset_dir = get_datasets_dir(data_dir) / _TEMPLATE_ROOT
+    dataset_dir.mkdir(parents=True, exist_ok=True)
+    dest = dataset_dir / _FILENAME
+
+    if refresh and dest.exists():
+        dest.unlink()
+
+    if not dest.exists():
+        url = resolve_template_url()
+        with quiet_pooch_logger():
+            retrieve_with_retries(url, dest, logger=pooch.get_logger())
+
+    return load(dest)

--- a/src/confusius/datasets/_registry.py
+++ b/src/confusius/datasets/_registry.py
@@ -8,6 +8,8 @@ from ._cybis_pereira_2026 import _BIDS_ROOT as _cybis_pereira_2026_bids_root
 from ._cybis_pereira_2026 import _TOTAL_SIZE_BYTES as _cybis_pereira_2026_size
 from ._nunez_elizalde_2022 import _BIDS_ROOT as _nunez_elizalde_2022_bids_root
 from ._nunez_elizalde_2022 import _TOTAL_SIZE_BYTES as _nunez_elizalde_2022_size
+from ._pepe_mariani_2026 import _TEMPLATE_ROOT as _pepe_mariani_2026_template_root
+from ._pepe_mariani_2026 import _TOTAL_SIZE_BYTES as _pepe_mariani_2026_size
 from ._utils import get_datasets_dir
 
 _SIZE_UNITS = ("B", "KB", "MB", "GB", "TB")
@@ -25,8 +27,13 @@ _REGISTRY: tuple[RegistryEntry, ...] = (
         _nunez_elizalde_2022_size,
         _nunez_elizalde_2022_bids_root,
     ),
+    (
+        "fetch_template_pepe_mariani_2026",
+        _pepe_mariani_2026_size,
+        _pepe_mariani_2026_template_root,
+    ),
 )
-"""Registry of (fetcher_name, total_size_bytes, bids_root_dirname) per dataset."""
+"""Registry of (fetcher_name, total_size_bytes, root_dirname) per dataset."""
 
 
 def _format_bytes(size_bytes: int) -> str:
@@ -80,8 +87,8 @@ def list_datasets(data_dir: str | Path | None = None) -> None:
     table.add_column("Size", justify="right")
     table.add_column("On disk", justify="center")
 
-    for fetcher_name, size_bytes, bids_root in _REGISTRY:
-        path = datasets_dir / bids_root
+    for fetcher_name, size_bytes, root_dirname in _REGISTRY:
+        path = datasets_dir / root_dirname
         is_cached = path.exists() and any(path.iterdir())
         table.add_row(
             fetcher_name,

--- a/src/confusius/datasets/_registry.py
+++ b/src/confusius/datasets/_registry.py
@@ -55,7 +55,7 @@ def _format_bytes(size_bytes: int) -> str:
     for unit in _SIZE_UNITS[:-1]:
         if abs(size) < 1000:
             return f"{size:.4g} {unit}"
-        size /= 1024
+        size /= 1000
     return f"{size:.4g} {_SIZE_UNITS[-1]}"
 
 

--- a/tests/unit/test_datasets/test_pepe_mariani_2026.py
+++ b/tests/unit/test_datasets/test_pepe_mariani_2026.py
@@ -1,0 +1,132 @@
+"""Unit tests for confusius.datasets._pepe_mariani_2026."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from confusius.datasets import fetch_template_pepe_mariani_2026
+from confusius.datasets._pepe_mariani_2026 import (
+    _FILENAME,
+    _OSF_PROJECT_ID,
+    _TEMPLATE_ROOT,
+    resolve_template_url,
+)
+
+
+class _Response:
+    def __init__(self, payload: dict):
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict:
+        return self._payload
+
+
+def test_resolve_template_url_returns_download_link() -> None:
+    payload = {
+        "data": [
+            {
+                "attributes": {"name": _FILENAME},
+                "links": {"download": "https://files.osf.io/template"},
+            }
+        ]
+    }
+    with patch(
+        "confusius.datasets._pepe_mariani_2026.requests.get",
+        return_value=_Response(payload),
+    ) as mock_get:
+        assert resolve_template_url() == "https://files.osf.io/template"
+
+    mock_get.assert_called_once_with(
+        f"https://api.osf.io/v2/nodes/{_OSF_PROJECT_ID}/files/osfstorage/"
+    )
+
+
+def test_resolve_template_url_raises_when_missing() -> None:
+    with patch(
+        "confusius.datasets._pepe_mariani_2026.requests.get",
+        return_value=_Response({"data": []}),
+    ):
+        with pytest.raises(RuntimeError, match=_FILENAME):
+            resolve_template_url()
+
+
+@pytest.fixture
+def mock_resolve() -> object:
+    with patch(
+        "confusius.datasets._pepe_mariani_2026.resolve_template_url",
+        return_value="https://files.osf.io/template",
+    ) as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_retrieve(tmp_path: Path):
+    def _retrieve(url, dest, logger, progressbar=False, on_retry=None):
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.touch()
+
+    with patch(
+        "confusius.datasets._pepe_mariani_2026.retrieve_with_retries",
+        side_effect=_retrieve,
+    ) as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_load():
+    sentinel = object()
+    with patch("confusius.datasets._pepe_mariani_2026.load", return_value=sentinel) as mock:
+        yield sentinel, mock
+
+
+def test_fetch_downloads_missing_template(
+    tmp_path, mock_resolve, mock_retrieve, mock_load
+):
+    sentinel, mock_load_fn = mock_load
+    result = fetch_template_pepe_mariani_2026(data_dir=tmp_path)
+    dest = tmp_path / _TEMPLATE_ROOT / _FILENAME
+
+    assert result is sentinel
+    mock_resolve.assert_called_once_with()
+    mock_retrieve.assert_called_once()
+    mock_load_fn.assert_called_once_with(dest)
+    assert dest.exists()
+
+
+def test_fetch_skips_download_when_cached(
+    tmp_path, mock_resolve, mock_retrieve, mock_load
+):
+    sentinel, mock_load_fn = mock_load
+    dest = tmp_path / _TEMPLATE_ROOT / _FILENAME
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.touch()
+
+    result = fetch_template_pepe_mariani_2026(data_dir=tmp_path)
+
+    assert result is sentinel
+    mock_resolve.assert_not_called()
+    mock_retrieve.assert_not_called()
+    mock_load_fn.assert_called_once_with(dest)
+
+
+def test_fetch_refresh_redownloads_cached_template(
+    tmp_path, mock_resolve, mock_retrieve, mock_load
+):
+    sentinel, mock_load_fn = mock_load
+    dest = tmp_path / _TEMPLATE_ROOT / _FILENAME
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text("old")
+
+    result = fetch_template_pepe_mariani_2026(data_dir=tmp_path, refresh=True)
+
+    assert result is sentinel
+    mock_resolve.assert_called_once_with()
+    mock_retrieve.assert_called_once()
+    mock_load_fn.assert_called_once_with(dest)
+    assert dest.exists()


### PR DESCRIPTION
Closes #81.

## Summary
- Adds `fetch_template_pepe_mariani_2026` for the mouse fUSI template hosted on [OSF (43tu9)](https://osf.io/43tu9/), registered in `list_datasets`.
- Reorganizes the datasets user-guide page into "Available fUSI-BIDS Datasets" / "Available Templates" to leave room for a future atlases section.
