### PR TITLE
fix(ci): combine docs preview cleanup into single atomic commit

### DIFF
--- a/.github/workflows/docs-cleanup-preview.yml
+++ b/.github/workflows/docs-cleanup-preview.yml
@@ -14,36 +14,39 @@ jobs:
       pull-requests: write
     steps:
       - name: Remove preview from docs repo
-        env:
-          GH_TOKEN: ${{ secrets.DOCS_DEPLOY_TOKEN }}
         run: |
+          set -euo pipefail
           git clone --depth 1 \
             "https://x-access-token:${{ secrets.DOCS_DEPLOY_TOKEN }}@github.com/confusius-tools/confusius-docs.git" \
             docs-repo
           cd docs-repo
-          if [ -d "pr-preview/pr-${{ github.event.number }}" ]; then
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git rm -rf "pr-preview/pr-${{ github.event.number }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          CHANGED=false
+          PR_DIR="pr-preview/pr-${{ github.event.number }}"
+          if [ -d "$PR_DIR" ]; then
+            git rm -rf "$PR_DIR"
+            CHANGED=true
+          fi
+
+          VERSIONS_FILE="pr-preview/versions.json"
+          if [ -f "$VERSIONS_FILE" ]; then
+            PR_ENTRY=$(jq --arg ver "pr-${{ github.event.number }}" \
+              '.[] | select(.version == $ver)' "$VERSIONS_FILE")
+            if [ -n "$PR_ENTRY" ]; then
+              jq --arg ver "pr-${{ github.event.number }}" \
+                '[.[] | select(.version != $ver)]' "$VERSIONS_FILE" > versions_new.json
+              mv versions_new.json "$VERSIONS_FILE"
+              git add "$VERSIONS_FILE"
+              CHANGED=true
+            fi
+          fi
+
+          if [ "$CHANGED" = "true" ]; then
             git commit -m "docs: remove preview for PR #${{ github.event.number }}"
             git push
           fi
-
-      - name: Remove PR entry from pr-preview/versions.json
-        env:
-          GH_TOKEN: ${{ secrets.DOCS_DEPLOY_TOKEN }}
-        run: |
-          PR_NUM="${{ github.event.number }}"
-          RESPONSE=$(gh api repos/confusius-tools/confusius-docs/contents/pr-preview/versions.json 2>/dev/null || echo "")
-          if [ -z "$RESPONSE" ]; then exit 0; fi
-          SHA=$(echo "$RESPONSE" | jq -r '.sha')
-          OLD_CONTENT=$(echo "$RESPONSE" | jq -r '.content | gsub("\\n"; "") | @base64d')
-          NEW_CONTENT=$(echo "$OLD_CONTENT" | jq --arg ver "pr-${PR_NUM}" '[.[] | select(.version != $ver)]')
-          CONTENT_B64=$(printf '%s' "$NEW_CONTENT" | base64 -w 0)
-          PAYLOAD=$(jq -n --arg sha "$SHA" --arg c "$CONTENT_B64" --arg pr "$PR_NUM" \
-            '{message:"chore: remove pr-\($pr) from pr-preview/versions.json",content:$c,sha:$sha}')
-          echo "$PAYLOAD" | gh api repos/confusius-tools/confusius-docs/contents/pr-preview/versions.json \
-            -X PUT --input -
 
       - name: Delete preview comment
         uses: marocchino/sticky-pull-request-comment@v2


### PR DESCRIPTION
Fixes #143.

## Summary

- Replace two separate git commits (one via `git push`, one via `gh api PUT`) with a single `git commit + git push` that removes the preview dir and edits `versions.json` in-place via `jq`
- Add `set -euo pipefail` so failures are visible rather than silently swallowed
- Guard the commit behind a `CHANGED` flag so closed PRs with no deployed preview don't create empty commits