### PR TITLE
fix(ci): add --mpl flag to enable visual regression checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
         run: uv sync --frozen --all-extras
 
       - name: Run pytest with coverage
-        run: uv run pytest tests/
+        run: uv run pytest tests/ --mpl
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.14' && matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
Closes #130

`pytest-mpl` requires `--mpl` to actually compare plots against baselines. Without it, `@pytest.mark.mpl_image_compare` tests run but skip all image comparisons, silently passing regardless of visual changes.