### PR TITLE
fix(napari): exclude cursor vline from x-axis extent computation

### DIFF
--- a/src/confusius/_napari/_qc/_plots.py
+++ b/src/confusius/_napari/_qc/_plots.py
@@ -295,7 +295,7 @@ class QCPlotsWidget(QWidget):
         )
         self._dvars_vline = ax.axvline(
             t0,
-            color=colors["cursor"],
+            color=colors["accent"],
             linewidth=1.2,
             alpha=0.85,
             zorder=10,
@@ -347,7 +347,7 @@ class QCPlotsWidget(QWidget):
             t0 = float(time_coord[0]) if time_coord is not None else 0.0
         self._carpet_vline = ax.axvline(
             t0,
-            color=colors["cursor"],
+            color=colors["accent"],
             linewidth=1.2,
             alpha=0.85,
             zorder=10,

--- a/src/confusius/_napari/_signals/_plotter.py
+++ b/src/confusius/_napari/_signals/_plotter.py
@@ -976,8 +976,10 @@ class SignalPlotter(QWidget):
         if not data_lines:
             return None
         try:
+            # orig=False applies matplotlib's unit conversion so categorical
+            # string labels become the numeric indices used for plotting.
             all_x = np.concatenate(
-                [np.asarray(ln.get_xdata(), dtype=float) for ln in data_lines]
+                [np.asarray(ln.get_xdata(orig=False), dtype=float) for ln in data_lines]
             )
         except (ValueError, TypeError):
             return None

--- a/src/confusius/_napari/_signals/_plotter.py
+++ b/src/confusius/_napari/_signals/_plotter.py
@@ -1515,7 +1515,7 @@ class SignalPlotter(QWidget):
         if self._show_cursor and show_cursor:
             self._vline = self._axes.axvline(
                 cast(float, self._world_to_xaxis(self._cursor_world)),
-                color=colors["cursor"],
+                color=colors["accent"],
                 linewidth=1.2,
                 alpha=0.85,
                 zorder=10,

--- a/src/confusius/_napari/_signals/_plotter.py
+++ b/src/confusius/_napari/_signals/_plotter.py
@@ -967,16 +967,27 @@ class SignalPlotter(QWidget):
         return not np.allclose(self._axes.get_xlim(), auto_xlim, rtol=0.0, atol=1e-9)
 
     def _plotted_x_extent(self) -> tuple[float, float] | None:
-        """Return the overall x extent across all currently plotted lines."""
-        if not self._axes.get_lines():
-            return None
+        """Return the overall x extent across all currently plotted lines.
 
-        self._axes.relim()
-        x0 = float(self._axes.dataLim.x0)
-        x1 = float(self._axes.dataLim.x1)
+        The x-axis cursor vline is excluded so its position (which may be 0
+        before any cursor event) does not shift the data range.
+        """
+        data_lines = [ln for ln in self._axes.get_lines() if ln is not self._vline]
+        if not data_lines:
+            return None
+        try:
+            all_x = np.concatenate(
+                [np.asarray(ln.get_xdata(), dtype=float) for ln in data_lines]
+            )
+        except (ValueError, TypeError):
+            return None
+        if len(all_x) == 0:
+            return None
+        x0 = float(np.nanmin(all_x))
+        x1 = float(np.nanmax(all_x))
         if not (np.isfinite(x0) and np.isfinite(x1)):
             return None
-        return min(x0, x1), max(x0, x1)
+        return x0, x1
 
     def _set_export_signals(self, signals: list[ExportSignal]) -> None:
         """Store the currently plotted signals for export."""

--- a/src/confusius/_napari/_theme.py
+++ b/src/confusius/_napari/_theme.py
@@ -32,9 +32,7 @@ def get_napari_colors(theme_name: str) -> dict:
         `"fg"`
             Foreground (text) hex color string.
         `"accent"`
-            Accent hex color string for plot lines.
-        `"cursor"`
-            Hex color string for the time cursor line.
+            Accent hex color string for plot lines and cursors.
         `"is_dark"`
             `True` when the background luminance is below 50 %.
     """
@@ -62,7 +60,6 @@ def get_napari_colors(theme_name: str) -> dict:
         "bg": bg,
         "fg": fg,
         "accent": "#e94b5f" if is_dark else "#d93a54",
-        "cursor": "#e94b5f" if is_dark else "#d93a54",
         "is_dark": is_dark,
     }
 

--- a/src/confusius/_napari/_theme.py
+++ b/src/confusius/_napari/_theme.py
@@ -62,7 +62,7 @@ def get_napari_colors(theme_name: str) -> dict:
         "bg": bg,
         "fg": fg,
         "accent": "#e94b5f" if is_dark else "#d93a54",
-        "cursor": "#ff6b6b" if is_dark else "#cc2200",
+        "cursor": "#e94b5f" if is_dark else "#d93a54",
         "is_dark": is_dark,
     }
 


### PR DESCRIPTION
## Summary

- `_plotted_x_extent` used `axes.relim()` which included the `axvline` used as the x-axis cursor in the data limits.
- Because `_cursor_world` initialises to `0.0`, enabling "Show x-axis cursor" before the time slider moved placed a vline at x=0 and pulled the lower xlim to 0 instead of the first time value.
- Fix replaces `relim()` + `dataLim` with a manual computation over data lines only, skipping `self._vline`.

Closes #104.