### PR TITLE
feat(datasets): add datatype filter to fetch_cybis_pereira_2026

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,9 @@ Current development version for the next ConfUSIus release.
 
 ### :sparkles: Enhancements
 
+- Added `datatypes` filter to `fetch_cybis_pereira_2026`, allowing downloads to be
+  scoped to specific BIDS datatype directories (`"fusi"`, `"angio"`, `"motion"`)
+  ([#NNN](https://github.com/confusius-tools/confusius/pull/NNN)).
 - Added `show_progress` to volumewise registration so joblib progress output can be
   disabled in scripted or quiet workflows
   ([#126](https://github.com/confusius-tools/confusius/pull/126)).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,7 +14,7 @@ Current development version for the next ConfUSIus release.
 
 - Added `datatypes` filter to `fetch_cybis_pereira_2026`, allowing downloads to be
   scoped to specific BIDS datatype directories (`"fusi"`, `"angio"`, `"motion"`)
-  ([#NNN](https://github.com/confusius-tools/confusius/pull/NNN)).
+  ([#141](https://github.com/confusius-tools/confusius/pull/141)).
 - Added `show_progress` to volumewise registration so joblib progress output can be
   disabled in scripted or quiet workflows
   ([#126](https://github.com/confusius-tools/confusius/pull/126)).

--- a/src/confusius/datasets/_cybis_pereira_2026.py
+++ b/src/confusius/datasets/_cybis_pereira_2026.py
@@ -27,20 +27,26 @@ _VALID_DATASETS = frozenset(
 """Valid values for the `datasets` parameter of `fetch_cybis_pereira_2026`."""
 
 
+_VALID_DATATYPES = frozenset({"fusi", "angio", "motion"})
+"""Valid values for the `datatypes` parameter of `fetch_cybis_pereira_2026`."""
+
+
 def _filter_files(
     index: dict[str, OsfFileInfo],
     datasets: list[str] | None,
     subjects: list[str] | None,
     sessions: list[str] | None,
     acqs: list[str] | None,
+    datatypes: list[str] | None,
 ) -> dict[str, OsfFileInfo]:
     """Filter the index to files matching the requested datasets and subjects.
 
     Top-level BIDS metadata files (dataset_description.json, participants.*,
-    etc.) are always included. The `sessions` and `acqs` filters only
-    exclude files that carry the corresponding BIDS entity; subject- or
-    dataset-level aggregate files (e.g. `sub-rat73_acq-slice32_statmap.nii`
-    in derivatives, or `decode-speed/sub-rat73/...`) are kept when they
+    etc.) are always included. The `sessions`, `acqs`, and `datatypes`
+    filters only exclude files that carry the corresponding BIDS entity
+    or live under a datatype directory; subject- or dataset-level
+    aggregate files (e.g. `sub-rat73_acq-slice32_statmap.nii` in
+    derivatives, or `decode-speed/sub-rat73/...`) are kept when they
     match every entity they do declare.
 
     Parameters
@@ -63,6 +69,11 @@ def _filter_files(
         Acquisition labels to include (without "acq-" prefix), e.g.
         `["slice32"]`. If `None`, all acquisitions are included. Files
         with no `acq-` entity are passed through.
+    datatypes : list[str] or None
+        BIDS datatype directories to include (e.g. `["fusi", "angio"]`).
+        If `None`, all datatypes are included. Files that do not sit
+        under a datatype directory (e.g. session-level `scans.tsv`,
+        subject-level derivative aggregates) are passed through.
 
     Returns
     -------
@@ -89,7 +100,7 @@ def _filter_files(
                 if subjects is not None and sub_id not in subjects:
                     continue
 
-            if not _matches_entities(parts, sessions, acqs):
+            if not _matches_entities(parts, sessions, acqs, datatypes):
                 continue
 
             filtered[path] = file_info
@@ -108,7 +119,7 @@ def _filter_files(
         if subjects is not None and sub_id not in subjects:
             continue
 
-        if not _matches_entities(parts, sessions, acqs):
+        if not _matches_entities(parts, sessions, acqs, datatypes):
             continue
 
         filtered[path] = file_info
@@ -120,14 +131,16 @@ def _matches_entities(
     parts: tuple[str, ...],
     sessions: list[str] | None,
     acqs: list[str] | None,
+    datatypes: list[str] | None,
 ) -> bool:
-    """Return True when the path satisfies the session and acquisition filters.
+    """Return True when the path satisfies the entity filters.
 
-    A file matches when, for each of `sessions` and `acqs`, it either
-    omits the corresponding BIDS entity entirely or declares a value
-    that is in the requested list. The session is read from any
+    A file matches when, for each of `sessions`, `acqs`, and `datatypes`,
+    it either omits the corresponding BIDS entity entirely or declares a
+    value that is in the requested list. The session is read from any
     `ses-*` directory in `parts`; the acquisition is read from the
-    `acq-*` entity in the filename.
+    `acq-*` entity in the filename; the datatype is read from the
+    directory component immediately following the `ses-*` directory.
     """
     if sessions is not None:
         ses_dir = next((p for p in parts if p.startswith("ses-")), None)
@@ -141,7 +154,29 @@ def _matches_entities(
         if match is not None and match.group(1) not in acqs:
             return False
 
+    if datatypes is not None:
+        datatype = _datatype_from_parts(parts)
+        if datatype is not None and datatype not in datatypes:
+            return False
+
     return True
+
+
+def _datatype_from_parts(parts: tuple[str, ...]) -> str | None:
+    """Return the BIDS datatype directory in `parts`, or None if absent.
+
+    The datatype is the directory component immediately following the
+    `ses-*` directory, provided it is not itself the file name and is
+    one of the known datatypes ([_VALID_DATATYPES][]). Returns `None`
+    for paths without a session directory or with no datatype layer
+    (e.g. session-level `scans.tsv`, subject-level aggregates).
+    """
+    for i, part in enumerate(parts):
+        if part.startswith("ses-") and i + 1 < len(parts) - 1:
+            candidate = parts[i + 1]
+            if candidate in _VALID_DATATYPES:
+                return candidate
+    return None
 
 
 def fetch_cybis_pereira_2026(
@@ -150,6 +185,7 @@ def fetch_cybis_pereira_2026(
     subjects: str | list[str] | None = None,
     sessions: str | list[str] | None = None,
     acqs: str | list[str] | None = None,
+    datatypes: str | list[str] | None = None,
     refresh: bool = False,
 ) -> Path:
     """Fetch the Cybis Pereira 2026 fUSI-BIDS dataset.
@@ -188,6 +224,13 @@ def fetch_cybis_pereira_2026(
         `"slice32"` or `["slice32", "slice42"]`. If not provided, all
         acquisitions are downloaded. Files with no acquisition entity
         are always included.
+    datatypes : str or list[str], optional
+        BIDS datatype directories to download, e.g. `"fusi"`, `"angio"`,
+        `["fusi", "angio"]`. Valid values are `"fusi"`, `"angio"`
+        and `"motion"`. If not provided, all datatypes are
+        downloaded. Files that do not sit under a datatype directory
+        (e.g. session-level `scans.tsv`, subject-level derivative
+        aggregates) are always included.
     refresh : bool, default: False
         Whether to re-fetch the dataset index from OSF and download any files
         that are missing locally. If `False` and all requested files are
@@ -202,7 +245,8 @@ def fetch_cybis_pereira_2026(
     Raises
     ------
     ValueError
-        If an unknown dataset name is passed in `datasets`.
+        If an unknown dataset name is passed in `datasets`, or an
+        unknown datatype is passed in `datatypes`.
 
     References
     ----------
@@ -226,6 +270,8 @@ def fetch_cybis_pereira_2026(
         sessions = [sessions]
     if isinstance(acqs, str):
         acqs = [acqs]
+    if isinstance(datatypes, str):
+        datatypes = [datatypes]
 
     if datasets is not None:
         invalid = set(datasets) - _VALID_DATASETS
@@ -235,11 +281,19 @@ def fetch_cybis_pereira_2026(
                 f"Valid options: {sorted(_VALID_DATASETS)}"
             )
 
+    if datatypes is not None:
+        invalid = set(datatypes) - _VALID_DATATYPES
+        if invalid:
+            raise ValueError(
+                f"Unknown datatype(s): {invalid}. "
+                f"Valid options: {sorted(_VALID_DATATYPES)}"
+            )
+
     index = cast(
         "dict[str, OsfFileInfo]",
         get_index(bids_dir, _OSF_PROJECT_ID, _BIDS_ROOT, refresh=refresh),
     )
-    files = _filter_files(index, datasets, subjects, sessions, acqs)
+    files = _filter_files(index, datasets, subjects, sessions, acqs, datatypes)
 
     download_missing_osf_files(bids_dir, files)
 

--- a/tests/unit/test_datasets/test_cybis_pereira_2026.py
+++ b/tests/unit/test_datasets/test_cybis_pereira_2026.py
@@ -19,16 +19,22 @@ _FAKE_INDEX = {
     "participants.tsv": {"osf_path": "/file002", "size": 200},
     # Rawdata — requires "rawdata" in datasets filter. Two sessions, two
     # acquisitions per session for sub-rat83; sub-rat84 has a single
-    # session with no acquisition entity.
-    "sub-rat83/ses-20220523/fus/sub-rat83_ses-20220523_task-openfield_acq-slice32_pwd.nii.gz": {
+    # session with no acquisition entity. Each session carries both fusi
+    # and angio datatypes, plus a session-level scans.tsv with no
+    # datatype layer.
+    "sub-rat83/ses-20220523/fusi/sub-rat83_ses-20220523_task-openfield_acq-slice32_pwd.nii.gz": {
         "osf_path": "/file003",
         "size": 1000,
     },
-    "sub-rat83/ses-20220523/fus/sub-rat83_ses-20220523_task-openfield_acq-slice42_pwd.nii.gz": {
+    "sub-rat83/ses-20220523/fusi/sub-rat83_ses-20220523_task-openfield_acq-slice42_pwd.nii.gz": {
         "osf_path": "/file004",
         "size": 1000,
     },
-    "sub-rat83/ses-20220524/fus/sub-rat83_ses-20220524_task-openfield_acq-slice32_pwd.nii.gz": {
+    "sub-rat83/ses-20220523/angio/sub-rat83_ses-20220523_acq-slice32_rec-minframe2d_pwd.nii.gz": {
+        "osf_path": "/file004a",
+        "size": 800,
+    },
+    "sub-rat83/ses-20220524/fusi/sub-rat83_ses-20220524_task-openfield_acq-slice32_pwd.nii.gz": {
         "osf_path": "/file005",
         "size": 1000,
     },
@@ -36,9 +42,13 @@ _FAKE_INDEX = {
         "osf_path": "/file006",
         "size": 50,
     },
-    "sub-rat84/ses-20210407/fus/sub-rat84_ses-20210407_task-openfield_pwd.nii.gz": {
+    "sub-rat84/ses-20210407/fusi/sub-rat84_ses-20210407_task-openfield_pwd.nii.gz": {
         "osf_path": "/file007",
         "size": 1000,
+    },
+    "sub-rat84/ses-20210407/angio/sub-rat84_ses-20210407_rec-minframe2d_pwd.nii.gz": {
+        "osf_path": "/file007a",
+        "size": 800,
     },
     # Derivatives — filtered by derivative name and subject.
     "derivatives/glm-speed/dataset_description.json": {
@@ -54,8 +64,8 @@ _FAKE_INDEX = {
         "osf_path": "/file010",
         "size": 500,
     },
-    # Session-level derivative file (has both ses and acq).
-    "derivatives/glm-speed/sub-rat83/ses-20220523/fus/sub-rat83_ses-20220523_task-openfield_acq-slice32_dm.tsv": {
+    # Session-level derivative file (has both ses and acq, under fusi).
+    "derivatives/glm-speed/sub-rat83/ses-20220523/fusi/sub-rat83_ses-20220523_task-openfield_acq-slice32_dm.tsv": {
         "osf_path": "/file011",
         "size": 200,
     },
@@ -249,9 +259,47 @@ def test_fetch_combined_session_and_acq_filters(
     )
 
 
+def test_fetch_datatype_filter_fusi_only(tmp_path, mock_get_index, mock_retrieve):
+    """`datatypes=["fusi"]` excludes angio files but keeps files without a datatype."""
+    fetch_cybis_pereira_2026(data_dir=tmp_path, datatypes=["fusi"])
+
+    downloaded = _downloaded_paths(mock_retrieve)
+    # fusi files included.
+    assert "sub-rat83_ses-20220523_task-openfield_acq-slice32_pwd.nii.gz" in downloaded
+    # angio files excluded.
+    assert (
+        "sub-rat83_ses-20220523_acq-slice32_rec-minframe2d_pwd.nii.gz" not in downloaded
+    )
+    assert "sub-rat84_ses-20210407_rec-minframe2d_pwd.nii.gz" not in downloaded
+    # Files with no datatype layer pass through (session-level, subject-level).
+    assert "sub-rat83_ses-20220523_scans.tsv" in downloaded
+    assert "sub-rat83_acq-slice32_stat-t_statmap.nii.gz" in downloaded
+    # Top-level metadata always included.
+    assert "dataset_description.json" in downloaded
+
+
+def test_fetch_datatype_filter_angio_only(tmp_path, mock_get_index, mock_retrieve):
+    """`datatypes=["angio"]` keeps angio files and excludes fusi files."""
+    fetch_cybis_pereira_2026(data_dir=tmp_path, datatypes=["angio"])
+
+    downloaded = _downloaded_paths(mock_retrieve)
+    assert "sub-rat83_ses-20220523_acq-slice32_rec-minframe2d_pwd.nii.gz" in downloaded
+    assert "sub-rat84_ses-20210407_rec-minframe2d_pwd.nii.gz" in downloaded
+    assert (
+        "sub-rat83_ses-20220523_task-openfield_acq-slice32_pwd.nii.gz" not in downloaded
+    )
+    # Files with no datatype layer still pass through.
+    assert "sub-rat83_ses-20220523_scans.tsv" in downloaded
+
+
 def test_fetch_invalid_dataset_raises(tmp_path):
     with pytest.raises(ValueError, match="Unknown dataset"):
         fetch_cybis_pereira_2026(data_dir=tmp_path, datasets=["nonexistent"])
+
+
+def test_fetch_invalid_datatype_raises(tmp_path):
+    with pytest.raises(ValueError, match="Unknown datatype"):
+        fetch_cybis_pereira_2026(data_dir=tmp_path, datatypes=["nonexistent"])
 
 
 def test_fetch_accepts_string_datasets(tmp_path, mock_get_index, mock_retrieve):
@@ -296,7 +344,7 @@ def test_fetch_retries_on_transient_failure(tmp_path, mock_get_index):
 
     # Pre-create every file except one so only that file goes through retrieve.
     target_rel = (
-        "sub-rat83/ses-20220523/fus/"
+        "sub-rat83/ses-20220523/fusi/"
         "sub-rat83_ses-20220523_task-openfield_acq-slice32_pwd.nii.gz"
     )
     for rel in _FAKE_INDEX:
@@ -334,7 +382,7 @@ def test_fetch_raises_after_max_retries(tmp_path, mock_get_index):
     bids_dir = tmp_path / _BIDS_ROOT
 
     target_rel = (
-        "sub-rat83/ses-20220523/fus/"
+        "sub-rat83/ses-20220523/fusi/"
         "sub-rat83_ses-20220523_task-openfield_acq-slice32_pwd.nii.gz"
     )
     for rel in _FAKE_INDEX:


### PR DESCRIPTION
## Description

Adds a `datatypes` filter to `fetch_cybis_pereira_2026`, mirroring the existing `subjects` / `sessions` / `acqs` parameters. Valid values are `"fusi"`, `"angio"`, and `"motion"`.

Also corrects the test fixture, which used a non-existent `fus/` datatype directory; the real dataset uses `fusi/` (alongside `angio/`).

## Checklist

- [x] Tests pass locally (`just t`)
- [x] Pre-commit hooks pass (`just pc`)
- [x] New public API is documented (NumPy docstring, type hints)
- [x] Changelog updated if user-facing