### PR TITLE
perf: lazy-load top-level package imports (SPEC-0001)

### DIFF
--- a/src/confusius/__init__.py
+++ b/src/confusius/__init__.py
@@ -27,6 +27,10 @@ __all__ = [
 
 __version__ = metadata.version("confusius")
 
+# Import the lightweight xarray registration module eagerly so `import confusius`
+# continues to register the `.fusi` accessor on xarray objects.
+from confusius import xarray as xarray
+
 _SUBMODULES = {
     "atlas",
     "connectivity",
@@ -43,7 +47,6 @@ _SUBMODULES = {
     "spatial",
     "timing",
     "validation",
-    "xarray",
 }
 
 _ATTR_TO_MODULE = {

--- a/src/confusius/__init__.py
+++ b/src/confusius/__init__.py
@@ -1,5 +1,8 @@
 """Python package for analysis and visualization of functional ultrasound imaging data."""
 
+from importlib import import_module, metadata
+from typing import TYPE_CHECKING, Any
+
 __all__ = [
     "atlas",
     "connectivity",
@@ -22,26 +25,71 @@ __all__ = [
     "__version__",
 ]
 
-from importlib import metadata
-
 __version__ = metadata.version("confusius")
 
-from confusius import (
-    atlas,
-    connectivity,
-    decomposition,
-    datasets,
-    extract,
-    io,
-    iq,
-    multipose,
-    plotting,
-    qc,
-    registration,
-    signal,
-    spatial,
-    timing,
-    validation,
-    xarray,
-)
-from confusius.io.loadsave import load, save
+_SUBMODULES = {
+    "atlas",
+    "connectivity",
+    "decomposition",
+    "datasets",
+    "extract",
+    "io",
+    "iq",
+    "multipose",
+    "plotting",
+    "qc",
+    "registration",
+    "signal",
+    "spatial",
+    "timing",
+    "validation",
+    "xarray",
+}
+
+_ATTR_TO_MODULE = {
+    "load": "confusius.io.loadsave",
+    "save": "confusius.io.loadsave",
+}
+
+
+# SPEC-0001 recommends PEP 562-based lazy loading for top-level namespaces.
+def __getattr__(name: str) -> Any:
+    if name in _SUBMODULES:
+        module = import_module(f"confusius.{name}")
+        globals()[name] = module
+        return module
+
+    module_name = _ATTR_TO_MODULE.get(name)
+    if module_name is not None:
+        module = import_module(module_name)
+        value = getattr(module, name)
+        globals()[name] = value
+        return value
+
+    raise AttributeError(f"module 'confusius' has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(__all__))
+
+
+if TYPE_CHECKING:
+    from confusius import (
+        atlas,
+        connectivity,
+        decomposition,
+        datasets,
+        extract,
+        io,
+        iq,
+        multipose,
+        plotting,
+        qc,
+        registration,
+        signal,
+        spatial,
+        timing,
+        validation,
+        xarray,
+    )
+    from confusius.io.loadsave import load, save

--- a/src/confusius/xarray/__init__.py
+++ b/src/confusius/xarray/__init__.py
@@ -1,5 +1,8 @@
 """Xarray extensions for fUSI data analysis."""
 
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
 __all__ = [
     "FUSIAccessor",
     "FUSIAffineAccessor",
@@ -15,12 +18,48 @@ __all__ = [
 ]
 
 from confusius.xarray.accessors import FUSIAccessor
-from confusius.xarray.affine import FUSIAffineAccessor
-from confusius.xarray.connectivity import FUSIConnectivityAccessor
-from confusius.xarray.extract import FUSIExtractAccessor
-from confusius.xarray.iq import FUSIIQAccessor
-from confusius.xarray.plotting import FUSIPlotAccessor
-from confusius.xarray.registration import FUSIRegistrationAccessor
-from confusius.xarray.scale import FUSIScaleAccessor, db_scale, log_scale, power_scale
+
+_ATTR_TO_MODULE = {
+    "FUSIAffineAccessor": "confusius.xarray.affine",
+    "FUSIConnectivityAccessor": "confusius.xarray.connectivity",
+    "FUSIExtractAccessor": "confusius.xarray.extract",
+    "FUSIIQAccessor": "confusius.xarray.iq",
+    "FUSIPlotAccessor": "confusius.xarray.plotting",
+    "FUSIRegistrationAccessor": "confusius.xarray.registration",
+    "FUSIScaleAccessor": "confusius.xarray.scale",
+    "db_scale": "confusius.xarray.scale",
+    "log_scale": "confusius.xarray.scale",
+    "power_scale": "confusius.xarray.scale",
+}
+
+
+def __getattr__(name: str) -> Any:
+    module_name = _ATTR_TO_MODULE.get(name)
+    if module_name is None:
+        raise AttributeError(f"module 'confusius.xarray' has no attribute {name!r}")
+
+    module = import_module(module_name)
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(__all__))
+
+
+if TYPE_CHECKING:
+    from confusius.xarray.affine import FUSIAffineAccessor
+    from confusius.xarray.connectivity import FUSIConnectivityAccessor
+    from confusius.xarray.extract import FUSIExtractAccessor
+    from confusius.xarray.iq import FUSIIQAccessor
+    from confusius.xarray.plotting import FUSIPlotAccessor
+    from confusius.xarray.registration import FUSIRegistrationAccessor
+    from confusius.xarray.scale import (
+        FUSIScaleAccessor,
+        db_scale,
+        log_scale,
+        power_scale,
+    )
 
 # Accessor is registered automatically via @xr.register_dataarray_accessor decorator.

--- a/src/confusius/xarray/accessors.py
+++ b/src/confusius/xarray/accessors.py
@@ -1,18 +1,18 @@
 """Xarray accessor for fUSI-specific operations."""
 
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import xarray as xr
 
-from confusius._utils import get_coordinate_origins, get_coordinate_spacings
-from confusius.xarray.affine import FUSIAffineAccessor
-from confusius.xarray.connectivity import FUSIConnectivityAccessor
-from confusius.xarray.extract import FUSIExtractAccessor
-from confusius.xarray.iq import FUSIIQAccessor
-from confusius.xarray.plotting import FUSIPlotAccessor
-from confusius.xarray.registration import FUSIRegistrationAccessor
-from confusius.xarray.scale import FUSIScaleAccessor
+if TYPE_CHECKING:
+    from confusius.xarray.affine import FUSIAffineAccessor
+    from confusius.xarray.connectivity import FUSIConnectivityAccessor
+    from confusius.xarray.extract import FUSIExtractAccessor
+    from confusius.xarray.iq import FUSIIQAccessor
+    from confusius.xarray.plotting import FUSIPlotAccessor
+    from confusius.xarray.registration import FUSIRegistrationAccessor
+    from confusius.xarray.scale import FUSIScaleAccessor
 
 
 @xr.register_dataarray_accessor("fusi")
@@ -58,6 +58,8 @@ class FUSIAccessor:
         >>> seed_masks = xr.open_zarr("seed_masks.zarr")["masks"]
         >>> mapper = data.fusi.connectivity.seed_map(seed_masks=seed_masks)
         """
+        from confusius.xarray.connectivity import FUSIConnectivityAccessor
+
         return FUSIConnectivityAccessor(self._obj)
 
     @property
@@ -76,6 +78,8 @@ class FUSIAccessor:
         <xarray.DataArray (dim_0: 4)>
         array([-30., -20., -10.,   0.])
         """
+        from confusius.xarray.scale import FUSIScaleAccessor
+
         return FUSIScaleAccessor(self._obj)
 
     @property
@@ -93,6 +97,8 @@ class FUSIAccessor:
         >>> data = xr.open_zarr("output.zarr")["iq"]
         >>> viewer, layer = data.fusi.plot.napari()
         """
+        from confusius.xarray.plotting import FUSIPlotAccessor
+
         return FUSIPlotAccessor(self._obj)
 
     @property
@@ -110,6 +116,8 @@ class FUSIAccessor:
         >>> data = xr.open_zarr("output.zarr")["power_doppler"]
         >>> registered = data.fusi.register.volumewise(reference_time=0)
         """
+        from confusius.xarray.registration import FUSIRegistrationAccessor
+
         return FUSIRegistrationAccessor(self._obj)
 
     @property
@@ -129,6 +137,8 @@ class FUSIAccessor:
         >>> pwd = iq.fusi.iq.process_to_power_doppler()
         >>> velocity = iq.fusi.iq.process_to_axial_velocity()
         """
+        from confusius.xarray.iq import FUSIIQAccessor
+
         return FUSIIQAccessor(self._obj)
 
     @property
@@ -150,6 +160,8 @@ class FUSIAccessor:
         >>> # ... process signals ...
         >>> restored = signals.fusi.extract.unmask(mask)
         """
+        from confusius.xarray.extract import FUSIExtractAccessor
+
         return FUSIExtractAccessor(self._obj)
 
     @property
@@ -179,6 +191,8 @@ class FUSIAccessor:
         >>> data.fusi.spacing
         {'y': 0.2, 'x': 0.1}
         """
+        from confusius._utils import get_coordinate_spacings
+
         return get_coordinate_spacings(self._obj)
 
     @property
@@ -206,6 +220,8 @@ class FUSIAccessor:
         >>> data.fusi.origin
         {'y': 0.0, 'x': 0.0}
         """
+        from confusius._utils import get_coordinate_origins
+
         return get_coordinate_origins(self._obj)
 
     @property
@@ -229,6 +245,8 @@ class FUSIAccessor:
         >>> np.allclose(a.fusi.affine.to(b, via="to_world"), np.eye(4))
         True
         """
+        from confusius.xarray.affine import FUSIAffineAccessor
+
         return FUSIAffineAccessor(self._obj)
 
     def save(self, path: str | Path, **kwargs: Any) -> None:


### PR DESCRIPTION
## Summary
- Implement PEP 562 lazy loading in `confusius.__init__` (`__getattr__`/`__dir__`) so `import confusius` no longer eagerly imports heavy subpackages.
- Preserve the top-level API (`__all__`, `from confusius import ...`) and cache resolved attributes/modules after first access.
- Add an inline reference to Scientific Python SPEC-0001: https://scientific-python.org/specs/spec-0001/

Closes #119