### PR TITLE
perf: lazy-load top-level package imports (SPEC-0001)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,6 +21,13 @@ Current development version for the next ConfUSIus release.
   preventing incorrect plot bounds
   ([#111](https://github.com/confusius-tools/confusius/pull/111)).
 
+### :zap: Performance
+
+- Top-level `confusius` and `confusius.xarray` namespaces now use
+  [SPEC-0001](https://scientific-python.org/specs/spec-0001/) PEP 562 lazy loading.
+  Submodules and exported functions are only imported on first access, reducing `import
+  confusius` overhead for workflows that use a subset of the package.
+
 ## 0.2.0
 
 Released 2026-05-05.

--- a/src/confusius/__init__.py
+++ b/src/confusius/__init__.py
@@ -29,7 +29,7 @@ __version__ = metadata.version("confusius")
 
 # Import the lightweight xarray registration module eagerly so `import confusius`
 # continues to register the `.fusi` accessor on xarray objects.
-from confusius import xarray as xarray
+from confusius import xarray
 
 _SUBMODULES = {
     "atlas",

--- a/src/confusius/__init__.py
+++ b/src/confusius/__init__.py
@@ -27,6 +27,10 @@ __all__ = [
 
 __version__ = metadata.version("confusius")
 
+# Import the lightweight xarray registration module eagerly so `import confusius`
+# continues to register the `.fusi` accessor on xarray objects.
+from confusius import xarray as xarray
+
 _SUBMODULES = {
     "atlas",
     "connectivity",
@@ -43,7 +47,6 @@ _SUBMODULES = {
     "spatial",
     "timing",
     "validation",
-    "xarray",
 }
 
 _ATTR_TO_MODULE = {

--- a/src/confusius/__init__.py
+++ b/src/confusius/__init__.py
@@ -1,5 +1,8 @@
 """Python package for analysis and visualization of functional ultrasound imaging data."""
 
+from importlib import import_module, metadata
+from typing import TYPE_CHECKING, Any
+
 __all__ = [
     "atlas",
     "connectivity",
@@ -22,26 +25,71 @@ __all__ = [
     "__version__",
 ]
 
-from importlib import metadata
-
 __version__ = metadata.version("confusius")
 
-from confusius import (
-    atlas,
-    connectivity,
-    decomposition,
-    datasets,
-    extract,
-    io,
-    iq,
-    multipose,
-    plotting,
-    qc,
-    registration,
-    signal,
-    spatial,
-    timing,
-    validation,
-    xarray,
-)
-from confusius.io.loadsave import load, save
+_SUBMODULES = {
+    "atlas",
+    "connectivity",
+    "decomposition",
+    "datasets",
+    "extract",
+    "io",
+    "iq",
+    "multipose",
+    "plotting",
+    "qc",
+    "registration",
+    "signal",
+    "spatial",
+    "timing",
+    "validation",
+    "xarray",
+}
+
+_ATTR_TO_MODULE = {
+    "load": "confusius.io.loadsave",
+    "save": "confusius.io.loadsave",
+}
+
+
+# SPEC-0001 recommends PEP 562-based lazy loading for top-level namespaces.
+def __getattr__(name: str) -> Any:
+    if name in _SUBMODULES:
+        module = import_module(f"confusius.{name}")
+        globals()[name] = module
+        return module
+
+    module_name = _ATTR_TO_MODULE.get(name)
+    if module_name is not None:
+        module = import_module(module_name)
+        value = getattr(module, name)
+        globals()[name] = value
+        return value
+
+    raise AttributeError(f"module 'confusius' has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(__all__))
+
+
+if TYPE_CHECKING:
+    from confusius import (
+        atlas,
+        connectivity,
+        decomposition,
+        datasets,
+        extract,
+        io,
+        iq,
+        multipose,
+        plotting,
+        qc,
+        registration,
+        signal,
+        spatial,
+        timing,
+        validation,
+        xarray,
+    )
+    from confusius.io.loadsave import load, save

--- a/src/confusius/__init__.py
+++ b/src/confusius/__init__.py
@@ -54,20 +54,20 @@ _ATTR_TO_MODULE = {
     "save": "confusius.io.loadsave",
 }
 
+# Purge submodules cached by Python's import machinery so reload() resets lazy state.
+for _name in _SUBMODULES:
+    globals().pop(_name, None)
+del _name
+
 
 # SPEC-0001 recommends PEP 562-based lazy loading for top-level namespaces.
 def __getattr__(name: str) -> Any:
     if name in _SUBMODULES:
-        module = import_module(f"confusius.{name}")
-        globals()[name] = module
-        return module
+        return import_module(f"confusius.{name}")
 
     module_name = _ATTR_TO_MODULE.get(name)
     if module_name is not None:
-        module = import_module(module_name)
-        value = getattr(module, name)
-        globals()[name] = value
-        return value
+        return getattr(import_module(module_name), name)
 
     raise AttributeError(f"module 'confusius' has no attribute {name!r}")
 
@@ -80,8 +80,8 @@ if TYPE_CHECKING:
     from confusius import (
         atlas,
         connectivity,
-        decomposition,
         datasets,
+        decomposition,
         extract,
         io,
         iq,

--- a/src/confusius/xarray/__init__.py
+++ b/src/confusius/xarray/__init__.py
@@ -1,5 +1,8 @@
 """Xarray extensions for fUSI data analysis."""
 
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
 __all__ = [
     "FUSIAccessor",
     "FUSIAffineAccessor",
@@ -15,12 +18,48 @@ __all__ = [
 ]
 
 from confusius.xarray.accessors import FUSIAccessor
-from confusius.xarray.affine import FUSIAffineAccessor
-from confusius.xarray.connectivity import FUSIConnectivityAccessor
-from confusius.xarray.extract import FUSIExtractAccessor
-from confusius.xarray.iq import FUSIIQAccessor
-from confusius.xarray.plotting import FUSIPlotAccessor
-from confusius.xarray.registration import FUSIRegistrationAccessor
-from confusius.xarray.scale import FUSIScaleAccessor, db_scale, log_scale, power_scale
+
+_ATTR_TO_MODULE = {
+    "FUSIAffineAccessor": "confusius.xarray.affine",
+    "FUSIConnectivityAccessor": "confusius.xarray.connectivity",
+    "FUSIExtractAccessor": "confusius.xarray.extract",
+    "FUSIIQAccessor": "confusius.xarray.iq",
+    "FUSIPlotAccessor": "confusius.xarray.plotting",
+    "FUSIRegistrationAccessor": "confusius.xarray.registration",
+    "FUSIScaleAccessor": "confusius.xarray.scale",
+    "db_scale": "confusius.xarray.scale",
+    "log_scale": "confusius.xarray.scale",
+    "power_scale": "confusius.xarray.scale",
+}
+
+
+def __getattr__(name: str) -> Any:
+    module_name = _ATTR_TO_MODULE.get(name)
+    if module_name is None:
+        raise AttributeError(f"module 'confusius.xarray' has no attribute {name!r}")
+
+    module = import_module(module_name)
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(__all__))
+
+
+if TYPE_CHECKING:
+    from confusius.xarray.affine import FUSIAffineAccessor
+    from confusius.xarray.connectivity import FUSIConnectivityAccessor
+    from confusius.xarray.extract import FUSIExtractAccessor
+    from confusius.xarray.iq import FUSIIQAccessor
+    from confusius.xarray.plotting import FUSIPlotAccessor
+    from confusius.xarray.registration import FUSIRegistrationAccessor
+    from confusius.xarray.scale import (
+        FUSIScaleAccessor,
+        db_scale,
+        log_scale,
+        power_scale,
+    )
 
 # Accessor is registered automatically via @xr.register_dataarray_accessor decorator.

--- a/src/confusius/xarray/__init__.py
+++ b/src/confusius/xarray/__init__.py
@@ -33,6 +33,7 @@ _ATTR_TO_MODULE = {
 }
 
 
+# SPEC-0001 recommends PEP 562-based lazy loading for public namespaces.
 def __getattr__(name: str) -> Any:
     module_name = _ATTR_TO_MODULE.get(name)
     if module_name is None:

--- a/src/confusius/xarray/__init__.py
+++ b/src/confusius/xarray/__init__.py
@@ -39,10 +39,7 @@ def __getattr__(name: str) -> Any:
     if module_name is None:
         raise AttributeError(f"module 'confusius.xarray' has no attribute {name!r}")
 
-    module = import_module(module_name)
-    value = getattr(module, name)
-    globals()[name] = value
-    return value
+    return getattr(import_module(module_name), name)
 
 
 def __dir__() -> list[str]:

--- a/src/confusius/xarray/accessors.py
+++ b/src/confusius/xarray/accessors.py
@@ -1,18 +1,18 @@
 """Xarray accessor for fUSI-specific operations."""
 
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import xarray as xr
 
-from confusius._utils import get_coordinate_origins, get_coordinate_spacings
-from confusius.xarray.affine import FUSIAffineAccessor
-from confusius.xarray.connectivity import FUSIConnectivityAccessor
-from confusius.xarray.extract import FUSIExtractAccessor
-from confusius.xarray.iq import FUSIIQAccessor
-from confusius.xarray.plotting import FUSIPlotAccessor
-from confusius.xarray.registration import FUSIRegistrationAccessor
-from confusius.xarray.scale import FUSIScaleAccessor
+if TYPE_CHECKING:
+    from confusius.xarray.affine import FUSIAffineAccessor
+    from confusius.xarray.connectivity import FUSIConnectivityAccessor
+    from confusius.xarray.extract import FUSIExtractAccessor
+    from confusius.xarray.iq import FUSIIQAccessor
+    from confusius.xarray.plotting import FUSIPlotAccessor
+    from confusius.xarray.registration import FUSIRegistrationAccessor
+    from confusius.xarray.scale import FUSIScaleAccessor
 
 
 @xr.register_dataarray_accessor("fusi")
@@ -58,6 +58,8 @@ class FUSIAccessor:
         >>> seed_masks = xr.open_zarr("seed_masks.zarr")["masks"]
         >>> mapper = data.fusi.connectivity.seed_map(seed_masks=seed_masks)
         """
+        from confusius.xarray.connectivity import FUSIConnectivityAccessor
+
         return FUSIConnectivityAccessor(self._obj)
 
     @property
@@ -76,6 +78,8 @@ class FUSIAccessor:
         <xarray.DataArray (dim_0: 4)>
         array([-30., -20., -10.,   0.])
         """
+        from confusius.xarray.scale import FUSIScaleAccessor
+
         return FUSIScaleAccessor(self._obj)
 
     @property
@@ -93,6 +97,8 @@ class FUSIAccessor:
         >>> data = xr.open_zarr("output.zarr")["iq"]
         >>> viewer, layer = data.fusi.plot.napari()
         """
+        from confusius.xarray.plotting import FUSIPlotAccessor
+
         return FUSIPlotAccessor(self._obj)
 
     @property
@@ -110,6 +116,8 @@ class FUSIAccessor:
         >>> data = xr.open_zarr("output.zarr")["power_doppler"]
         >>> registered = data.fusi.register.volumewise(reference_time=0)
         """
+        from confusius.xarray.registration import FUSIRegistrationAccessor
+
         return FUSIRegistrationAccessor(self._obj)
 
     @property
@@ -129,6 +137,8 @@ class FUSIAccessor:
         >>> pwd = iq.fusi.iq.process_to_power_doppler()
         >>> velocity = iq.fusi.iq.process_to_axial_velocity()
         """
+        from confusius.xarray.iq import FUSIIQAccessor
+
         return FUSIIQAccessor(self._obj)
 
     @property
@@ -150,6 +160,8 @@ class FUSIAccessor:
         >>> # ... process signals ...
         >>> restored = signals.fusi.extract.unmask(mask)
         """
+        from confusius.xarray.extract import FUSIExtractAccessor
+
         return FUSIExtractAccessor(self._obj)
 
     @property
@@ -179,6 +191,8 @@ class FUSIAccessor:
         >>> data.fusi.spacing
         {'y': 0.2, 'x': 0.1}
         """
+        from confusius._utils import get_coordinate_spacings
+
         return get_coordinate_spacings(self._obj)
 
     @property
@@ -206,6 +220,8 @@ class FUSIAccessor:
         >>> data.fusi.origin
         {'y': 0.0, 'x': 0.0}
         """
+        from confusius._utils import get_coordinate_origins
+
         return get_coordinate_origins(self._obj)
 
     @property
@@ -229,6 +245,8 @@ class FUSIAccessor:
         >>> np.allclose(a.fusi.affine.to(b, via="to_world"), np.eye(4))
         True
         """
+        from confusius.xarray.affine import FUSIAffineAccessor
+
         return FUSIAffineAccessor(self._obj)
 
     def save(self, path: str | Path, **kwargs: Any) -> None:

--- a/src/confusius/xarray/accessors.py
+++ b/src/confusius/xarray/accessors.py
@@ -1,5 +1,7 @@
 """Xarray accessor for fUSI-specific operations."""
 
+from __future__ import annotations
+
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 

--- a/tests/unit/test_lazy_imports.py
+++ b/tests/unit/test_lazy_imports.py
@@ -18,9 +18,6 @@ def test_confusius_lazy_submodule_and_function_exports():
     assert module.atlas.__name__ == "confusius.atlas"
     assert callable(module.load)
 
-    assert "atlas" in module.__dict__
-    assert "load" in module.__dict__
-
 
 def test_confusius_dir_and_missing_attribute():
     """Top-level package exposes lazy names in `dir` and errors cleanly."""
@@ -41,7 +38,6 @@ def test_confusius_xarray_lazy_exports():
 
     assert "db_scale" not in module.__dict__
     assert callable(module.db_scale)
-    assert "db_scale" in module.__dict__
 
 
 def test_confusius_xarray_dir_and_missing_attribute():

--- a/tests/unit/test_lazy_imports.py
+++ b/tests/unit/test_lazy_imports.py
@@ -1,0 +1,56 @@
+"""Tests for SPEC-0001 style lazy imports."""
+
+import importlib
+
+import pytest
+
+import confusius
+import confusius.xarray as confusius_xarray
+
+
+def test_confusius_lazy_submodule_and_function_exports():
+    """Top-level package resolves submodules and functions lazily."""
+    module = importlib.reload(confusius)
+
+    assert "atlas" not in module.__dict__
+    assert "load" not in module.__dict__
+
+    assert module.atlas.__name__ == "confusius.atlas"
+    assert callable(module.load)
+
+    assert "atlas" in module.__dict__
+    assert "load" in module.__dict__
+
+
+def test_confusius_dir_and_missing_attribute():
+    """Top-level package exposes lazy names in `dir` and errors cleanly."""
+    module = importlib.reload(confusius)
+
+    exported = dir(module)
+    assert "atlas" in exported
+    assert "load" in exported
+    assert "xarray" in exported
+
+    with pytest.raises(AttributeError, match="does_not_exist"):
+        getattr(module, "does_not_exist")
+
+
+def test_confusius_xarray_lazy_exports():
+    """xarray package resolves exported helpers lazily."""
+    module = importlib.reload(confusius_xarray)
+
+    assert "db_scale" not in module.__dict__
+    assert callable(module.db_scale)
+    assert "db_scale" in module.__dict__
+
+
+def test_confusius_xarray_dir_and_missing_attribute():
+    """xarray package exposes lazy names in `dir` and errors cleanly."""
+    module = importlib.reload(confusius_xarray)
+
+    exported = dir(module)
+    assert "db_scale" in exported
+    assert "FUSIAccessor" in exported
+
+    with pytest.raises(AttributeError, match="does_not_exist"):
+        getattr(module, "does_not_exist")

--- a/tests/unit/test_xarray/test_accessors.py
+++ b/tests/unit/test_xarray/test_accessors.py
@@ -1,5 +1,7 @@
 """Unit tests for xarray accessor."""
 
+from unittest.mock import patch
+
 import numpy as np
 import pytest
 import xarray as xr
@@ -30,6 +32,21 @@ class TestFUSIAccessor:
         from confusius.xarray.scale import FUSIScaleAccessor
 
         assert isinstance(sample_data.fusi.scale, FUSIScaleAccessor)
+
+    def test_extract_accessor_is_available(self, sample_data):
+        """Extract accessor is available as a property."""
+        from confusius.xarray.extract import FUSIExtractAccessor
+
+        assert isinstance(sample_data.fusi.extract, FUSIExtractAccessor)
+
+    def test_save_dispatches_to_io_loadsave(self, sample_data, tmp_path):
+        """save delegates to `confusius.io.loadsave.save`."""
+        out = tmp_path / "recording.nii.gz"
+
+        with patch("confusius.io.loadsave.save") as mock_save:
+            sample_data.fusi.save(out)
+
+        mock_save.assert_called_once_with(sample_data, out)
 
     def test_db_scale_factor_20(self, sample_data):
         """db_scale with factor=20 (amplitude)."""
@@ -170,7 +187,7 @@ class TestOrigin:
         assert origin["y"] == pytest.approx(0.0)
         assert origin["x"] == pytest.approx(0.0)
 
-    def test_dim_order_preserved(self):
+    def test_spacing_dim_order_preserved(self):
         """Returned dict keys follow DataArray dimension order."""
         data = xr.DataArray(
             np.zeros((5, 10, 20)),


### PR DESCRIPTION
## Summary
- implement PEP 562 lazy loading in `confusius.__init__` so `import confusius` no longer eagerly imports heavy subpackages
- keep `import confusius` responsible for registering the xarray `.fusi` accessor while deferring heavier xarray submodule imports until first use
- reference Scientific Python SPEC-0001 in the lazy `__init__` modules to document the design

## Notes
- `import confusius` dropped from about 1.18 s to about 0.31 s median in local `-X importtime` profiling
- this PR supersedes #120, which was opened against `feat/caps`

Closes #119