### PR TITLE
fix(plotting): keep atlas colours intact in plot_volume

### DIFF
--- a/src/confusius/plotting/image.py
+++ b/src/confusius/plotting/image.py
@@ -188,9 +188,20 @@ def _resolve_cmap(
             gray_band_high = []
         new_colors = gray_band_low + colors_middle + gray_band_high
 
-    return mcolors.LinearSegmentedColormap.from_list(
-        f"{cmap.name}_thresholded", new_colors
+    # Preserve the source colormap's resolution. The default N=256 of
+    # `LinearSegmentedColormap.from_list` collapses larger discrete cmaps such as
+    # the atlas `ListedColormap` (N == number of regions, often >256), aliasing
+    # high indices to wrong (or out-of-range) colours.
+    new_cmap = mcolors.LinearSegmentedColormap.from_list(
+        f"{cmap.name}_thresholded", new_colors, N=cmap.N
     )
+    # Propagate under/over/bad colours so the atlas's transparent under-colour
+    # for label 0 (background) survives the rebuild. Cast to tuple because the
+    # getters return numpy arrays but the setters expect a color-like.
+    new_cmap.set_under(tuple(cmap.get_under()))
+    new_cmap.set_over(tuple(cmap.get_over()))
+    new_cmap.set_bad(tuple(cmap.get_bad()))
+    return new_cmap
 
 
 def _build_axis_label(da: xr.DataArray, dim: str) -> str:


### PR DESCRIPTION
## Summary

When `plot_volume` / `add_volume` rendered an atlas annotation, regions came out with the wrong colours and the background appeared as the first region's colour instead of transparent. `plot_contours` was correct because it bypasses the rebuild path.

`_resolve_cmap` rebuilds the colormap as a `LinearSegmentedColormap` to splice in a gray threshold band. The rebuild dropped two properties of the source cmap that matter for the atlas:

- `LinearSegmentedColormap.from_list` defaulted to `N=256`, collapsing the atlas `ListedColormap` (one slot per region, ~840 for `allen_mouse_100um`). High `BoundaryNorm` indices then aliased to wrong colours or fell out of range. Now passes `N=cmap.N`.
- `set_under` / `set_over` / `set_bad` were not transferred. The atlas builds its cmap with a transparent under-colour, so background voxels (label 0, which `BoundaryNorm(clip=False)` maps to -1) used to render as the first region's colour. Now forwarded via the public `get_under` / `get_over` / `get_bad` getters (cast to `tuple` because the getters return numpy arrays).

Closes #87

## Actual behavior

<img width="1789" height="872" alt="image" src="https://github.com/user-attachments/assets/465988d0-8873-44a0-9733-7984028a2fef" />
