### PR TITLE
fix(plotting): keep hover manager alive after plotter is GC'd

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -25,6 +25,10 @@ Current development version for the next ConfUSIus release.
 
 ### :bug: Fixes
 
+- Fixed plotting hover information silently disappearing when the returned
+  `VolumePlotter` was not held in a variable (e.g. `obj.fusi.plot.volume().show()`). The
+  hover manager is now kept alive until the figure is closed
+  ([#148](https://github.com/confusius-tools/confusius/pull/148)).
 - Fixed napari x-axis extent computation to ignore the interactive cursor guide line,
   preventing incorrect plot bounds
   ([#111](https://github.com/confusius-tools/confusius/pull/111)).

--- a/src/confusius/plotting/_hover.py
+++ b/src/confusius/plotting/_hover.py
@@ -24,7 +24,8 @@ if TYPE_CHECKING:
     from matplotlib.backend_bases import Event
     from matplotlib.figure import Figure
 
-_CONFUSIUS_HOVER_MANAGER: set[_HoverManager] = set()
+_CONFUSIUS_HOVER_MANAGERS: set[_HoverManager] = set()
+"""Strong-reference registry of active `_HoverManager` instances."""
 
 
 @dataclass
@@ -65,7 +66,7 @@ class _HoverManager:
         self.roi_labels.clear()
         self._ax_layers.clear()
         self._attached = False
-        _CONFUSIUS_HOVER_MANAGER.discard(self)
+        _CONFUSIUS_HOVER_MANAGERS.discard(self)
 
     def is_attached(self) -> bool:
         """Return `True` if this hover manager is attached to a figure."""
@@ -80,9 +81,9 @@ class _HoverManager:
             Figure to attach to.
         """
         self._cid = figure.canvas.mpl_connect("motion_notify_event", self._on_hover)
-        _CONFUSIUS_HOVER_MANAGER.add(self)
+        _CONFUSIUS_HOVER_MANAGERS.add(self)
         figure.canvas.mpl_connect(
-            "close_event", lambda _e, mgr=self: _CONFUSIUS_HOVER_MANAGER.discard(mgr)
+            "close_event", lambda _e, mgr=self: _CONFUSIUS_HOVER_MANAGERS.discard(mgr)
         )
         toolbar = figure.canvas.toolbar
         if toolbar is not None and hasattr(

--- a/src/confusius/plotting/_hover.py
+++ b/src/confusius/plotting/_hover.py
@@ -24,6 +24,8 @@ if TYPE_CHECKING:
     from matplotlib.backend_bases import Event
     from matplotlib.figure import Figure
 
+_CONFUSIUS_HOVER_MANAGER: set[_HoverManager] = set()
+
 
 @dataclass
 class _SliceLayer:
@@ -43,7 +45,7 @@ class _SliceLayer:
     """Units string appended to the numeric value, if any."""
 
 
-class _RegionHoverManager:
+class _HoverManager:
     """Show the data value and/or ROI name under the cursor in the status bar.
 
     Attributes
@@ -63,6 +65,7 @@ class _RegionHoverManager:
         self.roi_labels.clear()
         self._ax_layers.clear()
         self._attached = False
+        _CONFUSIUS_HOVER_MANAGER.discard(self)
 
     def is_attached(self) -> bool:
         """Return `True` if this hover manager is attached to a figure."""
@@ -77,6 +80,10 @@ class _RegionHoverManager:
             Figure to attach to.
         """
         self._cid = figure.canvas.mpl_connect("motion_notify_event", self._on_hover)
+        _CONFUSIUS_HOVER_MANAGER.add(self)
+        figure.canvas.mpl_connect(
+            "close_event", lambda _e, mgr=self: _CONFUSIUS_HOVER_MANAGER.discard(mgr)
+        )
         toolbar = figure.canvas.toolbar
         if toolbar is not None and hasattr(
             toolbar, "_mouse_event_to_message"

--- a/src/confusius/plotting/image.py
+++ b/src/confusius/plotting/image.py
@@ -14,8 +14,8 @@ from confusius._utils import find_stack_level, get_coordinate_spacings_best_effo
 from confusius.atlas._structures import _build_atlas_cmap_and_norm
 from confusius.extract import extract_with_mask
 from confusius.plotting._hover import (
+    _HoverManager,
     _normalize_roi_labels,
-    _RegionHoverManager,
 )
 from confusius.signal import clean
 from confusius.validation import validate_time_series
@@ -447,7 +447,7 @@ class VolumePlotter:
         self._axis_xlims: dict[int, tuple[float, float]] = {}
         self._axis_ylims: dict[int, tuple[float, float]] = {}
 
-        self._hover_manager = _RegionHoverManager()
+        self._hover_manager = _HoverManager()
 
     def _ensure_figure(
         self,

--- a/tests/unit/test_plotting/test_image.py
+++ b/tests/unit/test_plotting/test_image.py
@@ -738,6 +738,79 @@ class TestRoiHover:
             "; annotation=7 (somatosensory)"
         )
 
+    def test_hover_survives_plotter_gc(self, matplotlib_pyplot):
+        """Hover stays wired up after the returned plotter is dropped and GC'd.
+
+        Regression test for the fix that anchors active `_HoverManager`
+        instances in a module-level set: matplotlib's `CallbackRegistry`
+        stores bound methods as `WeakMethod`, so without the strong-ref
+        registry the manager would be collected as soon as the
+        `VolumePlotter` returned by `plot_volume(...)` went out of scope
+        (e.g. `plot_volume(...).show()`), silently disabling hover.
+        """
+        import gc
+        import weakref
+
+        from confusius.plotting._hover import _CONFUSIUS_HOVER_MANAGERS
+
+        coords = {"z": [0.0], "y": [0.0, 0.5, 1.0, 1.5], "x": [0.0, 0.5, 1.0, 1.5]}
+        labels = xr.DataArray(
+            np.array(
+                [[[0, 0, 0, 0], [0, 7, 7, 0], [0, 7, 42, 0], [0, 0, 42, 0]]],
+                dtype=np.int32,
+            ),
+            dims=["z", "y", "x"],
+            coords=coords,
+            name="annotation",
+        )
+        roi_labels = {7: "somatosensory", 42: "visual"}
+        x, y = 0.5, 0.5
+
+        plotter = plot_volume(
+            labels,
+            slice_mode="z",
+            slice_coords=[0.0],
+            show_colorbar=False,
+            roi_labels=roi_labels,
+        )
+        fig = plotter.figure
+        ax = plotter.axes.flat[0]
+        plotter_ref = weakref.ref(plotter)
+        manager_ref = weakref.ref(plotter._hover_manager)
+        assert manager_ref() in _CONFUSIUS_HOVER_MANAGERS
+
+        del plotter
+        gc.collect()
+
+        # The plotter is gone, but the hover manager must still be alive
+        # (anchored by the module-level registry) and still wired to the
+        # canvas's motion_notify_event.
+        assert plotter_ref() is None
+        assert manager_ref() is not None
+        assert manager_ref() in _CONFUSIUS_HOVER_MANAGERS
+
+        self._fire_motion(ax, x, y)
+        assert (
+            ax.format_coord(x, y)
+            == f"x={x:.3g}, y={y:.3g}; annotation=7 (somatosensory)"
+        )
+
+        # Closing the figure must release the manager from the registry,
+        # after which it is free to be garbage collected. The Agg backend
+        # used in tests does not dispatch `close_event` from `plt.close`,
+        # so emit it explicitly to mirror what interactive backends do.
+        from matplotlib.backend_bases import CloseEvent
+
+        fig.canvas.callbacks.process(
+            "close_event", CloseEvent("close_event", fig.canvas)
+        )
+        assert manager_ref() not in _CONFUSIUS_HOVER_MANAGERS
+
+        matplotlib_pyplot.close(fig)
+        del ax, fig
+        gc.collect()
+        assert manager_ref() is None
+
 
 class TestPlotNapari:
     """Tests for plot_napari scale and translate parameters."""


### PR DESCRIPTION
## Description

- Close #147 

Matplotlib's CallbackRegistry holds bound-method callbacks as WeakMethod, so the hover manager was collected as soon as the returning VolumePlotter went out of scope (e.g. `data.fusi.plot.volume().show()`), silently disabling status-bar hover.

Anchor active managers in a module-level set and discard them on matplotlib's close_event (and on clear()), mirroring the pattern used by stateful mpl helpers such as MultiCursor. Also rename `_RegionHoverManager` to `_HoverManager` as it is not specific to ROI hovering.

## Checklist

- [x] Tests pass locally (`just t`)
- [x] Pre-commit hooks pass (`just pc`)
- [x] New public API is documented (NumPy docstring, type hints)
- [x] Changelog updated if user-facing
