### PR TITLE
chore: start 0.3.0.dev0 development

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -265,16 +265,14 @@ Current development version for the next ConfUSIus release.
 - Place it above the most recent released version section.
 
 ### `CITATION.cff`
-- Replace `version: OLD` with `version: VERSION`.
-- Do not invent a new release date for a development version.
-- If the file already contains a release date for the last release, preserve it unless the
-  user asks for a different convention.
+- **Do not modify.** Citation metadata must keep pointing at the last tagged release so
+  users cite the released version, not an unreleased development snapshot. `CITATION.cff`
+  is only updated in `prepare` mode.
 
 ### `README.md` and `docs/citing.md`
-- Update citation version strings only if the repository convention is to keep them aligned
-  with the in-repo development version.
-- If updating them would make the citation text misleading for users, stop and ask the
-  user before changing those files.
+- **Do not modify** the citation section. Same reason as `CITATION.cff`: the rendered
+  citation must reference the last tagged release, not a development version. These files
+  are only updated in `prepare` mode.
 
 ### Step 3 — Sync and verify
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -32,5 +32,5 @@ keywords:
   - Brain connectivity
   - Python
 license: BSD-3-Clause
-version: 0.2.0
+version: 0.3.0.dev0
 date-released: '2026-05-05'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -32,5 +32,5 @@ keywords:
   - Brain connectivity
   - Python
 license: BSD-3-Clause
-version: 0.3.0.dev0
+version: 0.2.0
 date-released: '2026-05-05'

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,17 @@ icon: lucide/history
 
 Current development version for the next ConfUSIus release.
 
+### :sparkles: Enhancements
+
+- Added example gallery helper utilities to streamline writing and maintaining docs
+  examples ([#102](https://github.com/confusius-tools/confusius/pull/102)).
+
+### :bug: Fixes
+
+- Fixed napari x-axis extent computation to ignore the interactive cursor guide line,
+  preventing incorrect plot bounds
+  ([#111](https://github.com/confusius-tools/confusius/pull/111)).
+
 ## 0.2.0
 
 Released 2026-05-05.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,10 @@ icon: lucide/history
 
 # Changelog
 
+## 0.3.0.dev0
+
+Current development version for the next ConfUSIus release.
+
 ## 0.2.0
 
 Released 2026-05-05.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "confusius"
-version = "0.2.0"
+version = "0.3.0.dev0"
 description = "Python package for analysis and visualization of functional ultrasound imaging data."
 readme = "README.md"
 license = "BSD-3-Clause AND Apache-2.0 AND BSD-2-Clause"

--- a/uv.lock
+++ b/uv.lock
@@ -763,7 +763,7 @@ wheels = [
 
 [[package]]
 name = "confusius"
-version = "0.2.0"
+version = "0.3.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "brainglobe-atlasapi" },


### PR DESCRIPTION
## Summary
- bump the repository version to `0.3.0.dev0`
- start the next changelog section
- restore development-version metadata after the release