### PR TITLE
fix(registration): cast images to float64 before registration

### DIFF
--- a/src/confusius/registration/volume.py
+++ b/src/confusius/registration/volume.py
@@ -524,6 +524,11 @@ def register_volume(
     fixed_reg = _expand_thin_dims(fixed_sitk)
     moving_reg = _expand_thin_dims(moving_sitk)
 
+    # CenteredTransformInitializer (and the registration method) require both images to
+    # have the same pixel type. Cast to Float64 to normalise across dtype combinations.
+    fixed_reg = sitk.Cast(fixed_reg, sitk.sitkFloat64)
+    moving_reg = sitk.Cast(moving_reg, sitk.sitkFloat64)
+
     ndim = fixed_reg.GetDimension()
 
     # Validate initial_transform shape now that ndim is known.

--- a/src/confusius/registration/volume.py
+++ b/src/confusius/registration/volume.py
@@ -525,9 +525,9 @@ def register_volume(
     moving_reg = _expand_thin_dims(moving_sitk)
 
     # CenteredTransformInitializer (and the registration method) require both images to
-    # have the same pixel type. Cast to Float64 to normalise across dtype combinations.
-    fixed_reg = sitk.Cast(fixed_reg, sitk.sitkFloat64)
-    moving_reg = sitk.Cast(moving_reg, sitk.sitkFloat64)
+    # have the same pixel type. Cast moving to fixed's type when they differ.
+    if moving_reg.GetPixelID() != fixed_reg.GetPixelID():
+        moving_reg = sitk.Cast(moving_reg, fixed_reg.GetPixelID())
 
     ndim = fixed_reg.GetDimension()
 

--- a/tests/unit/test_registration/test_volume.py
+++ b/tests/unit/test_registration/test_volume.py
@@ -287,6 +287,20 @@ class TestRegisterVolumeThinDims:
             )
         assert result.shape == da.shape
 
+    def test_float32_moving_float64_fixed_does_not_crash(
+        self, sample_2d_dataarray_spatial
+    ):
+        """float32 moving and float64 fixed register without a dtype mismatch error.
+
+        Regression test: CenteredTransformInitializer requires both images to share the
+        same pixel type. Mixed dtypes (e.g. float32 template vs. float64 mean of NIfTI
+        data) previously raised a RuntimeError.
+        """
+        moving = sample_2d_dataarray_spatial  # float32
+        fixed = sample_2d_dataarray_spatial.astype(np.float64)
+        result, _ = register_volume(moving, fixed, transform_type="translation")
+        assert result.shape == fixed.shape
+
     def test_3d_volume_with_depth_2_does_not_crash(self):
         """3D volume with depth=2 (below the 4-voxel threshold) registers without error."""
         arr = np.zeros((2, 16, 16), dtype=np.float32)


### PR DESCRIPTION
Fixes #83.

`CenteredTransformInitializer` requires both images to share the same pixel type. Mixed dtypes raised a `RuntimeError`. Cast both `fixed_reg` and `moving_reg` to `Float64` after `_expand_thin_dims`.

Adds a regression test.