### PR TITLE
refactor: handle monotonic-decreasing coordinates

### DIFF
--- a/src/confusius/_napari/_io/_readers.py
+++ b/src/confusius/_napari/_io/_readers.py
@@ -16,7 +16,10 @@ from typing import TYPE_CHECKING, Any, Callable
 from napari.layers.utils.layer_utils import calc_data_range
 from napari.utils.notifications import show_warning
 
-from confusius._utils.coordinates import get_coordinate_spacings_best_effort
+from confusius._utils.coordinates import (
+    get_coordinate_spacings_best_effort,
+    sort_coords_into_increasing_order,
+)
 from confusius.io import load
 
 if TYPE_CHECKING:
@@ -42,7 +45,11 @@ def _convert_dataarray_to_layer_data(da: xr.DataArray, name: str) -> FullLayerDa
     """
 
     all_dims = list(da.dims)
+    time_dim = "time" if "time" in all_dims else None
+    spatial_dims = [d for d in all_dims if d != time_dim]
 
+    da = sort_coords_into_increasing_order(da, spatial_dims)
+    # spacing is ensured to be positive in spatial_dims by `sort_coords_into_increasing_order`
     spacing, non_uniform = get_coordinate_spacings_best_effort(da)
     for dim in non_uniform:
         show_warning(

--- a/src/confusius/_utils/coordinates.py
+++ b/src/confusius/_utils/coordinates.py
@@ -1,6 +1,7 @@
 """Coordinate spacing and origin helpers shared across modules."""
 
 import warnings
+from collections.abc import Hashable, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -274,3 +275,43 @@ def get_coordinate_origins(data: xr.DataArray) -> dict[str, float]:
             else:
                 result[dim] = float(coord.values.flat[0])
     return result
+
+
+def sort_coords_into_increasing_order(
+    data: xr.DataArray,
+    dims: Sequence[Hashable],
+) -> xr.DataArray:
+    """Sort coordinate axes into increasing order.
+
+    Importantly used in two cases throughout the package:
+
+        - Any plotted coordinate axis that is not already monotonic increasing,
+          including monotonic-decreasing axes, is sorted to avoid ambiguous geometry in
+          plotting backends that assume ordered coordinates (e.g. `pcolormesh` edge
+          construction, contour interpolation, and napari array indexing with
+          scale/translate).
+
+        - During resampling/registration steps, `spacing` in spatial dimensions is
+          expected to be positive. Any monotonic-decreasing coordinate is flipped to
+          ensure positive spacing.
+
+    Parameters
+    ----------
+    data : xarray.DataArray
+        Input DataArray whose plotted coordinate axes should be sorted.
+    dims : sequence of hashable
+        Dimensions whose coordinates to consider for sorting.
+
+    Returns
+    -------
+    xarray.DataArray
+        The input with every non-monotonic-increasing coordinate among `dims`
+        sorted into ascending order.
+    """
+    sorted_data = data
+    for dim in dims:
+        if dim not in sorted_data.coords:
+            continue
+        if not sorted_data.get_index(dim).is_monotonic_increasing:
+            sorted_data = sorted_data.sortby(dim)
+    return sorted_data

--- a/src/confusius/io/autc.py
+++ b/src/confusius/io/autc.py
@@ -770,8 +770,8 @@ def convert_autc_dats_to_zarr(
     # but we're currently missing some information for that, such as the elevation
     # aperture and elevation focus.
     zarr_group["z"].attrs["voxdim"] = 0.4
-    zarr_group["y"].attrs["voxdim"] = axial_coords_dim
-    zarr_group["x"].attrs["voxdim"] = lateral_coords_dim
+    zarr_group["y"].attrs["voxdim"] = abs(axial_coords_dim)
+    zarr_group["x"].attrs["voxdim"] = abs(lateral_coords_dim)
 
     if transmit_frequency is not None:
         zarr_iq.attrs["transmit_frequency"] = transmit_frequency

--- a/src/confusius/io/echoframe.py
+++ b/src/confusius/io/echoframe.py
@@ -460,8 +460,8 @@ def convert_echoframe_dat_to_zarr(
     # but we're currently missing some information for that, such as the elevation
     # aperture and elevation focus.
     zarr_group["z"].attrs["voxdim"] = 0.4
-    zarr_group["y"].attrs["voxdim"] = float(np.diff(meta["axial_coords"]).mean())
-    zarr_group["x"].attrs["voxdim"] = float(np.diff(meta["lateral_coords"]).mean())
+    zarr_group["y"].attrs["voxdim"] = abs(float(np.diff(meta["axial_coords"]).mean()))
+    zarr_group["x"].attrs["voxdim"] = abs(float(np.diff(meta["lateral_coords"]).mean()))
     zarr_iq.attrs["transmit_frequency"] = meta["transmit_frequency"]
     zarr_iq.attrs["probe_number_of_elements"] = meta["probe_number_of_elements"]
     zarr_iq.attrs["probe_pitch"] = meta["probe_pitch"]

--- a/src/confusius/plotting/_utils.py
+++ b/src/confusius/plotting/_utils.py
@@ -1,7 +1,6 @@
 """Helpers shared between matplotlib- and napari-based plotting code."""
 
 import warnings
-from collections.abc import Hashable, Sequence
 
 import numpy as np
 import xarray as xr
@@ -39,37 +38,3 @@ def coerce_complex_to_magnitude(data: xr.DataArray, caller: str) -> xr.DataArray
         )
         return xr.ufuncs.abs(data)
     return data
-
-
-def sort_coords_for_plot(
-    data: xr.DataArray,
-    dims: Sequence[Hashable],
-) -> xr.DataArray:
-    """Sort coordinate axes into increasing order before plotting.
-
-    Any plotted coordinate axis that is not already monotonic increasing,
-    including monotonic-decreasing axes, is sorted to avoid ambiguous
-    geometry in plotting backends that assume ordered coordinates (e.g.
-    `pcolormesh` edge construction, contour interpolation, and napari array
-    indexing with scale/translate).
-
-    Parameters
-    ----------
-    data : xarray.DataArray
-        Input DataArray whose plotted coordinate axes should be sorted.
-    dims : sequence of hashable
-        Dimensions whose coordinates to consider for sorting.
-
-    Returns
-    -------
-    xarray.DataArray
-        The input with every non-monotonic-increasing coordinate among `dims`
-        sorted into ascending order.
-    """
-    sorted_data = data
-    for dim in dims:
-        if dim not in sorted_data.coords:
-            continue
-        if not sorted_data.get_index(dim).is_monotonic_increasing:
-            sorted_data = sorted_data.sortby(dim)
-    return sorted_data

--- a/src/confusius/plotting/image.py
+++ b/src/confusius/plotting/image.py
@@ -7,6 +7,7 @@ import numpy as np
 import xarray as xr
 
 from confusius._utils.atlas import build_atlas_cmap_and_norm
+from confusius._utils.coordinates import sort_coords_into_increasing_order
 from confusius._utils.plotting import blend_red_cyan, scale_min_max
 from confusius._utils.stack import find_stack_level
 from confusius.extract import extract_with_mask
@@ -14,10 +15,7 @@ from confusius.plotting._hover import (
     _HoverManager,
     _normalize_roi_labels,
 )
-from confusius.plotting._utils import (
-    coerce_complex_to_magnitude,
-    sort_coords_for_plot,
-)
+from confusius.plotting._utils import coerce_complex_to_magnitude
 from confusius.signal import clean
 from confusius.validation import validate_matching_coordinates, validate_time_series
 
@@ -597,7 +595,7 @@ class VolumePlotter:
                 f"Data must be 3D, but got shape {data.shape} with dims "
                 f"{list(data.dims)}."
             )
-        return sort_coords_for_plot(data, data.dims)
+        return sort_coords_into_increasing_order(data, data.dims)
 
     def _resolve_axes_layout(
         self,
@@ -1370,7 +1368,7 @@ class VolumePlotter:
         if mask.ndim != 3:
             raise ValueError(f"mask must be 3D, got shape {mask.shape}")
 
-        mask = sort_coords_for_plot(mask, mask.dims)
+        mask = sort_coords_into_increasing_order(mask, mask.dims)
 
         unique_labels = sorted(
             [label for label in np.unique(mask.values) if label != 0]

--- a/src/confusius/plotting/napari.py
+++ b/src/confusius/plotting/napari.py
@@ -10,12 +10,12 @@ import xarray as xr
 from napari.utils.colormaps import DirectLabelColormap
 
 from confusius._utils.atlas import build_atlas_cmap_and_norm
-from confusius._utils.coordinates import get_coordinate_spacings_best_effort
-from confusius._utils.stack import find_stack_level
-from confusius.plotting._utils import (
-    coerce_complex_to_magnitude,
-    sort_coords_for_plot,
+from confusius._utils.coordinates import (
+    get_coordinate_spacings_best_effort,
+    sort_coords_into_increasing_order,
 )
+from confusius._utils.stack import find_stack_level
+from confusius.plotting._utils import coerce_complex_to_magnitude
 
 if TYPE_CHECKING:
     from napari import Viewer
@@ -124,14 +124,14 @@ def plot_napari(
     time_dim = "time" if "time" in all_dims else None
     spatial_dims = [d for d in all_dims if d != time_dim]
 
-    data = sort_coords_for_plot(data, spatial_dims)
-
     if dim_order is not None and set(dim_order) != set(spatial_dims):
         raise ValueError(
             f"dim_order {dim_order} does not match spatial dimensions {spatial_dims}. "
             "Ensure 'dim_order' contains all spatial dimension names."
         )
 
+    data = sort_coords_into_increasing_order(data, spatial_dims)
+    # spacing is ensured to be positive in spatial_dims by `sort_coords_into_increasing_order`
     spacing, non_uniform = get_coordinate_spacings_best_effort(data)
     for dim in non_uniform:
         warnings.warn(
@@ -367,6 +367,8 @@ def draw_napari_labels(
     time_dim = "time" if "time" in all_dims else None
     spatial_dims = [d for d in all_dims if d != time_dim]
 
+    data = sort_coords_into_increasing_order(data, spatial_dims)
+    # spacing is ensured to be positive in spatial_dims by `sort_coords_into_increasing_order`
     spacing = data.fusi.spacing
     spatial_scale = [
         s if (s := spacing[dim]) is not None else 1.0 for dim in spatial_dims

--- a/src/confusius/registration/_utils.py
+++ b/src/confusius/registration/_utils.py
@@ -1,12 +1,14 @@
 """Internal utilities shared by registration modules."""
 
 import os
-from copy import deepcopy
 from contextlib import contextmanager
+from copy import deepcopy
 from typing import TYPE_CHECKING, Generator
 
 import numpy as np
 import xarray as xr
+
+from confusius._utils.coordinates import sort_coords_into_increasing_order
 
 if TYPE_CHECKING:
     import SimpleITK as sitk
@@ -94,16 +96,21 @@ def dataarray_to_sitk_image(da: xr.DataArray) -> "sitk.Image":
     """
     import SimpleITK as sitk
 
-    spacing_dict = da.fusi.spacing
-    origin_dict = da.fusi.origin
+    all_dims = list(da.dims)
+    time_dim = "time" if "time" in all_dims else None
+    spatial_dims = [d for d in all_dims if d != time_dim]
 
-    has_time = "time" in da.dims
-    spacing = tuple(
-        s if s is not None else 1.0 for d, s in spacing_dict.items() if str(d) != "time"
-    )
+    da = sort_coords_into_increasing_order(da, spatial_dims)
+
+    spacing_dict = da.fusi.spacing
+    spacing = [
+        s if (s := spacing_dict[dim]) is not None else 1.0 for dim in spatial_dims
+    ]
+
+    origin_dict: dict[str, float] = da.fusi.origin
     origin = tuple(o for d, o in origin_dict.items() if str(d) != "time")
 
-    if has_time:
+    if "time" in da.dims:
         data = da.values
         time_idx = da.dims.index("time")
         # SimpleITK expects the vector dimension to be the last axis, so move time

--- a/src/confusius/registration/bspline.py
+++ b/src/confusius/registration/bspline.py
@@ -32,6 +32,7 @@ import numpy as np
 import numpy.typing as npt
 import xarray as xr
 
+from confusius._utils.coordinates import sort_coords_into_increasing_order
 from confusius.registration.affines import affine_to_sitk_linear_transform
 
 if TYPE_CHECKING:
@@ -152,6 +153,7 @@ def _dataarray_to_sitk_bspline(da: xr.DataArray) -> "sitk.Transform":
     direction_sitk = direction_zyx[np.ix_(perm, perm)]
 
     spatial_dims = list(da.dims[1:])  # e.g. ["z", "y", "x"]
+    da = sort_coords_into_increasing_order(da, spatial_dims)
 
     # Recover grid geometry from DataArray coordinates (z, y, x order).
     # The coordinates store the physical position of each control-point node;

--- a/src/confusius/registration/motion.py
+++ b/src/confusius/registration/motion.py
@@ -211,15 +211,12 @@ def compute_framewise_displacement(
     n_frames = len(affines)
     ndim = reference.ndim
 
-    spacing_dict = reference.fusi.spacing
-    origin_dict = reference.fusi.origin
-
     coords_1d = []
     for dim in (str(d) for d in reference.dims):
-        sp = spacing_dict.get(dim) or 1.0
-        orig = origin_dict.get(dim, 0.0)
-        n = reference.sizes[dim]
-        coords_1d.append(orig + np.arange(n) * sp)
+        if dim in reference.coords:
+            coords_1d.append(np.atleast_1d(reference.coords[dim].values).astype(float))
+        else:
+            coords_1d.append(np.arange(reference.sizes[dim], dtype=float))
 
     grids = np.meshgrid(*coords_1d, indexing="ij")
     points = np.stack([g.ravel() for g in grids], axis=1)  # (n_voxels, ndim)

--- a/src/confusius/registration/resampling.py
+++ b/src/confusius/registration/resampling.py
@@ -7,6 +7,7 @@ import numpy as np
 import numpy.typing as npt
 import xarray as xr
 
+from confusius._utils.coordinates import sort_coords_into_increasing_order
 from confusius.registration._utils import (
     dataarray_to_sitk_image,
     replace_affines_attr,
@@ -220,10 +221,13 @@ def resample_like(
             f"'reference' must be 2D or 3D; got {reference.ndim}D array with dims {reference.dims}."
         )
 
-    shape = list(reference.sizes[str(d)] for d in reference.dims)
+    dims = list(reference.dims)
+
+    reference = sort_coords_into_increasing_order(reference, dims)
+    shape = list(reference.sizes[str(d)] for d in dims)
     spacing = [s if s is not None else 1.0 for s in reference.fusi.spacing.values()]
     origin = list(reference.fusi.origin.values())
-    dims = [str(d) for d in reference.dims]
+    dims = [str(d) for d in dims]
 
     result = resample_volume(
         moving,

--- a/src/confusius/spatial/smooth.py
+++ b/src/confusius/spatial/smooth.py
@@ -153,7 +153,7 @@ def smooth_volume(
                 "dict to explicitly select only the dimensions to smooth, e.g. "
                 f"fwhm={{'{dim}': value}} to include or omit '{dim}'."
             )
-        smooth_spacing[dim] = s
+        smooth_spacing[dim] = abs(s)
 
     if hasattr(data.data, "chunks"):
         for dim in smooth_dims:

--- a/tests/unit/test_spatial/test_smooth.py
+++ b/tests/unit/test_spatial/test_smooth.py
@@ -27,7 +27,9 @@ class TestSmoothVolume:
         expected_sigmas = [
             fwhm * fwhm_to_sigma / _spacing(vol, d) for d in ["z", "y", "x"]
         ]
-        expected = scipy.ndimage.gaussian_filter(vol.values.astype(float), expected_sigmas)
+        expected = scipy.ndimage.gaussian_filter(
+            vol.values.astype(float), expected_sigmas
+        )
 
         np.testing.assert_allclose(smoothed.values, expected, rtol=1e-10)
 
@@ -42,7 +44,9 @@ class TestSmoothVolume:
         expected_sigmas = [0.0] + [
             fwhm * fwhm_to_sigma / _spacing(vol, d) for d in ["z", "y", "x"]
         ]
-        expected = scipy.ndimage.gaussian_filter(vol.values.astype(float), expected_sigmas)
+        expected = scipy.ndimage.gaussian_filter(
+            vol.values.astype(float), expected_sigmas
+        )
 
         np.testing.assert_allclose(smoothed.values, expected, rtol=1e-10)
 
@@ -57,7 +61,9 @@ class TestSmoothVolume:
         expected_sigmas = [
             fwhm_dict[d] * fwhm_to_sigma / _spacing(vol, d) for d in ["z", "y", "x"]
         ]
-        expected = scipy.ndimage.gaussian_filter(vol.values.astype(float), expected_sigmas)
+        expected = scipy.ndimage.gaussian_filter(
+            vol.values.astype(float), expected_sigmas
+        )
 
         np.testing.assert_allclose(smoothed.values, expected, rtol=1e-10)
 
@@ -74,7 +80,9 @@ class TestSmoothVolume:
             0.0,  # y not smoothed.
             fwhm * fwhm_to_sigma / _spacing(vol, "x"),
         ]
-        expected = scipy.ndimage.gaussian_filter(vol.values.astype(float), expected_sigmas)
+        expected = scipy.ndimage.gaussian_filter(
+            vol.values.astype(float), expected_sigmas
+        )
 
         np.testing.assert_allclose(smoothed.values, expected, rtol=1e-10)
 
@@ -91,7 +99,9 @@ class TestSmoothVolume:
             0.0,
             fwhm_dict["x"] * fwhm_to_sigma / _spacing(vol, "x"),
         ]
-        expected = scipy.ndimage.gaussian_filter(vol.values.astype(float), expected_sigmas)
+        expected = scipy.ndimage.gaussian_filter(
+            vol.values.astype(float), expected_sigmas
+        )
 
         np.testing.assert_allclose(smoothed.values, expected, rtol=1e-10)
 
@@ -109,7 +119,9 @@ class TestSmoothVolume:
             0.0,
             0.0,
         ]
-        expected = scipy.ndimage.gaussian_filter(vol.values.astype(float), expected_sigmas)
+        expected = scipy.ndimage.gaussian_filter(
+            vol.values.astype(float), expected_sigmas
+        )
 
         np.testing.assert_allclose(smoothed.values, expected, rtol=1e-10)
 
@@ -129,6 +141,21 @@ class TestSmoothVolume:
         vol = sample_3d_volume
         smoothed = smooth_volume(vol, fwhm=0.0)
         np.testing.assert_allclose(smoothed.values, vol.values, rtol=1e-10)
+
+    def test_decreasing_coord_matches_increasing(self, sample_3d_volume):
+        """Reversing a coord axis must not change smoothed values (issue #146).
+
+        Spacing magnitude — not its sign — determines the Gaussian kernel width.
+        Flipping only the coordinate (data values untouched) preserves the
+        physical voxel size, so the smoothed pixel values must be identical.
+        """
+        vol = sample_3d_volume
+        reversed_vol = vol.assign_coords(z=vol.coords["z"].values[::-1])
+
+        smoothed = smooth_volume(vol, fwhm=0.4)
+        smoothed_reversed = smooth_volume(reversed_vol, fwhm=0.4)
+
+        np.testing.assert_array_equal(smoothed_reversed.values, smoothed.values)
 
     def test_singleton_dim_is_not_smoothed(self):
         """Length-1 dimensions should be ignored instead of requiring spacing."""
@@ -152,7 +179,9 @@ class TestSmoothVolume:
             0.0,
             0.4 * fwhm_to_sigma / _spacing(vol, "x"),
         ]
-        expected = scipy.ndimage.gaussian_filter(vol.values.astype(float), expected_sigmas)
+        expected = scipy.ndimage.gaussian_filter(
+            vol.values.astype(float), expected_sigmas
+        )
 
         np.testing.assert_allclose(smoothed.values, expected, rtol=1e-10)
 
@@ -232,13 +261,17 @@ class TestSmoothVolume:
             dims=["z", "y", "x"],
             coords={"z": coords, "y": np.arange(8) * 0.1, "x": np.arange(10) * 0.1},
         )
-        with pytest.raises(ValueError, match="non-uniform or undefined coordinate spacing"):
+        with pytest.raises(
+            ValueError, match="non-uniform or undefined coordinate spacing"
+        ):
             smooth_volume(vol, fwhm=0.3)
 
     def test_raises_missing_coord(self):
         """Should raise ValueError if a smoothed dim has no coordinate."""
         vol = xr.DataArray(np.ones((8, 10, 12)), dims=["z", "y", "x"])
-        with pytest.raises(ValueError, match="non-uniform or undefined coordinate spacing"):
+        with pytest.raises(
+            ValueError, match="non-uniform or undefined coordinate spacing"
+        ):
             smooth_volume(vol, fwhm=0.3)
 
     def test_raises_unknown_fwhm_key(self, sample_3d_volume):


### PR DESCRIPTION
This is a WIP for closing #150 and #151 

Currently, this moves the plotting helper function to sort coordinates into `confusius._utils` and refactor plotting and resampling/registration functions to use it and force monotonic-increasing coordinates in the data.

`smooth_volume` uses abs(spacing) as this is the expected result even if data coordinates are monotonic-decreasing.

## Checklist

- [ ] Tests pass locally (`just t`)
- [ ] Pre-commit hooks pass (`just pc`)
- [ ] Docstring updates after deciding how to handle non-monotonic-increasing coordinates
- [ ] Changelog updated if user-facing
- [ ] Add information about what is decided here in the User Guide
