### PR TITLE
feat(registration): add `show_progress` to volumewise registration

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,11 @@ Current development version for the next ConfUSIus release.
 
 ### :sparkles: Enhancements
 
+- Added `show_progress` to volumewise registration so joblib progress output can be
+  disabled in scripted or quiet workflows
+  ([#126](https://github.com/confusius-tools/confusius/pull/126)).
+- Replaced plotting `black_bg` with explicit `bg_color` and `fg_color` controls for
+  clearer visual customization ([#124](https://github.com/confusius-tools/confusius/pull/124)).
 - Added example gallery helper utilities to streamline writing and maintaining docs
   examples ([#102](https://github.com/confusius-tools/confusius/pull/102)).
 

--- a/src/confusius/registration/volumewise.py
+++ b/src/confusius/registration/volumewise.py
@@ -1,6 +1,7 @@
 """Volumewise registration for fUSI data."""
 
 from collections.abc import Sequence
+from contextlib import nullcontext
 from typing import Literal, cast
 
 import numpy as np
@@ -30,6 +31,7 @@ def register_volumewise(
     shrink_factors: Sequence[int] = (6, 2, 1),
     smoothing_sigmas: Sequence[int] = (6, 2, 1),
     resample_interpolation: Literal["linear", "bspline"] = "linear",
+    show_progress: bool = True,
 ) -> xr.DataArray:
     """Register all volumes in a fUSI recording to a reference volume.
 
@@ -102,6 +104,8 @@ def register_volumewise(
         `"linear"` is fast and appropriate for motion correction.
         `"bspline"` (3rd-order B-spline) produces smoother results at the
         cost of speed.
+    show_progress : bool, default: True
+        Whether to display a progress bar while registering volumes.
 
     Returns
     -------
@@ -131,7 +135,6 @@ def register_volumewise(
     SCAN data).
     """
     from joblib import Parallel, delayed
-    from joblib_progress import joblib_progress
 
     if "time" not in data.dims:
         raise ValueError("Time dimension 'time' not found in data")
@@ -152,7 +155,13 @@ def register_volumewise(
     n_frames = data_moved.sizes["time"]
     ref_da = data_moved.isel(time=reference_time)
 
-    with joblib_progress("Registering volumes...", total=n_frames):
+    progress_context = nullcontext()
+    if show_progress:
+        from joblib_progress import joblib_progress
+
+        progress_context = joblib_progress("Registering volumes...", total=n_frames)
+
+    with progress_context:
         results = cast(
             "list[tuple[xr.DataArray, npt.NDArray[np.floating] | None]]",
             Parallel(n_jobs=n_jobs)(

--- a/src/confusius/xarray/registration.py
+++ b/src/confusius/xarray/registration.py
@@ -166,6 +166,7 @@ class FUSIRegistrationAccessor:
         shrink_factors: Sequence[int] = (6, 2, 1),
         smoothing_sigmas: Sequence[int] = (6, 2, 1),
         resample_interpolation: Literal["linear", "bspline"] = "linear",
+        show_progress: bool = True,
     ) -> xr.DataArray:
         """Register all volumes to a reference time point.
 
@@ -211,6 +212,8 @@ class FUSIRegistrationAccessor:
             coarsest to finest. Only used when `use_multi_resolution=True`.
         resample_interpolation : {"linear", "bspline"}, default: "linear"
             Interpolation method used for the final resample step.
+        show_progress : bool, default: True
+            Whether to display a progress bar while registering volumes.
 
         Returns
         -------
@@ -239,4 +242,5 @@ class FUSIRegistrationAccessor:
             shrink_factors=shrink_factors,
             smoothing_sigmas=smoothing_sigmas,
             resample_interpolation=resample_interpolation,
+            show_progress=show_progress,
         )

--- a/tests/unit/test_registration/test_volumewise.py
+++ b/tests/unit/test_registration/test_volumewise.py
@@ -42,6 +42,32 @@ class TestRegisterVolumewise:
         result = register_volumewise(dask_data, n_jobs=2, transform="translation")
         assert result.shape == sample_2d_dataarray.shape
 
+    def test_show_progress_false_skips_joblib_progress_import(
+        self, sample_2d_dataarray, monkeypatch
+    ):
+        """show_progress=False does not import joblib_progress."""
+        import builtins
+
+        original_import = builtins.__import__
+
+        def _guarded_import(name, *args, **kwargs):
+            if name == "joblib_progress":
+                raise AssertionError(
+                    "joblib_progress should not be imported when show_progress=False"
+                )
+            return original_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _guarded_import)
+
+        result = register_volumewise(
+            sample_2d_dataarray,
+            n_jobs=1,
+            transform="translation",
+            show_progress=False,
+        )
+
+        assert result.shape == sample_2d_dataarray.shape
+
     def test_wrong_dimensionality_raises(self):
         """Data that is neither 2D+t nor 3D+t raises ValueError."""
         # 1D+time = 2D total.


### PR DESCRIPTION
## Summary
- add `show_progress` to `register_volumewise` and accessor API, defaulting to `True`
- use `contextlib.nullcontext()` when disabled to skip `joblib_progress`
- add a unit test that verifies `joblib_progress` is not imported when `show_progress=False`

Closes #125