### PR TITLE
feat(plotting): ROI name and value on matplotlib & napari hover

### DIFF
--- a/src/confusius/atlas/atlas.py
+++ b/src/confusius/atlas/atlas.py
@@ -53,6 +53,7 @@ def _build_dataset(bg_atlas: "BrainGlobeAtlas") -> xr.Dataset:
 
     rgb_lookup = _build_rgb_lookup(bg_atlas.structures)
     cmap, norm = _build_atlas_cmap_and_norm(rgb_lookup)
+    roi_labels = {int(sid): info["name"] for sid, info in bg_atlas.structures.items()}
 
     reference = xr.DataArray(
         bg_atlas.reference.astype(np.float32),
@@ -67,7 +68,12 @@ def _build_dataset(bg_atlas: "BrainGlobeAtlas") -> xr.Dataset:
         coords={d: xr.Variable(d, v, attrs=a) for d, (v, a) in coords.items()},
         # cmap and norm are non-serializable but are skipped automatically when saving
         # to zarr; rgb_lookup is the serializable source of truth.
-        attrs={"rgb_lookup": rgb_lookup, "cmap": cmap, "norm": norm},
+        attrs={
+            "rgb_lookup": rgb_lookup,
+            "roi_labels": roi_labels,
+            "cmap": cmap,
+            "norm": norm,
+        },
     )
 
     hemispheres = xr.DataArray(

--- a/src/confusius/atlas/atlas.py
+++ b/src/confusius/atlas/atlas.py
@@ -53,7 +53,10 @@ def _build_dataset(bg_atlas: "BrainGlobeAtlas") -> xr.Dataset:
 
     rgb_lookup = _build_rgb_lookup(bg_atlas.structures)
     cmap, norm = _build_atlas_cmap_and_norm(rgb_lookup)
-    roi_labels = {int(sid): info["name"] for sid, info in bg_atlas.structures.items()}
+    roi_labels = {
+        int(sid): str(info["name"] + f" ({info['acronym']})")
+        for sid, info in bg_atlas.structures.items()
+    }
 
     reference = xr.DataArray(
         bg_atlas.reference.astype(np.float32),

--- a/src/confusius/plotting/_hover.py
+++ b/src/confusius/plotting/_hover.py
@@ -72,7 +72,9 @@ class _RegionHoverManager:
         """
         self._cid = figure.canvas.mpl_connect("motion_notify_event", self._on_hover)
         toolbar = figure.canvas.toolbar
-        if toolbar is not None and hasattr(toolbar, "_mouse_event_to_message"):
+        if toolbar is not None and hasattr(
+            toolbar, "_mouse_event_to_message"
+        ):  # pragma: no cover
             # Avoid the duplicated "x=..., y=..., [value]" toolbar message
             # so our format_coord output is shown verbatim.
             toolbar._mouse_event_to_message = (  # type: ignore[method-assign]
@@ -186,7 +188,7 @@ def _format_volume(value: float, layer: _SliceLayer) -> str:
     return f"{layer.name}={rendered}"
 
 
-def _custom_mouse_event_to_message(event):
+def _custom_mouse_event_to_message(event):  # pragma: no cover
     """Custom `_mouse_event_to_message` returning only `format_coord`'s output.
 
     Mirrors the matplotlib default at

--- a/src/confusius/plotting/_hover.py
+++ b/src/confusius/plotting/_hover.py
@@ -4,7 +4,7 @@ The manager attaches to a Figure's `motion_notify_event` and, for any
 registered axes, samples the underlying 2D arrays at the cursor position to
 build a single status-bar string of the form
 
-    x=..., y=...; <value_label>=<v>; ROI: <name> (<id>)
+    x=..., y=...; <value_label>=<v>; <label_name>=<id> (<roi_name>)
 
 Each axes can have several registered layers (one volume + one label map, for
 instance), so an atlas overlaid on a power-Doppler scan shows both the data

--- a/src/confusius/plotting/_hover.py
+++ b/src/confusius/plotting/_hover.py
@@ -1,0 +1,223 @@
+"""Hover information for matplotlib volume and contour plots.
+
+The manager attaches to a Figure's `motion_notify_event` and, for any
+registered axes, samples the underlying 2D arrays at the cursor position to
+build a single status-bar string of the form
+
+    x=..., y=...; <value_label>=<v>; ROI: <name> (<id>)
+
+Each axes can have several registered layers (one volume + one label map, for
+instance), so an atlas overlaid on a power-Doppler scan shows both the data
+value and the ROI name simultaneously.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
+
+import numpy as np
+from matplotlib.backend_bases import MouseEvent
+
+if TYPE_CHECKING:
+    from matplotlib.axes import Axes
+    from matplotlib.backend_bases import Event
+    from matplotlib.figure import Figure
+
+
+@dataclass
+class _SliceLayer:
+    """One sample-able 2D array attached to a single axes."""
+
+    x_coords: np.ndarray
+    """Sorted (ascending) physical coordinates of the column dimension."""
+    y_coords: np.ndarray
+    """Sorted (ascending) physical coordinates of the row dimension."""
+    data_2d: np.ndarray
+    """The values to sample, shape `(len(y_coords), len(x_coords))`."""
+    role: Literal["volume", "labels"]
+    """How to interpret samples: as a numeric value or as an integer ROI id."""
+    value_label: str = "value"
+    """Display name for the numeric value (used only when `role == 'volume'`)."""
+    units: str | None = None
+    """Units string appended to the numeric value, if any."""
+
+
+class _RegionHoverManager:
+    """Show the data value and/or ROI name under the cursor in the status bar.
+
+    Attributes
+    ----------
+    roi_labels : dict[int, str]
+        The id-to-name mapping. Updated in-place when new label slices are
+        registered with additional ids.
+    """
+
+    def __init__(self):
+        self.roi_labels: dict[int, str] = dict()
+        self._ax_layers: dict["Axes", list[_SliceLayer]] = {}
+        self._attached = False
+
+    def is_attached(self) -> bool:
+        """Return `True` if this hover manager is attached to a figure."""
+        return self._attached
+
+    def attach_figure(self, figure: "Figure") -> None:
+        """Attach this hover manager to a figure.
+
+        Parameters
+        ----------
+        figure : matplotlib.figure.Figure
+            Figure to attach to.
+        """
+        self._cid = figure.canvas.mpl_connect("motion_notify_event", self._on_hover)
+        toolbar = figure.canvas.toolbar
+        if toolbar is not None and hasattr(toolbar, "_mouse_event_to_message"):
+            # Avoid the duplicated "x=..., y=..., [value]" toolbar message
+            # so our format_coord output is shown verbatim.
+            toolbar._mouse_event_to_message = (  # type: ignore[method-assign]
+                _custom_mouse_event_to_message
+            )
+
+        self._attached = True
+
+    def register_data_to_axis(
+        self,
+        ax: "Axes",
+        x_coords: np.ndarray,
+        y_coords: np.ndarray,
+        data_2d: np.ndarray,
+        role: Literal["volume", "labels"],
+        value_label: str = "value",
+        units: str | None = None,
+    ) -> None:
+        """Attach a 2D slice for hover lookup on `ax`.
+
+        Parameters
+        ----------
+        ax : matplotlib.axes.Axes
+            The axes the slice is drawn on.
+        x_coords : (W,) numpy.ndarray
+            Ascending physical coordinates of the column dimension.
+        y_coords : (H,) numpy.ndarray
+            Ascending physical coordinates of the row dimension.
+        data_2d : (H, W) numpy.ndarray
+            Numeric values sampled at `(y_coords, x_coords)`.
+        role : {"volume", "labels"}
+            How to interpret the slice: as a numeric volume or as integer labels.
+        value_label : str, default: "value"
+            Display name shown next to the sampled value.
+        units : str, optional
+            Units string appended after the value.
+        """
+        self._ax_layers.setdefault(ax, []).append(
+            _SliceLayer(
+                x_coords=np.asarray(x_coords),
+                y_coords=np.asarray(y_coords),
+                data_2d=np.asarray(data_2d),
+                role=role,
+                value_label=value_label,
+                units=units,
+            )
+        )
+
+    def _on_hover(self, event: "Event") -> None:
+        """Handle a `motion_notify_event` and rewrite the axes' `format_coord`.
+
+        Parameters
+        ----------
+        event : matplotlib.backend_bases.MouseEvent
+            Event delivered by matplotlib's canvas.
+        """
+        if not isinstance(event, MouseEvent):
+            return
+
+        ax = event.inaxes
+        if ax is None or event.xdata is None or event.ydata is None:
+            return
+        layers = self._ax_layers.get(ax)
+        if not layers:
+            return
+
+        x = float(event.xdata)
+        y = float(event.ydata)
+        info = f"x={x:.3g}, y={y:.3g}"
+        value_part: str | None = None
+        roi_part: str | None = None
+
+        # Iterate latest-first so an overlay shadows earlier registrations.
+        for layer in reversed(layers):
+            sample = _sample(layer, x, y)
+            if sample is None:
+                continue
+            if layer.role == "volume" and value_part is None:
+                value_part = _format_value(sample, layer)
+            elif layer.role == "labels" and roi_part is None:
+                label = int(sample)
+                if label != 0:
+                    name = self.roi_labels.get(label)
+                    if name is not None:
+                        roi_part = f"ROI: {name} ({label})"
+                    else:
+                        roi_part = f"id={label}"
+
+        if value_part is not None:
+            info += "; " + value_part
+        if roi_part is not None:
+            info += "; " + roi_part
+
+        ax.format_coord = lambda x, y, _info=info: _info  # type: ignore[method-assign]
+
+
+def _sample(layer: _SliceLayer, x: float, y: float) -> float | None:
+    """Return the value at `(x, y)` using nearest-coordinate lookup."""
+    if x < layer.x_coords.min() or x > layer.x_coords.max():
+        return None
+    if y < layer.y_coords.min() or y > layer.y_coords.max():
+        return None
+    j = int(np.argmin(np.abs(layer.x_coords - x)))
+    i = int(np.argmin(np.abs(layer.y_coords - y)))
+    return float(layer.data_2d[i, j])
+
+
+def _format_value(value: float, layer: _SliceLayer) -> str:
+    """Format a sampled volume value as `<label>=<value>[ <units>]`."""
+    if np.isnan(value):
+        rendered = "nan"
+    elif np.issubdtype(layer.data_2d.dtype, np.integer):
+        rendered = f"{int(value)}"
+    else:
+        rendered = f"{value:.4g}"
+    if layer.units:
+        return f"{layer.value_label}={rendered} {layer.units}"
+    return f"{layer.value_label}={rendered}"
+
+
+def _custom_mouse_event_to_message(event):
+    """Custom `_mouse_event_to_message` returning only `format_coord`'s output.
+
+    Mirrors the matplotlib default at
+    https://github.com/matplotlib/matplotlib/blob/v3.9.0/lib/matplotlib/backend_bases.py
+    but skips the data-value suffix that would otherwise duplicate our value/ROI info.
+    """
+    if event.inaxes and event.inaxes.get_navigate():
+        try:
+            return event.inaxes.format_coord(event.xdata, event.ydata)
+        except (ValueError, OverflowError):
+            return ""
+    return ""
+
+
+def _normalize_roi_labels(
+    roi_labels: dict | None,
+) -> dict[int, str]:
+    """Coerce a user-provided `roi_labels` dict to `{int: str}`."""
+    if not roi_labels:
+        return {}
+    out: dict[int, str] = {}
+    for k, v in roi_labels.items():
+        try:
+            out[int(k)] = str(v)
+        except (TypeError, ValueError):
+            continue
+    return out

--- a/src/confusius/plotting/_hover.py
+++ b/src/confusius/plotting/_hover.py
@@ -37,8 +37,8 @@ class _SliceLayer:
     """The values to sample, shape `(len(y_coords), len(x_coords))`."""
     role: Literal["volume", "labels"]
     """How to interpret samples: as a numeric value or as an integer ROI id."""
-    value_label: str = "value"
-    """Display name for the numeric value (used only when `role == 'volume'`)."""
+    name: str = "value"
+    """Display name for this slice's sampled value (typically `DataArray.name`)."""
     units: str | None = None
     """Units string appended to the numeric value, if any."""
 
@@ -88,7 +88,7 @@ class _RegionHoverManager:
         y_coords: np.ndarray,
         data_2d: np.ndarray,
         role: Literal["volume", "labels"],
-        value_label: str = "value",
+        name: str = "value",
         units: str | None = None,
     ) -> None:
         """Attach a 2D slice for hover lookup on `ax`.
@@ -105,8 +105,9 @@ class _RegionHoverManager:
             Numeric values sampled at `(y_coords, x_coords)`.
         role : {"volume", "labels"}
             How to interpret the slice: as a numeric volume or as integer labels.
-        value_label : str, default: "value"
-            Display name shown next to the sampled value.
+        name : str, default: "value"
+            Display name shown next to the sampled value (typically the source
+            `xarray.DataArray.name`).
         units : str, optional
             Units string appended after the value.
         """
@@ -116,7 +117,7 @@ class _RegionHoverManager:
                 y_coords=np.asarray(y_coords),
                 data_2d=np.asarray(data_2d),
                 role=role,
-                value_label=value_label,
+                name=name,
                 units=units,
             )
         )
@@ -141,47 +142,39 @@ class _RegionHoverManager:
 
         x = float(event.xdata)
         y = float(event.ydata)
-        info = f"x={x:.3g}, y={y:.3g}"
-        value_part: str | None = None
-        roi_part: str | None = None
+        parts = [f"x={x:.3g}, y={y:.3g}"]
+        for layer in layers:
+            segment = self._format_layer(layer, x, y)
+            if segment is not None:
+                parts.append(segment)
 
-        # Iterate latest-first so an overlay shadows earlier registrations.
-        for layer in reversed(layers):
-            sample = _sample(layer, x, y)
-            if sample is None:
-                continue
-            if layer.role == "volume" and value_part is None:
-                value_part = _format_value(sample, layer)
-            elif layer.role == "labels" and roi_part is None:
-                label = int(sample)
-                if label != 0:
-                    name = self.roi_labels.get(label)
-                    if name is not None:
-                        roi_part = f"ROI: {name} ({label})"
-                    else:
-                        roi_part = f"id={label}"
-
-        if value_part is not None:
-            info += "; " + value_part
-        if roi_part is not None:
-            info += "; " + roi_part
-
+        info = "; ".join(parts)
         ax.format_coord = lambda x, y, _info=info: _info  # type: ignore[method-assign]
 
+    def _format_layer(self, layer: _SliceLayer, x: float, y: float) -> str | None:
+        """Build the hover segment for one registered slice, or `None` to skip it."""
+        sample = _sample(layer, x, y)
+        if layer.role == "volume":
+            return _format_volume(sample, layer)
+        # role == "labels": skip background voxels and append the ROI name when known.
+        label = int(sample)
+        if label == 0:
+            return None
+        roi_name = self.roi_labels.get(label)
+        if roi_name is None:
+            return f"{layer.name}={label}"
+        return f"{layer.name}={label} ({roi_name})"
 
-def _sample(layer: _SliceLayer, x: float, y: float) -> float | None:
+
+def _sample(layer: _SliceLayer, x: float, y: float) -> float:
     """Return the value at `(x, y)` using nearest-coordinate lookup."""
-    if x < layer.x_coords.min() or x > layer.x_coords.max():
-        return None
-    if y < layer.y_coords.min() or y > layer.y_coords.max():
-        return None
     j = int(np.argmin(np.abs(layer.x_coords - x)))
     i = int(np.argmin(np.abs(layer.y_coords - y)))
     return float(layer.data_2d[i, j])
 
 
-def _format_value(value: float, layer: _SliceLayer) -> str:
-    """Format a sampled volume value as `<label>=<value>[ <units>]`."""
+def _format_volume(value: float, layer: _SliceLayer) -> str:
+    """Format a sampled volume value as `<name>=<value>[ <units>]`."""
     if np.isnan(value):
         rendered = "nan"
     elif np.issubdtype(layer.data_2d.dtype, np.integer):
@@ -189,8 +182,8 @@ def _format_value(value: float, layer: _SliceLayer) -> str:
     else:
         rendered = f"{value:.4g}"
     if layer.units:
-        return f"{layer.value_label}={rendered} {layer.units}"
-    return f"{layer.value_label}={rendered}"
+        return f"{layer.name}={rendered} {layer.units}"
+    return f"{layer.name}={rendered}"
 
 
 def _custom_mouse_event_to_message(event):

--- a/src/confusius/plotting/_hover.py
+++ b/src/confusius/plotting/_hover.py
@@ -54,8 +54,14 @@ class _RegionHoverManager:
     """
 
     def __init__(self):
-        self.roi_labels: dict[int, str] = dict()
+        self.roi_labels: dict[int, str] = {}
         self._ax_layers: dict["Axes", list[_SliceLayer]] = {}
+        self._attached = False
+
+    def clear(self) -> None:
+        """Clear all registered slices and ROI labels."""
+        self.roi_labels.clear()
+        self._ax_layers.clear()
         self._attached = False
 
     def is_attached(self) -> bool:

--- a/src/confusius/plotting/image.py
+++ b/src/confusius/plotting/image.py
@@ -585,7 +585,7 @@ class VolumePlotter:
         roi_labels : dict[int, str], optional
             Mapping from integer label to display name. When provided (or when
             `data.attrs["roi_labels"]` is populated), hovering the cursor over a
-            voxel shows `ROI: <name> (<id>)` in the matplotlib status bar.
+            voxel shows `<data_name>=<id> (<roi_name>)` in the matplotlib status bar.
         show_titles : bool, default: True
             Whether to display subplot titles.
         show_axis_labels : bool, default: True
@@ -873,7 +873,7 @@ class VolumePlotter:
         roi_labels : dict[int, str], optional
             Mapping from integer label to display name. When provided (or when
             `mask.attrs["roi_labels"]` is populated), hovering the cursor over a
-            voxel shows `ROI: <name> (<id>)` in the matplotlib status bar. The
+            voxel shows `<data_name>=<id> (<roi_name>)` in the matplotlib status bar. The
             cursor samples the underlying label map directly, so hovering inside
             a closed contour is sufficient — there is no need to be on the line.
         **kwargs
@@ -1235,7 +1235,7 @@ def plot_contours(
     roi_labels : dict[int, str], optional
         Mapping from integer label to display name. When provided (or when
         `mask.attrs["roi_labels"]` is populated), hovering the cursor over a
-        voxel shows `ROI: <name> (<id>)` in the matplotlib status bar.
+        voxel shows `<data_name>=<id> (<roi_name>)` in the matplotlib status bar.
     **kwargs
         Additional keyword arguments passed to
         [`matplotlib.axes.Axes.plot`][matplotlib.axes.Axes.plot].
@@ -1378,7 +1378,7 @@ def plot_volume(
     roi_labels : dict[int, str], optional
         Mapping from integer label to display name. When provided (or when
         `data.attrs["roi_labels"]` is populated), hovering the cursor over a
-        voxel shows `ROI: <name> (<id>)` in the matplotlib status bar.
+        voxel shows `<data_name>=<id> (<roi_name>)` in the matplotlib status bar.
     show_titles : bool, default: True
         Whether to display subplot titles showing the slice coordinate.
     show_axis_labels : bool, default: True
@@ -1411,7 +1411,7 @@ def plot_volume(
     roi_labels : dict[int, str], optional
         Mapping from integer label to display name. When provided (or when
         `data.attrs["roi_labels"]` is populated), hovering the cursor over a
-        voxel shows `ROI: <name> (<id>)` in the matplotlib status bar.
+        voxel shows `<data_name>=<id> (<roi_name>)` in the matplotlib status bar.
 
     Returns
     -------

--- a/src/confusius/plotting/image.py
+++ b/src/confusius/plotting/image.py
@@ -585,7 +585,7 @@ class VolumePlotter:
         roi_labels : dict[int, str], optional
             Mapping from integer label to display name. When provided (or when
             `data.attrs["roi_labels"]` is populated), hovering the cursor over a
-            voxel shows `<data_name>=<id> (<roi_name>)` in the matplotlib status bar.
+            voxel shows `<layer.name>=<id> (<name>)` in the matplotlib status bar.
         show_titles : bool, default: True
             Whether to display subplot titles.
         show_axis_labels : bool, default: True

--- a/src/confusius/plotting/image.py
+++ b/src/confusius/plotting/image.py
@@ -1733,6 +1733,9 @@ def plot_napari(
             **layer_kwargs,
         )
 
+        if (roi_labels := data.attrs.get("roi_labels")) is not None:
+            _attach_roi_labels_to_napari(layer, roi_labels)
+
     else:
         raise ValueError(
             f"Unknown layer_type: {layer_type!r}. Expected 'image' or 'labels'."
@@ -1747,6 +1750,37 @@ def plot_napari(
         viewer.scale_bar.unit = scale_bar_unit
 
     return viewer, layer
+
+
+def _attach_roi_labels_to_napari(layer: "Labels", roi_labels: dict[int, str]) -> None:
+    """Make a napari Labels layer report the ROI name in the status bar.
+
+    Sets `layer.features` so that napari's built-in
+    `napari.layers.Labels.get_status` appends `name: <roi name>` to the status
+    bar (and the cursor tooltip when `viewer.tooltip.visible` is `True`)
+    whenever the cursor is over a labelled voxel.
+
+    A row for label `0` is included with a NaN name so background hovers do not
+    show napari's default `[No Properties]` placeholder.
+
+    Parameters
+    ----------
+    layer : napari.layers.Labels
+        Layer whose `features` table will be replaced.
+    roi_labels : dict[int, str]
+        Mapping from integer ROI id to display name.
+    """
+    import pandas as pd
+
+    ids: list[int] = [0]
+    names: list[float | str] = [float("nan")]
+    for sid, name in roi_labels.items():
+        sid_int = int(sid)
+        if sid_int == 0:
+            continue
+        ids.append(sid_int)
+        names.append(str(name))
+    layer.features = pd.DataFrame({"index": ids, "name": names})
 
 
 def draw_napari_labels(

--- a/src/confusius/plotting/image.py
+++ b/src/confusius/plotting/image.py
@@ -1165,6 +1165,7 @@ class VolumePlotter:
             self._coord_to_axis.clear()
             self._axis_xlims.clear()
             self._axis_ylims.clear()
+            self._hover_manager.clear()
 
 
 def plot_contours(

--- a/src/confusius/plotting/image.py
+++ b/src/confusius/plotting/image.py
@@ -13,6 +13,10 @@ from napari.utils.colormaps import DirectLabelColormap
 from confusius._utils import find_stack_level, get_coordinate_spacings_best_effort
 from confusius.atlas._structures import _build_atlas_cmap_and_norm
 from confusius.extract import extract_with_mask
+from confusius.plotting._hover import (
+    _normalize_roi_labels,
+    _RegionHoverManager,
+)
 from confusius.signal import clean
 from confusius.validation import validate_time_series
 
@@ -357,6 +361,8 @@ class VolumePlotter:
         self._axis_xlims: dict[int, tuple[float, float]] = {}
         self._axis_ylims: dict[int, tuple[float, float]] = {}
 
+        self._hover_manager = _RegionHoverManager()
+
     def _ensure_figure(
         self,
         n_slices: int,
@@ -398,6 +404,23 @@ class VolumePlotter:
 
         self.axes = np.array(axes_array)
         self.figure.patch.set_facecolor("black" if self._black_bg else "white")
+
+    def _attach_or_update_hover_manager(self, roi_labels: dict[int, str]) -> None:
+        """Ensure hover manager is attached to figure and update its ROI labels.
+
+        Parameters
+        ----------
+        roi_labels : dict[int, str]
+            Mapping from integer label to display name during mouse hover.
+        """
+
+        if self.figure is None:
+            return
+
+        if not self._hover_manager.is_attached():
+            self._hover_manager.attach_figure(self.figure)
+
+        self._hover_manager.roi_labels.update(roi_labels)
 
     def _find_matching_axes(
         self, actual_coords: list[float], tolerance: float = 1e-6
@@ -513,6 +536,7 @@ class VolumePlotter:
         alpha: float = 1.0,
         show_colorbar: bool = True,
         cbar_label: str | None = None,
+        roi_labels: dict[int, str] | None = None,
         show_titles: bool = True,
         show_axis_labels: bool = True,
         show_axis_ticks: bool = True,
@@ -560,6 +584,10 @@ class VolumePlotter:
             Whether to add a colorbar.
         cbar_label : str, optional
             Label for the colorbar.
+        roi_labels : dict[int, str], optional
+            Mapping from integer label to display name. When provided (or when
+            `data.attrs["roi_labels"]` is populated), hovering the cursor over a
+            voxel shows `ROI: <name> (<id>)` in the matplotlib status bar.
         show_titles : bool, default: True
             Whether to display subplot titles.
         show_axis_labels : bool, default: True
@@ -591,6 +619,9 @@ class VolumePlotter:
         import matplotlib.pyplot as plt
 
         data = _coerce_complex_to_magnitude(data, caller="VolumePlotter.add_volume")
+        resolved_roi_labels = _normalize_roi_labels(
+            roi_labels if roi_labels is not None else data.attrs.get("roi_labels")
+        )
 
         squeeze_dims = [
             d for d in data.dims if d != self.slice_mode and data.sizes[d] == 1
@@ -730,6 +761,16 @@ class VolumePlotter:
                 norm=norm,
                 alpha=alpha,
             )
+            self._attach_or_update_hover_manager(resolved_roi_labels)
+            self._hover_manager.register_data_to_axis(
+                ax,
+                x_vals,
+                y_vals,
+                slice_da.values,
+                role="labels" if resolved_roi_labels else "volume",
+                value_label=data.attrs.get("long_name") or str(data.name or "value"),
+                units=data.attrs.get("units"),
+            )
             ax.set_aspect("equal")
             self._style_ax(ax)
             ax.set_title(
@@ -792,6 +833,7 @@ class VolumePlotter:
         linestyles: str = "solid",
         match_coordinates: bool = True,
         slice_coords: list[float] | None = None,
+        roi_labels: dict[int, str] | None = None,
         **kwargs,
     ) -> "VolumePlotter":
         """Add mask contours to existing axes.
@@ -830,6 +872,12 @@ class VolumePlotter:
             Coordinate values along the plotter's `slice_mode` at which to draw
             contours. Slices are selected by nearest-neighbour lookup. If not
             provided, all coordinate values along `slice_mode` are used.
+        roi_labels : dict[int, str], optional
+            Mapping from integer label to display name. When provided (or when
+            `mask.attrs["roi_labels"]` is populated), hovering the cursor over a
+            voxel shows `ROI: <name> (<id>)` in the matplotlib status bar. The
+            cursor samples the underlying label map directly, so hovering inside
+            a closed contour is sufficient — there is no need to be on the line.
         **kwargs
             Additional keyword arguments passed to
             [`matplotlib.axes.Axes.plot`][matplotlib.axes.Axes.plot].
@@ -848,6 +896,10 @@ class VolumePlotter:
         """
         import matplotlib.colors as mcolors
         from skimage.measure import find_contours
+
+        resolved_roi_labels = _normalize_roi_labels(
+            roi_labels if roi_labels is not None else mask.attrs.get("roi_labels")
+        )
 
         # Stacked mask format: (mask, z, y, x) — one layer per region.
         if "mask" in mask.dims:
@@ -888,6 +940,7 @@ class VolumePlotter:
                     linestyles=linestyles,
                     match_coordinates=match_coordinates,
                     slice_coords=slice_coords,
+                    roi_labels=resolved_roi_labels or None,
                     **kwargs,
                 )
             return self
@@ -1040,6 +1093,16 @@ class VolumePlotter:
                         **kwargs,
                     )
 
+            if resolved_roi_labels and self.figure is not None:
+                self._attach_or_update_hover_manager(resolved_roi_labels)
+                self._hover_manager.register_data_to_axis(
+                    ax,
+                    x_coords=np.asarray(x_coords, dtype=float),
+                    y_coords=np.asarray(y_coords, dtype=float),
+                    data_2d=np.asarray(slice_data),
+                    role="labels",
+                )
+
             if not match_coordinates:
                 ax.set_aspect("equal")
 
@@ -1118,6 +1181,7 @@ def plot_contours(
     black_bg: bool = True,
     figure: "Figure | None" = None,
     axes: "npt.NDArray[Any] | Axes | None" = None,
+    roi_labels: dict[int, str] | None = None,
     **kwargs,
 ) -> VolumePlotter:
     """Plot mask contours as a grid of 2D slice panels.
@@ -1169,6 +1233,10 @@ def plot_contours(
         [`matplotlib.axes.Axes`][matplotlib.axes.Axes] or a 2D array of them. A single
         `Axes` is wrapped automatically. If not provided, new axes are created inside
         `figure`.
+    roi_labels : dict[int, str], optional
+        Mapping from integer label to display name. When provided (or when
+        `mask.attrs["roi_labels"]` is populated), hovering the cursor over a
+        voxel shows `ROI: <name> (<id>)` in the matplotlib status bar.
     **kwargs
         Additional keyword arguments passed to
         [`matplotlib.axes.Axes.plot`][matplotlib.axes.Axes.plot].
@@ -1228,6 +1296,7 @@ def plot_contours(
         linestyles=linestyles,
         match_coordinates=False,
         slice_coords=slice_coords,
+        roi_labels=roi_labels,
         **kwargs,
     )
 
@@ -1246,6 +1315,7 @@ def plot_volume(
     alpha: float = 1.0,
     show_colorbar: bool = True,
     cbar_label: str | None = None,
+    roi_labels: dict[int, str] | None = None,
     show_titles: bool = True,
     show_axis_labels: bool = True,
     show_axis_ticks: bool = True,
@@ -1306,6 +1376,10 @@ def plot_volume(
         Whether to add a shared colorbar to the figure.
     cbar_label : str, optional
         Label for the colorbar.
+    roi_labels : dict[int, str], optional
+        Mapping from integer label to display name. When provided (or when
+        `data.attrs["roi_labels"]` is populated), hovering the cursor over a
+        voxel shows `ROI: <name> (<id>)` in the matplotlib status bar.
     show_titles : bool, default: True
         Whether to display subplot titles showing the slice coordinate.
     show_axis_labels : bool, default: True
@@ -1335,6 +1409,10 @@ def plot_volume(
         Number of columns in the subplot grid. If not provided, computed automatically.
     dpi : int, optional
         Figure resolution in dots per inch. Ignored when `figure` is provided.
+    roi_labels : dict[int, str], optional
+        Mapping from integer label to display name. When provided (or when
+        `data.attrs["roi_labels"]` is populated), hovering the cursor over a
+        voxel shows `ROI: <name> (<id>)` in the matplotlib status bar.
 
     Returns
     -------
@@ -1419,6 +1497,7 @@ def plot_volume(
         nrows=nrows,
         ncols=ncols,
         dpi=dpi,
+        roi_labels=roi_labels,
     )
 
 

--- a/src/confusius/plotting/image.py
+++ b/src/confusius/plotting/image.py
@@ -738,17 +738,17 @@ class VolumePlotter:
             slice_da = unthresholded_slices[slice_idx]
 
             if dim_col in slice_da.coords:
-                x_vals = _centers_to_edges(
-                    slice_da.coords[dim_col].values.astype(float)
-                )
+                hover_x = slice_da.coords[dim_col].values.astype(float)
+                x_vals = _centers_to_edges(hover_x)
             else:
+                hover_x = np.arange(slice_da.sizes[dim_col], dtype=float)
                 x_vals = np.arange(slice_da.sizes[dim_col] + 1, dtype=float)
 
             if dim_row in slice_da.coords:
-                y_vals = _centers_to_edges(
-                    slice_da.coords[dim_row].values.astype(float)
-                )
+                hover_y = slice_da.coords[dim_row].values.astype(float)
+                y_vals = _centers_to_edges(hover_y)
             else:
+                hover_y = np.arange(slice_da.sizes[dim_row], dtype=float)
                 y_vals = np.arange(slice_da.sizes[dim_row] + 1, dtype=float)
 
             im = ax.pcolormesh(
@@ -762,8 +762,8 @@ class VolumePlotter:
             self._attach_or_update_hover_manager(resolved_roi_labels)
             self._hover_manager.register_data_to_axis(
                 ax,
-                x_vals,
-                y_vals,
+                hover_x,
+                hover_y,
                 slice_da.values,
                 role="labels" if resolved_roi_labels else "volume",
                 name=str(data.name) if data.name is not None else "value",

--- a/src/confusius/plotting/image.py
+++ b/src/confusius/plotting/image.py
@@ -414,13 +414,11 @@ class VolumePlotter:
             Mapping from integer label to display name during mouse hover.
         """
 
-        if self.figure is None:
-            return
+        if self.figure is not None:
+            if not self._hover_manager.is_attached():
+                self._hover_manager.attach_figure(self.figure)
 
-        if not self._hover_manager.is_attached():
-            self._hover_manager.attach_figure(self.figure)
-
-        self._hover_manager.roi_labels.update(roi_labels)
+            self._hover_manager.roi_labels.update(roi_labels)
 
     def _find_matching_axes(
         self, actual_coords: list[float], tolerance: float = 1e-6
@@ -1777,10 +1775,9 @@ def _attach_roi_labels_to_napari(layer: "Labels", roi_labels: dict[int, str]) ->
     names: list[float | str] = [float("nan")]
     for sid, name in roi_labels.items():
         sid_int = int(sid)
-        if sid_int == 0:
-            continue
-        ids.append(sid_int)
-        names.append(str(name))
+        if sid_int != 0:
+            ids.append(sid_int)
+            names.append(str(name))
     layer.features = pd.DataFrame({"index": ids, "name": names})
 
 

--- a/src/confusius/plotting/image.py
+++ b/src/confusius/plotting/image.py
@@ -768,7 +768,7 @@ class VolumePlotter:
                 y_vals,
                 slice_da.values,
                 role="labels" if resolved_roi_labels else "volume",
-                value_label=data.attrs.get("long_name") or str(data.name or "value"),
+                name=str(data.name) if data.name is not None else "value",
                 units=data.attrs.get("units"),
             )
             ax.set_aspect("equal")
@@ -1101,6 +1101,7 @@ class VolumePlotter:
                     y_coords=np.asarray(y_coords, dtype=float),
                     data_2d=np.asarray(slice_data),
                     role="labels",
+                    name=str(mask.name) if mask.name is not None else "label",
                 )
 
             if not match_coordinates:

--- a/tests/unit/test_plotting/test_image.py
+++ b/tests/unit/test_plotting/test_image.py
@@ -503,7 +503,11 @@ class TestPlotContours:
         mask = xr.DataArray(
             np.ones((3, 4, 4), dtype=int),
             dims=["z", "y", "x"],
-            coords={"z": [0.0, 1.0, 2.0], "y": [0.0, 0.5, 1.0, 1.5], "x": [0.0, 0.5, 1.0, 1.5]},
+            coords={
+                "z": [0.0, 1.0, 2.0],
+                "y": [0.0, 0.5, 1.0, 1.5],
+                "x": [0.0, 0.5, 1.0, 1.5],
+            },
         )
         fig, ax = plt.subplots()
 
@@ -616,9 +620,9 @@ class TestRoiHover:
     def test_hover_shows_value_and_roi(self, matplotlib_pyplot):
         """Cover the three hover paths: label-only, value-only, and overlay.
 
-        Uses a single labelled voxel `(y=0.5, x=0.5)` (label 7 / "somatosensory")
-        and exercises `plot_volume` with `roi_labels`, `plot_volume` on a non-atlas
-        float volume, and a stacked overlay of both on one `VolumePlotter`.
+        Each registered slice contributes its own `<DataArray.name>=<value>`
+        segment, so the overlay path produces both segments without either
+        shadowing the other.
         """
         coords = {"z": [0.0], "y": [0.0, 0.5, 1.0, 1.5], "x": [0.0, 0.5, 1.0, 1.5]}
         labels = xr.DataArray(
@@ -630,20 +634,21 @@ class TestRoiHover:
             ),
             dims=["z", "y", "x"],
             coords=coords,
+            name="annotation",
         )
         rng = np.random.default_rng(0)
         volume = xr.DataArray(
             rng.normal(size=(1, 4, 4)).astype(np.float32),
             dims=["z", "y", "x"],
             coords=coords,
-            attrs={"long_name": "PD", "units": "dB"},
+            attrs={"units": "dB"},
             name="pd",
         )
         roi_labels = {7: "somatosensory", 42: "visual"}
         x, y = 0.5, 0.5
         sampled_value = float(volume.sel(z=0.0, y=y, x=x).values)
 
-        # Atlas-only: ROI line, no value (label IS the value, no need to repeat).
+        # Atlas-only: one segment from the labels slice, no value-line.
         atlas_plotter = plot_volume(
             labels,
             slice_mode="z",
@@ -653,26 +658,28 @@ class TestRoiHover:
         )
         ax = atlas_plotter.axes.flat[0]
         self._fire_motion(ax, x, y)
-        assert ax.format_coord(x, y) == f"x={x:.3g}, y={y:.3g}; ROI: somatosensory (7)"
+        assert (
+            ax.format_coord(x, y)
+            == f"x={x:.3g}, y={y:.3g}; annotation=7 (somatosensory)"
+        )
 
-        # Background voxel (label=0) suppresses the ROI suffix.
+        # Background voxel (label=0) drops the labels segment entirely.
         bg_x, bg_y = 0.5, 1.5  # mask[3, 1] == 0.
         self._fire_motion(ax, bg_x, bg_y)
         bg_info = ax.format_coord(bg_x, bg_y)
-        assert "ROI:" not in bg_info and "id=" not in bg_info
+        assert "annotation" not in bg_info
 
-        # Volume-only: value with long_name + units, no ROI.
+        # Volume-only: one segment using `data.name` and `units`.
         volume_plotter = plot_volume(
             volume, slice_mode="z", slice_coords=[0.0], show_colorbar=False
         )
         ax = volume_plotter.axes.flat[0]
         self._fire_motion(ax, x, y)
         assert (
-            ax.format_coord(x, y)
-            == f"x={x:.3g}, y={y:.3g}; PD={sampled_value:.4g} dB"
+            ax.format_coord(x, y) == f"x={x:.3g}, y={y:.3g}; pd={sampled_value:.4g} dB"
         )
 
-        # Overlay: BOTH value and ROI in the same hover string.
+        # Overlay: both segments in registration order, neither shadowing the other.
         overlay = VolumePlotter(slice_mode="z")
         overlay.add_volume(
             volume, slice_coords=[0.0], match_coordinates=False, show_colorbar=False
@@ -681,9 +688,8 @@ class TestRoiHover:
         ax = overlay.axes.flat[0]
         self._fire_motion(ax, x, y)
         assert (
-            ax.format_coord(x, y)
-            == f"x={x:.3g}, y={y:.3g}; PD={sampled_value:.4g} dB"
-            "; ROI: somatosensory (7)"
+            ax.format_coord(x, y) == f"x={x:.3g}, y={y:.3g}; pd={sampled_value:.4g} dB"
+            "; annotation=7 (somatosensory)"
         )
 
 
@@ -808,14 +814,10 @@ class TestPlotNapari:
         assert np.all(np.diff(layer.metadata["xarray"].coords["x"].values) > 0)
         viewer.close()
 
+    # Image comparison tests with pytest-mpl
+    # These generate baseline images for visual regression testing
 
-# Image comparison tests with pytest-mpl
-# These generate baseline images for visual regression testing
-
-
-    def test_napari_labels_hover_shows_roi_name(
-        self, make_napari_viewer
-    ) -> None:
+    def test_napari_labels_hover_shows_roi_name(self, make_napari_viewer) -> None:
         """`plot_napari(layer_type='labels')` makes napari's status bar show ROI names.
 
         Sets `attrs["roi_labels"]` on a tiny integer label map; calls

--- a/tests/unit/test_plotting/test_image.py
+++ b/tests/unit/test_plotting/test_image.py
@@ -598,6 +598,95 @@ class TestVolumePlotterAddContours:
             plotter.add_contours(mask, colors="red")
 
 
+class TestRoiHover:
+    """Tests for the ROI hover feature wired into add_volume / add_contours."""
+
+    @staticmethod
+    def _fire_motion(ax, xdata, ydata):
+        """Synthesise a `motion_notify_event` at axes-data `(xdata, ydata)`."""
+        from matplotlib.backend_bases import MouseEvent
+
+        fig = ax.figure
+        fig.canvas.draw()
+        x_disp, y_disp = ax.transData.transform((xdata, ydata))
+        ev = MouseEvent("motion_notify_event", fig.canvas, x_disp, y_disp)
+        fig.canvas.callbacks.process("motion_notify_event", ev)
+        return ev
+
+    def test_hover_shows_value_and_roi(self, matplotlib_pyplot):
+        """Cover the three hover paths: label-only, value-only, and overlay.
+
+        Uses a single labelled voxel `(y=0.5, x=0.5)` (label 7 / "somatosensory")
+        and exercises `plot_volume` with `roi_labels`, `plot_volume` on a non-atlas
+        float volume, and a stacked overlay of both on one `VolumePlotter`.
+        """
+        coords = {"z": [0.0], "y": [0.0, 0.5, 1.0, 1.5], "x": [0.0, 0.5, 1.0, 1.5]}
+        labels = xr.DataArray(
+            np.array(
+                [
+                    [[0, 0, 0, 0], [0, 7, 7, 0], [0, 7, 42, 0], [0, 0, 42, 0]],
+                ],
+                dtype=np.int32,
+            ),
+            dims=["z", "y", "x"],
+            coords=coords,
+        )
+        rng = np.random.default_rng(0)
+        volume = xr.DataArray(
+            rng.normal(size=(1, 4, 4)).astype(np.float32),
+            dims=["z", "y", "x"],
+            coords=coords,
+            attrs={"long_name": "PD", "units": "dB"},
+            name="pd",
+        )
+        roi_labels = {7: "somatosensory", 42: "visual"}
+        x, y = 0.5, 0.5
+        sampled_value = float(volume.sel(z=0.0, y=y, x=x).values)
+
+        # Atlas-only: ROI line, no value (label IS the value, no need to repeat).
+        atlas_plotter = plot_volume(
+            labels,
+            slice_mode="z",
+            slice_coords=[0.0],
+            show_colorbar=False,
+            roi_labels=roi_labels,
+        )
+        ax = atlas_plotter.axes.flat[0]
+        self._fire_motion(ax, x, y)
+        assert ax.format_coord(x, y) == f"x={x:.3g}, y={y:.3g}; ROI: somatosensory (7)"
+
+        # Background voxel (label=0) suppresses the ROI suffix.
+        bg_x, bg_y = 0.5, 1.5  # mask[3, 1] == 0.
+        self._fire_motion(ax, bg_x, bg_y)
+        bg_info = ax.format_coord(bg_x, bg_y)
+        assert "ROI:" not in bg_info and "id=" not in bg_info
+
+        # Volume-only: value with long_name + units, no ROI.
+        volume_plotter = plot_volume(
+            volume, slice_mode="z", slice_coords=[0.0], show_colorbar=False
+        )
+        ax = volume_plotter.axes.flat[0]
+        self._fire_motion(ax, x, y)
+        assert (
+            ax.format_coord(x, y)
+            == f"x={x:.3g}, y={y:.3g}; PD={sampled_value:.4g} dB"
+        )
+
+        # Overlay: BOTH value and ROI in the same hover string.
+        overlay = VolumePlotter(slice_mode="z")
+        overlay.add_volume(
+            volume, slice_coords=[0.0], match_coordinates=False, show_colorbar=False
+        )
+        overlay.add_contours(labels, slice_coords=[0.0], roi_labels=roi_labels)
+        ax = overlay.axes.flat[0]
+        self._fire_motion(ax, x, y)
+        assert (
+            ax.format_coord(x, y)
+            == f"x={x:.3g}, y={y:.3g}; PD={sampled_value:.4g} dB"
+            "; ROI: somatosensory (7)"
+        )
+
+
 class TestPlotNapari:
     """Tests for plot_napari scale and translate parameters."""
 
@@ -722,6 +811,54 @@ class TestPlotNapari:
 
 # Image comparison tests with pytest-mpl
 # These generate baseline images for visual regression testing
+
+
+    def test_napari_labels_hover_shows_roi_name(
+        self, make_napari_viewer
+    ) -> None:
+        """`plot_napari(layer_type='labels')` makes napari's status bar show ROI names.
+
+        Sets `attrs["roi_labels"]` on a tiny integer label map; calls
+        `plot_napari(..., layer_type="labels")`; then directly invokes
+        `Labels.get_status` (the function napari calls to populate the status
+        bar) at one labelled and one background voxel.
+        """
+        roi_labels = {7: "somatosensory", 42: "visual"}
+        labels = xr.DataArray(
+            np.array([[0, 0, 0, 0], [0, 7, 7, 0], [0, 7, 42, 0], [0, 0, 42, 0]]),
+            dims=["y", "x"],
+            coords={"y": [0.0, 0.5, 1.0, 1.5], "x": [0.0, 0.5, 1.0, 1.5]},
+            attrs={"roi_labels": roi_labels},
+        )
+
+        viewer = make_napari_viewer()
+        _, layer = plot_napari(
+            labels,
+            viewer=viewer,
+            layer_type="labels",
+            show_scale_bar=False,
+        )
+
+        # `world=True` means positions are in physical coordinates (the same
+        # space the user hovers in the canvas).
+        # Voxel (y=0.5, x=0.5) holds label 7.
+        roi_status = layer.get_status(
+            (0.5, 0.5),
+            view_direction=np.array([1.0, 0.0]),
+            dims_displayed=[0, 1],
+            world=True,
+        )
+        assert "name: somatosensory" in roi_status["coordinates"]
+
+        # Background voxel: NaN row hides the default `[No Properties]` placeholder.
+        bg_status = layer.get_status(
+            (0.0, 0.0),
+            view_direction=np.array([1.0, 0.0]),
+            dims_displayed=[0, 1],
+            world=True,
+        )
+        assert "[No Properties]" not in bg_status["coordinates"]
+        viewer.close()
 
 
 def _create_deterministic_volume():


### PR DESCRIPTION
## Summary

- Persist `roi_labels` ({id: name}) on `Atlas.annotation.attrs` next to `rgb_lookup` so downstream consumers can resolve ROI names without reloading the atlas (Zarr-serializable).
- Add a matplotlib hover manager attached to each `VolumePlotter` figure. On every `motion_notify_event` it samples the underlying 2D data at the cursor and rewrites `Axes.format_coord` to include the data value (with `long_name` + `units` when available) and/or the ROI name and id when a label map is present. Each axes keeps a list of registered slices so an overlay (volume + atlas contours) shows both segments simultaneously.
- New `roi_labels` keyword on `add_volume`, `add_contours`, `plot_volume`, `plot_contours` (defaults to `data.attrs["roi_labels"]`).
- For `plot_napari(layer_type="labels")`, populate `layer.features` with an `index`/`name` table so napari's built-in `Labels.get_status` (and the cursor tooltip) shows `name: <roi>` in the status bar. A NaN row for label `0` suppresses the default `[No Properties]` placeholder.

## Notes

- Hover for contours samples the underlying mask, not the `Line2D` artist, so the ROI name shows up anywhere inside a closed region — not only on the contour line itself.
- Toolbar's `_mouse_event_to_message` is overridden so the default `[value]` suffix does not duplicate the composed string.

## Screenshots

```python
    import confusius as cf

    template = cf.datasets.fetch_template_pepe_mariani_2026()
    atlas = cf.atlas.Atlas.from_brainglobe("allen_mouse_100um", check_latest=False)
    resampled_atlas = atlas.resample_like(
        template,
        template.attrs["affines"]["physical_to_sform"],
    )

    plotter = cf.plotting.plot_volume(template[43:49])
    plotter.add_contours(
        resampled_atlas.annotation[43:49],
        alpha=0.5,
    )
    plotter.show()

    viewer, _ = cf.plotting.plot_napari(
        resampled_atlas.annotation[43:49], layer_type="labels"
    )
    viewer, _ = cf.plotting.plot_napari(template[43:49], viewer=viewer)
```

**matplotlib** — Power-Doppler volume + atlas contour overlay; status bar shows value (with units) and ROI name when hovering a labelled voxel:


https://github.com/user-attachments/assets/49d737c4-10ea-463e-bd63-f76e5358b493


**napari** — atlas Labels layer; status bar appends `name: <roi>` from `Labels.get_status`:


https://github.com/user-attachments/assets/4e16ad8f-536d-4518-9011-0946bb5d75dc

