### PR TITLE
chore: prepare v0.2.0 release

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -32,5 +32,5 @@ keywords:
   - Brain connectivity
   - Python
 license: BSD-3-Clause
-version: 0.0.1-a26
-date-released: '2026-05-01'
+version: 0.2.0
+date-released: '2026-05-05'

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ and tutorials.
 
 If you use ConfUSIus in your research, please cite it using the following reference:
 
-> Le Meur-Diebolt, S., & Cybis Pereira, F. (2026). ConfUSIus (v0.0.1-a26). Zenodo.
+> Le Meur-Diebolt, S., & Cybis Pereira, F. (2026). ConfUSIus (v0.2.0). Zenodo.
 > https://doi.org/10.5281/zenodo.18611124
 
 Or in BibTeX format:
@@ -124,7 +124,7 @@ Or in BibTeX format:
   title     = {ConfUSIus},
   year      = {2026},
   publisher = {Zenodo},
-  version   = {v0.0.1-a26},
+  version   = {v0.2.0},
   doi       = {10.5281/zenodo.18611124},
   url       = {https://doi.org/10.5281/zenodo.18611124}
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,9 +6,11 @@ icon: lucide/history
 
 # Changelog
 
-## 0.2.0.dev0
+## 0.2.0
 
-Current development version for the first official public beta release of ConfUSIus.
+Released 2026-05-05.
+
+First official public beta release of ConfUSIus.
 
 ### :sparkles: Highlights
 
@@ -22,5 +24,4 @@ Current development version for the first official public beta release of ConfUS
 
 - `0.1.0` was used only to reserve the `confusius` project name on PyPI and is not a
   supported public release. `0.2.0` is therefore the first official public release
-  series for ConfUSIus. This `0.2.0.dev0` entry tracks changes that will ship in
-  `0.2.0`.
+  series for ConfUSIus.

--- a/docs/citing.md
+++ b/docs/citing.md
@@ -8,7 +8,7 @@ icon: lucide/quote
 
 If you use ConfUSIus in your research, please cite it using the following reference:
 
-> Le Meur-Diebolt, S., & Cybis Pereira, F. (2026). ConfUSIus (v0.0.1-a26). Zenodo.
+> Le Meur-Diebolt, S., & Cybis Pereira, F. (2026). ConfUSIus (v0.2.0). Zenodo.
 > https://doi.org/10.5281/zenodo.18611124
 
 Or in BibTeX format:
@@ -19,7 +19,7 @@ Or in BibTeX format:
   title     = {ConfUSIus},
   year      = {2026},
   publisher = {Zenodo},
-  version   = {v0.0.1-a26},
+  version   = {v0.2.0},
   doi       = {10.5281/zenodo.18611124},
   url       = {https://doi.org/10.5281/zenodo.18611124}
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "confusius"
-version = "0.2.0.dev0"
+version = "0.2.0"
 description = "Python package for analysis and visualization of functional ultrasound imaging data."
 readme = "README.md"
 license = "BSD-3-Clause AND Apache-2.0 AND BSD-2-Clause"

--- a/uv.lock
+++ b/uv.lock
@@ -626,7 +626,7 @@ wheels = [
 
 [[package]]
 name = "confusius"
-version = "0.2.0.dev0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "brainglobe-atlasapi" },


### PR DESCRIPTION
## Summary
- finalize version metadata for `v0.2.0`
- convert the changelog entry from development to released form
- update release citation metadata and docs references