### PR TITLE
feat: add mask argument to decomposition, connectivity, and first-level GLM

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -23,6 +23,13 @@ Current development version for the next ConfUSIus release.
 
 ### :sparkles: Enhancements
 
+- Added a `mask` argument to the [`PCA`][confusius.decomposition.PCA],
+  [`FastICA`][confusius.decomposition.FastICA],
+  [`SeedBasedMaps`][confusius.connectivity.SeedBasedMaps], and
+  [`FirstLevelModel`][confusius.glm.FirstLevelModel] estimators, restricting fitting
+  and projection to the selected voxels. Output maps retain the full spatial geometry,
+  with voxels outside the mask set to `0`
+  ([#155](https://github.com/confusius-tools/confusius/pull/155)).
 - Added `plot_composite`, `VolumePlotter.add_composite`, and a matching
   `data.fusi.plot.composite` accessor that render two volumes as a red/cyan
   RGB overlay ([#145](https://github.com/confusius-tools/confusius/pull/145)).

--- a/src/confusius/connectivity/seed.py
+++ b/src/confusius/connectivity/seed.py
@@ -358,9 +358,17 @@ def _extract_with_labels_from_masked_space(
     reduction: Literal["mean", "sum", "median", "min", "max", "var", "std"],
 ) -> xr.DataArray:
     """Extract region signals from masked `(time, space)` data without unmasking."""
+    spatial_dims = tuple(str(d) for d in mask.dims)
+    labels_spatial_dims = tuple(str(d) for d in labels.dims if d != "mask")
+    if set(labels_spatial_dims) != set(spatial_dims):
+        raise ValueError(
+            "labels spatial dimensions must match mask dimensions for masked "
+            f"extraction. Expected {spatial_dims}, got {labels_spatial_dims}."
+        )
+
     if "mask" in labels.dims:
-        spatial_dims = [d for d in labels.dims if d != "mask"]
-        labels_masked = labels.where(mask, other=0).stack(space=spatial_dims)
+        labels_masked = labels.where(mask, other=0).transpose("mask", *spatial_dims)
+        labels_masked = labels_masked.stack(space=list(spatial_dims))
         labels_masked = labels_masked.sel(space=data.coords["space"])
 
         region_signals: list[xr.DataArray] = []
@@ -377,7 +385,8 @@ def _extract_with_labels_from_masked_space(
             .transpose("time", "region")
         )
 
-    labels_masked = labels.where(mask, other=0).stack(space=list(labels.dims))
+    labels_masked = labels.where(mask, other=0).transpose(*spatial_dims)
+    labels_masked = labels_masked.stack(space=list(spatial_dims))
     labels_masked = labels_masked.sel(space=data.coords["space"])
 
     region_ids = np.unique(labels_masked.values)

--- a/src/confusius/connectivity/seed.py
+++ b/src/confusius/connectivity/seed.py
@@ -9,9 +9,10 @@ import xarray as xr
 from matplotlib.colors import Normalize
 from sklearn.base import BaseEstimator
 
+from confusius.extract import extract_with_mask, unmask
 from confusius.extract.labels import extract_with_labels
 from confusius.signal import clean
-from confusius.validation import validate_labels, validate_time_series
+from confusius.validation import validate_labels, validate_mask, validate_time_series
 from confusius.validation.coordinates import validate_matching_coordinates
 
 
@@ -115,13 +116,21 @@ class SeedBasedMaps(BaseEstimator):
         provided.
     clean_kwargs : dict, optional
         Keyword arguments forwarded to [`clean`][confusius.signal.clean]. Cleaning is
-        applied to the full data array before computing correlations. If not provided,
+        applied before computing correlations. If `mask` is provided, cleaning is
+        applied to the masked `(time, space)` signals for efficiency. If not provided,
         no cleaning is applied.
 
         !!! warning "Chunking along time"
-            Any operation in `clean_kwargs` that involves detrending or
-            filtering requires the `time` dimension to be un-chunked.
-            Rechunk your data before calling `fit`: `data.chunk({'time': -1})`.
+            Any operation in `clean_kwargs` that involves detrending or filtering
+            requires the `time` dimension to be un-chunked. Rechunk your data before
+            calling `fit`: `data.chunk({'time': -1})`.
+
+    mask : xarray.DataArray, optional
+        Boolean spatial mask selecting which voxels are included in the correlation
+        computation. When provided, voxel signals are first extracted with
+        [`extract_with_mask`][confusius.extract.extract_with_mask], so cleaning and
+        correlation are computed only on masked voxels. Output maps retain the full
+        spatial geometry, with voxels outside the mask set to `0`.
 
     Attributes
     ----------
@@ -205,11 +214,13 @@ class SeedBasedMaps(BaseEstimator):
             "mean", "sum", "median", "min", "max", "var", "std"
         ] = "mean",
         clean_kwargs: dict | None = None,
+        mask: xr.DataArray | None = None,
     ) -> None:
         self.seed_masks = seed_masks
         self.seed_signals = seed_signals
         self.labels_reduction = labels_reduction
         self.clean_kwargs = clean_kwargs
+        self.mask = mask
 
     def fit(self, X: xr.DataArray, y: None = None) -> "SeedBasedMaps":
         """Compute the seed-based correlation maps.
@@ -270,15 +281,33 @@ class SeedBasedMaps(BaseEstimator):
             assert self.seed_signals is not None
             _validate_seed_signals(self.seed_signals, X)
 
-        if self.clean_kwargs is not None:
-            X_clean = clean(X, **self.clean_kwargs)
+        if self.mask is not None:
+            validate_mask(self.mask, X, "mask")
+
+        if self.mask is not None:
+            X_masked = extract_with_mask(X, self.mask)
+            X_for_corr = (
+                clean(X_masked, **self.clean_kwargs)
+                if self.clean_kwargs is not None
+                else X_masked
+            )
         else:
-            X_clean = X
+            X_for_corr = (
+                clean(X, **self.clean_kwargs) if self.clean_kwargs is not None else X
+            )
 
         if self.seed_masks is not None:
-            extracted: xr.DataArray = extract_with_labels(
-                X_clean, self.seed_masks, reduction=self.labels_reduction
-            )
+            if self.mask is not None:
+                extracted = _extract_with_labels_from_masked_space(
+                    X_for_corr,
+                    self.seed_masks,
+                    self.mask,
+                    reduction=self.labels_reduction,
+                )
+            else:
+                extracted = extract_with_labels(
+                    X_for_corr, self.seed_masks, reduction=self.labels_reduction
+                )
         else:
             # self.seed_signals is not None, guaranteed by the mutual-exclusivity check
             # above.
@@ -292,9 +321,14 @@ class SeedBasedMaps(BaseEstimator):
         if extracted.ndim == 1:
             extracted = extracted.expand_dims("region", axis=1)
 
-        self.seed_signals_: xr.DataArray = extracted
+        self.seed_signals_ = extracted
 
-        maps = _compute_correlation_maps(X_clean, extracted)
+        maps_masked = _compute_correlation_maps(X_for_corr, extracted)
+        maps = (
+            unmask(maps_masked, self.mask, fill_value=0.0)
+            if self.mask is not None
+            else maps_masked
+        )
 
         if maps.sizes.get("region", 0) == 1:
             maps = maps.isel(region=0, drop=False)
@@ -315,6 +349,48 @@ class SeedBasedMaps(BaseEstimator):
     def __sklearn_is_fitted__(self) -> bool:
         """Check whether the estimator has been fitted."""
         return hasattr(self, "maps_")
+
+
+def _extract_with_labels_from_masked_space(
+    data: xr.DataArray,
+    labels: xr.DataArray,
+    mask: xr.DataArray,
+    reduction: Literal["mean", "sum", "median", "min", "max", "var", "std"],
+) -> xr.DataArray:
+    """Extract region signals from masked `(time, space)` data without unmasking."""
+    if "mask" in labels.dims:
+        spatial_dims = [d for d in labels.dims if d != "mask"]
+        labels_masked = labels.where(mask, other=0).stack(space=spatial_dims)
+        labels_masked = labels_masked.sel(space=data.coords["space"])
+
+        region_signals: list[xr.DataArray] = []
+        region_names: list[object] = []
+        for i in range(labels_masked.sizes["mask"]):
+            layer = labels_masked.isel(mask=i)
+            selected = data.where(layer != 0)
+            region_signals.append(getattr(selected, reduction)(dim="space"))
+            region_names.append(labels_masked.coords["mask"].values[i])
+
+        return (
+            xr.concat(region_signals, dim="region")
+            .assign_coords(region=region_names)
+            .transpose("time", "region")
+        )
+
+    labels_masked = labels.where(mask, other=0).stack(space=list(labels.dims))
+    labels_masked = labels_masked.sel(space=data.coords["space"])
+
+    region_ids = np.unique(labels_masked.values)
+    region_ids = region_ids[region_ids != 0]
+    region_signals = [
+        getattr(data.where(labels_masked == region_id), reduction)(dim="space")
+        for region_id in region_ids
+    ]
+    return (
+        xr.concat(region_signals, dim="region")
+        .assign_coords(region=region_ids)
+        .transpose("time", "region")
+    )
 
 
 def _compute_correlation_maps(

--- a/src/confusius/decomposition/_base.py
+++ b/src/confusius/decomposition/_base.py
@@ -10,7 +10,8 @@ import xarray as xr
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.validation import check_is_fitted
 
-from confusius.validation import validate_time_series
+from confusius.extract import unmask
+from confusius.validation import validate_mask, validate_time_series
 
 
 class _BaseFUSIDecomposer(BaseEstimator, TransformerMixin):
@@ -27,6 +28,7 @@ class _BaseFUSIDecomposer(BaseEstimator, TransformerMixin):
     """
 
     _signals_long_name: str
+    mask: xr.DataArray | None
 
     # Fitted attributes, set by subclasses in fit.
     _estimator: Any
@@ -40,6 +42,9 @@ class _BaseFUSIDecomposer(BaseEstimator, TransformerMixin):
     spatial_dims_: tuple[str, ...]
     _spatial_sizes_: dict[str, int]
     _feature_coord_: xr.DataArray
+    _full_feature_coord_: xr.DataArray
+    _feature_mask_: npt.NDArray[np.bool_]
+    _reconstruction_mask_: xr.DataArray
     _fit_attrs_: dict[str, Any]
     _fit_name_: Hashable | None
     n_features_in_: int
@@ -112,7 +117,7 @@ class _BaseFUSIDecomposer(BaseEstimator, TransformerMixin):
             Decomposed signals in component space.
         """
         check_is_fitted(self)
-        X_proc, _, _ = self._prepare_data(
+        X_proc, _, _, _ = self._prepare_data(
             X,
             check_layout=True,
             operation_name=f"{type(self).__name__}.transform",
@@ -190,13 +195,14 @@ class _BaseFUSIDecomposer(BaseEstimator, TransformerMixin):
             reconstructed = self._spatial_inverse_transform(signals)
         else:
             reconstructed = self._estimator.inverse_transform(signals)
-        reconstructed_stacked = xr.DataArray(
+
+        reconstructed_da = unmask(
             reconstructed,
-            dims=["time", "feature"],
-            coords={"time": time_coord, "feature": self._feature_coord_},
+            self._reconstruction_mask_,
+            new_dims=["time"],
+            new_dims_coords={"time": np.asarray(time_coord)},
+            attrs=self._fit_attrs_,
         )
-        reconstructed_da = reconstructed_stacked.unstack("feature")
-        reconstructed_da.attrs.update(self._fit_attrs_)
         reconstructed_da.name = self._fit_name_
         return reconstructed_da
 
@@ -205,7 +211,9 @@ class _BaseFUSIDecomposer(BaseEstimator, TransformerMixin):
         X: xr.DataArray,
         check_layout: bool,
         operation_name: str,
-    ) -> tuple[npt.NDArray[np.floating], xr.DataArray, tuple[str, ...]]:
+    ) -> tuple[
+        npt.NDArray[np.floating], xr.DataArray, tuple[str, ...], npt.NDArray[np.bool_]
+    ]:
         """Validate and stack time series data into a 2D feature matrix.
 
         Parameters
@@ -221,13 +229,15 @@ class _BaseFUSIDecomposer(BaseEstimator, TransformerMixin):
         Returns
         -------
         X_proc : (time, feature) numpy.ndarray
-            Input data stacked over spatial dimensions. Dtype is preserved from `X`;
-            sklearn handles any required type promotion internally.
+            Input data stacked over selected spatial features. Dtype is preserved from
+            `X`; sklearn handles any required type promotion internally.
         X_stacked : (time, feature) xarray.DataArray
             View of `X` with all spatial dimensions stacked into a single `feature`
             dimension.
         spatial_dims : tuple[str, ...]
             Spatial dimensions used to order and stack the input data.
+        feature_mask : (n_features,) numpy.ndarray
+            Boolean mask selecting features used for fitting/projection.
 
         Raises
         ------
@@ -262,8 +272,31 @@ class _BaseFUSIDecomposer(BaseEstimator, TransformerMixin):
 
         X_ordered = X.transpose("time", *spatial_dims)
         X_stacked = X_ordered.stack(feature=list(spatial_dims))
-        X_proc = np.asarray(X_stacked.values)
-        return X_proc, X_stacked, spatial_dims
+
+        if getattr(self, "mask", None) is not None:
+            mask = self.mask
+            assert mask is not None
+            validate_mask(mask, X_ordered, "mask")
+
+            template = X_ordered.isel(time=0, drop=True)
+            coord_updates = {
+                dim: template.coords[dim]
+                for dim in mask.dims
+                if dim in mask.coords and dim in template.coords
+            }
+            mask_aligned = mask.assign_coords(coord_updates).reindex_like(template)
+            if bool(mask_aligned.isnull().any()):
+                raise ValueError(
+                    "mask could not be aligned to data coordinates. If coordinates are "
+                    "nearly equal but not exact, resample or round them before fitting."
+                )
+
+            feature_mask = mask_aligned.values.ravel().astype(bool)
+        else:
+            feature_mask = np.ones(X_stacked.sizes["feature"], dtype=bool)
+
+        X_proc = np.asarray(X_stacked.isel(feature=feature_mask).values)
+        return X_proc, X_stacked, spatial_dims, feature_mask
 
     def _reshape_component_matrix(
         self,
@@ -289,13 +322,14 @@ class _BaseFUSIDecomposer(BaseEstimator, TransformerMixin):
             Matrix unstacked to the original spatial dimensions, with
             `attrs["long_name"]` and `attrs["cmap"]` set.
         """
-        matrix_stacked = xr.DataArray(
+        reshaped = unmask(
             matrix,
-            dims=["component", "feature"],
-            coords={"component": component_coord, "feature": self._feature_coord_},
+            self._reconstruction_mask_,
+            new_dims=["component"],
+            new_dims_coords={"component": component_coord},
+            attrs={"long_name": long_name, "cmap": "coolwarm"},
+            fill_value=0.0,
         )
-        reshaped = matrix_stacked.unstack("feature")
-        reshaped.attrs.update({"long_name": long_name, "cmap": "coolwarm"})
         return reshaped
 
     def _reshape_mean(self, mean: npt.NDArray[np.floating]) -> xr.DataArray:
@@ -311,12 +345,7 @@ class _BaseFUSIDecomposer(BaseEstimator, TransformerMixin):
         (...) xarray.DataArray
             Mean unstacked to the original spatial dimensions.
         """
-        mean_stacked = xr.DataArray(
-            mean,
-            dims=["feature"],
-            coords={"feature": self._feature_coord_},
-        )
-        return mean_stacked.unstack("feature")
+        return unmask(mean, self._reconstruction_mask_, attrs={}, fill_value=0.0)
 
     def _store_fit_metadata(
         self,
@@ -324,6 +353,7 @@ class _BaseFUSIDecomposer(BaseEstimator, TransformerMixin):
         X_proc: npt.NDArray[np.floating],
         X_stacked: xr.DataArray,
         spatial_dims: tuple[str, ...],
+        feature_mask: npt.NDArray[np.bool_],
     ) -> None:
         """Store spatial and array metadata from a fit call.
 
@@ -343,7 +373,19 @@ class _BaseFUSIDecomposer(BaseEstimator, TransformerMixin):
         """
         self.spatial_dims_ = spatial_dims
         self._spatial_sizes_ = {dim: int(X.sizes[dim]) for dim in self.spatial_dims_}
-        self._feature_coord_ = X_stacked.coords["feature"]
+        self._full_feature_coord_ = X_stacked.coords["feature"]
+        self._feature_mask_ = feature_mask
+        self._feature_coord_ = X_stacked.isel(feature=feature_mask).coords["feature"]
+        template = X.transpose("time", *self.spatial_dims_).isel(time=0, drop=True)
+        self._reconstruction_mask_ = xr.DataArray(
+            feature_mask.reshape(tuple(template.sizes[d] for d in self.spatial_dims_)),
+            dims=self.spatial_dims_,
+            coords={
+                d: template.coords[d]
+                for d in self.spatial_dims_
+                if d in template.coords
+            },
+        )
         self._fit_attrs_ = dict(X.attrs)
         self._fit_name_ = X.name
         self.n_features_in_ = int(X_proc.shape[1])

--- a/src/confusius/decomposition/_base.py
+++ b/src/confusius/decomposition/_base.py
@@ -276,12 +276,7 @@ class _BaseFUSIDecomposer(BaseEstimator, TransformerMixin):
         if getattr(self, "mask", None) is not None:
             mask = self.mask
             assert mask is not None
-            validate_mask(mask, X_ordered, "mask")
-            if tuple(str(dim) for dim in mask.dims) != spatial_dims:
-                raise ValueError(
-                    "mask dimensions must match the full spatial dimensions of X "
-                    f"in the same order. Expected {spatial_dims}, got {tuple(mask.dims)}."
-                )
+            validate_mask(mask, X_ordered, "mask", require_exact_dims=True)
 
             template = X_ordered.isel(time=0, drop=True)
             coord_updates = {

--- a/src/confusius/decomposition/_base.py
+++ b/src/confusius/decomposition/_base.py
@@ -277,14 +277,20 @@ class _BaseFUSIDecomposer(BaseEstimator, TransformerMixin):
             mask = self.mask
             assert mask is not None
             validate_mask(mask, X_ordered, "mask")
+            if tuple(str(dim) for dim in mask.dims) != spatial_dims:
+                raise ValueError(
+                    "mask dimensions must match the full spatial dimensions of X "
+                    f"in the same order. Expected {spatial_dims}, got {tuple(mask.dims)}."
+                )
 
             template = X_ordered.isel(time=0, drop=True)
             coord_updates = {
                 dim: template.coords[dim]
-                for dim in mask.dims
+                for dim in spatial_dims
                 if dim in mask.coords and dim in template.coords
             }
-            mask_aligned = mask.assign_coords(coord_updates).reindex_like(template)
+            mask_aligned = mask.assign_coords(coord_updates).transpose(*spatial_dims)
+            mask_aligned = mask_aligned.reindex_like(template)
             if bool(mask_aligned.isnull().any()):
                 raise ValueError(
                     "mask could not be aligned to data coordinates. If coordinates are "

--- a/src/confusius/decomposition/_base.py
+++ b/src/confusius/decomposition/_base.py
@@ -10,7 +10,7 @@ import xarray as xr
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.validation import check_is_fitted
 
-from confusius.extract import unmask
+from confusius.extract import extract_with_mask, unmask
 from confusius.validation import validate_mask, validate_time_series
 
 
@@ -41,9 +41,6 @@ class _BaseFUSIDecomposer(BaseEstimator, TransformerMixin):
     # Set by _store_fit_metadata.
     spatial_dims_: tuple[str, ...]
     _spatial_sizes_: dict[str, int]
-    _feature_coord_: xr.DataArray
-    _full_feature_coord_: xr.DataArray
-    _feature_mask_: npt.NDArray[np.bool_]
     _reconstruction_mask_: xr.DataArray
     _fit_attrs_: dict[str, Any]
     _fit_name_: Hashable | None
@@ -117,7 +114,7 @@ class _BaseFUSIDecomposer(BaseEstimator, TransformerMixin):
             Decomposed signals in component space.
         """
         check_is_fitted(self)
-        X_proc, _, _, _ = self._prepare_data(
+        X_proc, _, _ = self._prepare_data(
             X,
             check_layout=True,
             operation_name=f"{type(self).__name__}.transform",
@@ -211,9 +208,7 @@ class _BaseFUSIDecomposer(BaseEstimator, TransformerMixin):
         X: xr.DataArray,
         check_layout: bool,
         operation_name: str,
-    ) -> tuple[
-        npt.NDArray[np.floating], xr.DataArray, tuple[str, ...], npt.NDArray[np.bool_]
-    ]:
+    ) -> tuple[npt.NDArray[np.floating], tuple[str, ...], npt.NDArray[np.bool_]]:
         """Validate and stack time series data into a 2D feature matrix.
 
         Parameters
@@ -231,9 +226,6 @@ class _BaseFUSIDecomposer(BaseEstimator, TransformerMixin):
         X_proc : (time, feature) numpy.ndarray
             Input data stacked over selected spatial features. Dtype is preserved from
             `X`; sklearn handles any required type promotion internally.
-        X_stacked : (time, feature) xarray.DataArray
-            View of `X` with all spatial dimensions stacked into a single `feature`
-            dimension.
         spatial_dims : tuple[str, ...]
             Spatial dimensions used to order and stack the input data.
         feature_mask : (n_features,) numpy.ndarray
@@ -271,33 +263,16 @@ class _BaseFUSIDecomposer(BaseEstimator, TransformerMixin):
             spatial_dims = input_spatial_dims
 
         X_ordered = X.transpose("time", *spatial_dims)
-        X_stacked = X_ordered.stack(feature=list(spatial_dims))
 
         if getattr(self, "mask", None) is not None:
             mask = self.mask
             assert mask is not None
             validate_mask(mask, X_ordered, "mask", require_exact_dims=True)
-
-            template = X_ordered.isel(time=0, drop=True)
-            coord_updates = {
-                dim: template.coords[dim]
-                for dim in spatial_dims
-                if dim in mask.coords and dim in template.coords
-            }
-            mask_aligned = mask.assign_coords(coord_updates).transpose(*spatial_dims)
-            mask_aligned = mask_aligned.reindex_like(template)
-            if bool(mask_aligned.isnull().any()):
-                raise ValueError(
-                    "mask could not be aligned to data coordinates. If coordinates are "
-                    "nearly equal but not exact, resample or round them before fitting."
-                )
-
-            feature_mask = mask_aligned.values.ravel().astype(bool)
         else:
-            feature_mask = np.ones(X_stacked.sizes["feature"], dtype=bool)
+            mask = xr.ones_like(X_ordered[0], dtype=bool)
 
-        X_proc = np.asarray(X_stacked.isel(feature=feature_mask).values)
-        return X_proc, X_stacked, spatial_dims, feature_mask
+        X_proc = extract_with_mask(X_ordered, mask).values
+        return X_proc, spatial_dims, mask.values.ravel().astype(bool)
 
     def _reshape_component_matrix(
         self,
@@ -352,13 +327,12 @@ class _BaseFUSIDecomposer(BaseEstimator, TransformerMixin):
         self,
         X: xr.DataArray,
         X_proc: npt.NDArray[np.floating],
-        X_stacked: xr.DataArray,
         spatial_dims: tuple[str, ...],
         feature_mask: npt.NDArray[np.bool_],
     ) -> None:
         """Store spatial and array metadata from a fit call.
 
-        Sets `spatial_dims_`, `_spatial_sizes_`, `_feature_coord_`, `_fit_attrs_`,
+        Sets `spatial_dims_`, `_spatial_sizes_`, `_reconstruction_mask_`, `_fit_attrs_`,
         `_fit_name_`, and `n_features_in_` on the estimator.
 
         Parameters
@@ -366,17 +340,14 @@ class _BaseFUSIDecomposer(BaseEstimator, TransformerMixin):
         X : (time, ...) xarray.DataArray
             Original input passed to `fit`.
         X_proc : (time, feature) numpy.ndarray
-            Stacked data returned by `_prepare_data`.
-        X_stacked : (time, feature) xarray.DataArray
-            Stacked view returned by `_prepare_data`.
+            Stacked data over selected features returned by `_prepare_data`.
         spatial_dims : tuple[str, ...]
             Spatial dimensions returned by `_prepare_data`.
+        feature_mask : (n_features,) numpy.ndarray
+            Boolean mask selecting features used for fitting/projection.
         """
         self.spatial_dims_ = spatial_dims
         self._spatial_sizes_ = {dim: int(X.sizes[dim]) for dim in self.spatial_dims_}
-        self._full_feature_coord_ = X_stacked.coords["feature"]
-        self._feature_mask_ = feature_mask
-        self._feature_coord_ = X_stacked.isel(feature=feature_mask).coords["feature"]
         template = X.transpose("time", *self.spatial_dims_).isel(time=0, drop=True)
         self._reconstruction_mask_ = xr.DataArray(
             feature_mask.reshape(tuple(template.sizes[d] for d in self.spatial_dims_)),

--- a/src/confusius/decomposition/fastica.py
+++ b/src/confusius/decomposition/fastica.py
@@ -98,6 +98,9 @@ class FastICA(_BaseFUSIDecomposer):
     random_state : int, optional
         Used to initialize `w_init` when not provided, with a normal distribution. Pass
         an int for reproducible results across multiple function calls.
+    mask : xarray.DataArray, optional
+        Boolean spatial mask selecting voxels to include during fitting and projection.
+        Must match the spatial dimensions and coordinates of the input data.
 
     Attributes
     ----------
@@ -172,6 +175,7 @@ class FastICA(_BaseFUSIDecomposer):
         w_init: npt.NDArray[np.floating] | None = None,
         whiten_solver: Literal["svd", "eigh"] = "svd",
         random_state: int | None = None,
+        mask: xr.DataArray | None = None,
     ) -> None:
         self.n_components = n_components
         self.mode = mode
@@ -184,6 +188,7 @@ class FastICA(_BaseFUSIDecomposer):
         self.w_init = w_init
         self.whiten_solver = whiten_solver
         self.random_state = random_state
+        self.mask = mask
 
     def fit(self, X: xr.DataArray, y: None = None) -> "FastICA":
         """Fit FastICA on `(time, ...)` fUSI data.
@@ -215,7 +220,7 @@ class FastICA(_BaseFUSIDecomposer):
                 f"mode must be 'spatial' or 'temporal', got '{self.mode}'."
             )
 
-        X_proc, X_stacked, spatial_dims = self._prepare_data(
+        X_proc, X_stacked, spatial_dims, feature_mask = self._prepare_data(
             X,
             check_layout=False,
             operation_name="FastICA.fit",
@@ -234,7 +239,7 @@ class FastICA(_BaseFUSIDecomposer):
             random_state=self.random_state,
         )
 
-        self._store_fit_metadata(X, X_proc, X_stacked, spatial_dims)
+        self._store_fit_metadata(X, X_proc, X_stacked, spatial_dims, feature_mask)
 
         if self.mode == "spatial":
             self._fit_spatial(fastica, X_proc)

--- a/src/confusius/decomposition/fastica.py
+++ b/src/confusius/decomposition/fastica.py
@@ -220,7 +220,7 @@ class FastICA(_BaseFUSIDecomposer):
                 f"mode must be 'spatial' or 'temporal', got '{self.mode}'."
             )
 
-        X_proc, X_stacked, spatial_dims, feature_mask = self._prepare_data(
+        X_proc, spatial_dims, feature_mask = self._prepare_data(
             X,
             check_layout=False,
             operation_name="FastICA.fit",
@@ -239,7 +239,7 @@ class FastICA(_BaseFUSIDecomposer):
             random_state=self.random_state,
         )
 
-        self._store_fit_metadata(X, X_proc, X_stacked, spatial_dims, feature_mask)
+        self._store_fit_metadata(X, X_proc, spatial_dims, feature_mask)
 
         if self.mode == "spatial":
             self._fit_spatial(fastica, X_proc)

--- a/src/confusius/decomposition/pca.py
+++ b/src/confusius/decomposition/pca.py
@@ -107,6 +107,9 @@ class PCA(_BaseFUSIDecomposer):
         - `"spatial"`: fit on `(voxels, time)`. The principal axes are time courses; the
           projected components are spatial maps that capture dominant variance across
           time.
+    mask : xarray.DataArray, optional
+        Boolean spatial mask selecting voxels to include during fitting and projection.
+        Must match the spatial dimensions and coordinates of the input data.
 
     Attributes
     ----------
@@ -194,6 +197,7 @@ class PCA(_BaseFUSIDecomposer):
         power_iteration_normalizer: Literal["auto", "QR", "LU", "none"] = "auto",
         random_state: int | None = None,
         mode: Literal["temporal", "spatial"] = "temporal",
+        mask: xr.DataArray | None = None,
     ) -> None:
         self.n_components = n_components
         self.whiten = whiten
@@ -204,6 +208,7 @@ class PCA(_BaseFUSIDecomposer):
         self.power_iteration_normalizer = power_iteration_normalizer
         self.random_state = random_state
         self.mode = mode
+        self.mask = mask
 
     def fit(self, X: xr.DataArray, y: None = None) -> "PCA":
         """Fit PCA on `(time, ...)` fUSI data.
@@ -235,7 +240,7 @@ class PCA(_BaseFUSIDecomposer):
                 f"mode must be 'temporal' or 'spatial', got '{self.mode}'."
             )
 
-        X_proc, X_stacked, spatial_dims = self._prepare_data(
+        X_proc, X_stacked, spatial_dims, feature_mask = self._prepare_data(
             X,
             check_layout=False,
             operation_name="PCA.fit",
@@ -252,7 +257,7 @@ class PCA(_BaseFUSIDecomposer):
             random_state=self.random_state,
         )
 
-        self._store_fit_metadata(X, X_proc, X_stacked, spatial_dims)
+        self._store_fit_metadata(X, X_proc, X_stacked, spatial_dims, feature_mask)
 
         if self.mode == "temporal":
             self._fit_temporal(pca, X_proc)

--- a/src/confusius/decomposition/pca.py
+++ b/src/confusius/decomposition/pca.py
@@ -240,7 +240,7 @@ class PCA(_BaseFUSIDecomposer):
                 f"mode must be 'temporal' or 'spatial', got '{self.mode}'."
             )
 
-        X_proc, X_stacked, spatial_dims, feature_mask = self._prepare_data(
+        X_proc, spatial_dims, feature_mask = self._prepare_data(
             X,
             check_layout=False,
             operation_name="PCA.fit",
@@ -257,7 +257,7 @@ class PCA(_BaseFUSIDecomposer):
             random_state=self.random_state,
         )
 
-        self._store_fit_metadata(X, X_proc, X_stacked, spatial_dims, feature_mask)
+        self._store_fit_metadata(X, X_proc, spatial_dims, feature_mask)
 
         if self.mode == "temporal":
             self._fit_temporal(pca, X_proc)

--- a/src/confusius/glm/first_level.py
+++ b/src/confusius/glm/first_level.py
@@ -66,22 +66,6 @@ def _flatten_spatial(
     return values, spatial_dims, spatial_shape
 
 
-def _validate_full_spatial_mask_dims(mask: xr.DataArray, data: xr.DataArray) -> None:
-    """Validate that `mask` covers all non-time dims in the same order.
-
-    First-level GLM currently treats every non-`time` dimension as part of the voxel
-    layout. The mask must therefore span exactly those dimensions in the same order so
-    masked extraction still produces `(time, space)` data.
-    """
-    spatial_dims = tuple(str(d) for d in data.dims if d != "time")
-    mask_dims = tuple(str(d) for d in mask.dims)
-    if mask_dims != spatial_dims:
-        raise ValueError(
-            "mask dimensions must match all non-time dimensions of the input data "
-            f"in the same order. Expected {spatial_dims}, got {mask_dims}."
-        )
-
-
 class FirstLevelModel(BaseEstimator):
     """First-level GLM estimator for voxel-wise fUSI analysis.
 
@@ -234,8 +218,7 @@ class FirstLevelModel(BaseEstimator):
         for i, run in enumerate(run_data):
             validate_time_series(run, f"FirstLevelModel fit (run {i})")
             if self.mask is not None:
-                validate_mask(self.mask, run, "mask")
-                _validate_full_spatial_mask_dims(self.mask, run)
+                validate_mask(self.mask, run, "mask", require_exact_dims=True)
 
         if n_runs > 1:
             ref_run = run_data[0]

--- a/src/confusius/glm/first_level.py
+++ b/src/confusius/glm/first_level.py
@@ -66,6 +66,22 @@ def _flatten_spatial(
     return values, spatial_dims, spatial_shape
 
 
+def _validate_full_spatial_mask_dims(mask: xr.DataArray, data: xr.DataArray) -> None:
+    """Validate that `mask` covers all non-time dims in the same order.
+
+    First-level GLM currently treats every non-`time` dimension as part of the voxel
+    layout. The mask must therefore span exactly those dimensions in the same order so
+    masked extraction still produces `(time, space)` data.
+    """
+    spatial_dims = tuple(str(d) for d in data.dims if d != "time")
+    mask_dims = tuple(str(d) for d in mask.dims)
+    if mask_dims != spatial_dims:
+        raise ValueError(
+            "mask dimensions must match all non-time dimensions of the input data "
+            f"in the same order. Expected {spatial_dims}, got {mask_dims}."
+        )
+
+
 class FirstLevelModel(BaseEstimator):
     """First-level GLM estimator for voxel-wise fUSI analysis.
 
@@ -219,6 +235,7 @@ class FirstLevelModel(BaseEstimator):
             validate_time_series(run, f"FirstLevelModel fit (run {i})")
             if self.mask is not None:
                 validate_mask(self.mask, run, "mask")
+                _validate_full_spatial_mask_dims(self.mask, run)
 
         if n_runs > 1:
             ref_run = run_data[0]

--- a/src/confusius/glm/first_level.py
+++ b/src/confusius/glm/first_level.py
@@ -16,6 +16,7 @@ import pandas as pd
 import xarray as xr
 from sklearn.base import BaseEstimator
 
+from confusius.extract import extract_with_mask, unmask
 from confusius.glm._contrasts import Contrast
 from confusius.glm._design import (
     DriftModelSpec,
@@ -31,6 +32,7 @@ from confusius.glm._utils import (
     to_spatial_dataarray,
 )
 from confusius.validation.coordinates import validate_matching_coordinates
+from confusius.validation.mask import validate_mask
 from confusius.validation.time_series import validate_time_series
 
 if TYPE_CHECKING:
@@ -107,6 +109,9 @@ class FirstLevelModel(BaseEstimator):
         interval in the run `time` coordinate (see
         [`get_representative_step`][confusius._utils.get_representative_step]).
         Increase this value to tolerate slight timestamp jitter.
+    mask : xarray.DataArray, optional
+        Boolean spatial mask selecting voxels to include in model fitting. Must match
+        the spatial dimensions and coordinates of each run.
 
     Attributes
     ----------
@@ -148,6 +153,7 @@ class FirstLevelModel(BaseEstimator):
         oversampling: int = 50,
         min_onset: float = -24.0,
         uniformity_tolerance: float = 1e-2,
+        mask: xr.DataArray | None = None,
     ) -> None:
         self.hrf_model = hrf_model
         self.drift_model = drift_model
@@ -159,6 +165,7 @@ class FirstLevelModel(BaseEstimator):
         self.oversampling = oversampling
         self.min_onset = min_onset
         self.uniformity_tolerance = uniformity_tolerance
+        self.mask = mask
 
     def fit(
         self,
@@ -210,6 +217,8 @@ class FirstLevelModel(BaseEstimator):
 
         for i, run in enumerate(run_data):
             validate_time_series(run, f"FirstLevelModel fit (run {i})")
+            if self.mask is not None:
+                validate_mask(self.mask, run, "mask")
 
         if n_runs > 1:
             ref_run = run_data[0]
@@ -277,6 +286,9 @@ class FirstLevelModel(BaseEstimator):
 
         for run_index in range(n_runs):
             data_2d, s_dims, s_shape = _flatten_spatial(run_data[run_index])
+            if self.mask is not None:
+                masked = extract_with_mask(run_data[run_index], self.mask)
+                data_2d = masked.transpose("time", "space").values
             self._spatial_shapes.append(s_shape)
             self._run_coords.append(
                 {
@@ -358,6 +370,23 @@ class FirstLevelModel(BaseEstimator):
             contrast_def, stat_type, baseline=baseline
         )
         flat = select_contrast_map(contrast_obj, output_type)
+
+        if self.mask is not None:
+            attrs = {**self._input_attrs, "long_name": output_type, "cmap": "coolwarm"}
+            if flat.ndim == 1:
+                result = unmask(flat, self.mask, attrs=attrs, fill_value=0.0)
+            else:
+                result = unmask(
+                    flat,
+                    self.mask,
+                    new_dims=["contrast_dim"],
+                    new_dims_coords={"contrast_dim": np.arange(flat.shape[0])},
+                    attrs=attrs,
+                    fill_value=0.0,
+                )
+            result.name = output_type
+            return result
+
         return to_spatial_dataarray(
             flat,
             spatial_dims=self._spatial_dims,

--- a/src/confusius/validation/mask.py
+++ b/src/confusius/validation/mask.py
@@ -74,6 +74,7 @@ def validate_mask(
     mask_name: str = "mask",
     rtol: float = 1e-5,
     atol: float = 1e-8,
+    require_exact_dims: bool = False,
 ) -> None:
     """Validate that a mask matches data spatial dimensions and coordinates.
 
@@ -92,6 +93,9 @@ def validate_mask(
         Relative tolerance for coordinate comparison.
     atol : float, default: 1e-8
         Absolute tolerance for coordinate comparison.
+    require_exact_dims : bool, default: False
+        Whether `mask.dims` must match all non-`time` dimensions of `data` in the same
+        order.
 
     Raises
     ------
@@ -123,6 +127,15 @@ def validate_mask(
         )
 
     _validate_spatial_coords(mask, data, mask_name, rtol, atol)
+
+    if require_exact_dims:
+        expected_dims = tuple(str(d) for d in data.dims if d != "time")
+        mask_dims = tuple(str(d) for d in mask.dims)
+        if mask_dims != expected_dims:
+            raise ValueError(
+                f"{mask_name} dimensions must match all non-time dimensions of data "
+                f"in the same order. Expected {expected_dims}, got {mask_dims}."
+            )
 
 
 def validate_labels(

--- a/tests/unit/test_connectivity/test_seed.py
+++ b/tests/unit/test_connectivity/test_seed.py
@@ -495,6 +495,52 @@ class TestSklearnInterface:
         assert result is mapper
 
 
+class TestMask:
+    """Tests for computational masking in SeedBasedMaps."""
+
+    def test_mask_sets_outside_voxels_to_zero(self, data_2d, flat_labels):
+        """Voxels outside mask are set to zero in maps_."""
+        mask = xr.DataArray(
+            np.zeros((data_2d.sizes["z"], data_2d.sizes["x"]), dtype=bool),
+            dims=["z", "x"],
+            coords={"z": data_2d.coords["z"], "x": data_2d.coords["x"]},
+        )
+        mask.values[:3, :] = True
+
+        mapper = SeedBasedMaps(seed_masks=flat_labels, mask=mask).fit(data_2d)
+
+        outside = mapper.maps_.where(~mask, other=np.nan)
+        np.testing.assert_array_equal(np.nan_to_num(outside.values), 0.0)
+
+    def test_mask_cleans_only_masked_signals(self, data_2d, flat_labels, monkeypatch):
+        """When mask is provided, cleaning is applied to `(time, space)` signals."""
+        import confusius.connectivity.seed as seed_module
+
+        mask = xr.DataArray(
+            np.zeros((data_2d.sizes["z"], data_2d.sizes["x"]), dtype=bool),
+            dims=["z", "x"],
+            coords={"z": data_2d.coords["z"], "x": data_2d.coords["x"]},
+        )
+        mask.values[:3, :] = True
+
+        seen = {}
+        original_clean = seed_module.clean
+
+        def _clean(x, **kwargs):
+            seen["dims"] = x.dims
+            return original_clean(x, **kwargs)
+
+        monkeypatch.setattr(seed_module, "clean", _clean)
+
+        SeedBasedMaps(
+            seed_masks=flat_labels,
+            mask=mask,
+            clean_kwargs={"detrend_order": 1},
+        ).fit(data_2d)
+
+        assert seen["dims"] == ("time", "space")
+
+
 # ---------------------------------------------------------------------------
 # Xarray accessor tests
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_connectivity/test_seed.py
+++ b/tests/unit/test_connectivity/test_seed.py
@@ -512,6 +512,72 @@ class TestMask:
         outside = mapper.maps_.where(~mask, other=np.nan)
         np.testing.assert_array_equal(np.nan_to_num(outside.values), 0.0)
 
+    def test_masked_stacked_labels_extracts_from_masked_space(
+        self, data_2d, stacked_labels
+    ):
+        """Masked stacked labels keep region names and full output geometry."""
+        mask = xr.DataArray(
+            np.zeros((data_2d.sizes["z"], data_2d.sizes["x"]), dtype=bool),
+            dims=["z", "x"],
+            coords={"z": data_2d.coords["z"], "x": data_2d.coords["x"]},
+        )
+        mask.values[1:5, :] = True
+
+        mapper = SeedBasedMaps(seed_masks=stacked_labels, mask=mask).fit(data_2d)
+
+        np.testing.assert_array_equal(
+            mapper.seed_signals_.coords["region"].values,
+            ["roi_a", "roi_b"],
+        )
+        np.testing.assert_array_equal(
+            mapper.maps_.coords["region"].values,
+            ["roi_a", "roi_b"],
+        )
+        outside = mapper.maps_.where(~mask, other=np.nan)
+        np.testing.assert_array_equal(np.nan_to_num(outside.values), 0.0)
+
+    def test_masked_seed_signals_1d_is_expanded(self, data_2d):
+        """Masked seed_signals path expands 1D signals to `(time, region)`."""
+        mask = xr.DataArray(
+            np.zeros((data_2d.sizes["z"], data_2d.sizes["x"]), dtype=bool),
+            dims=["z", "x"],
+            coords={"z": data_2d.coords["z"], "x": data_2d.coords["x"]},
+        )
+        mask.values[:3, :] = True
+
+        signal = xr.DataArray(
+            data_2d.values[:, 0, 0],
+            dims=["time"],
+            coords={"time": data_2d.coords["time"]},
+        )
+
+        mapper = SeedBasedMaps(seed_signals=signal, mask=mask).fit(data_2d)
+
+        assert mapper.seed_signals_.dims == ("time", "region")
+        assert mapper.maps_.dims == ("z", "x")
+        outside = mapper.maps_.where(~mask, other=np.nan)
+        np.testing.assert_array_equal(np.nan_to_num(outside.values), 0.0)
+
+    def test_masked_seed_signals_are_transposed_when_time_is_not_leading(self, data_2d):
+        """Masked seed_signals path transposes `(region, time)` to `(time, region)`."""
+        mask = xr.DataArray(
+            np.zeros((data_2d.sizes["z"], data_2d.sizes["x"]), dtype=bool),
+            dims=["z", "x"],
+            coords={"z": data_2d.coords["z"], "x": data_2d.coords["x"]},
+        )
+        mask.values[:3, :] = True
+
+        signal = xr.DataArray(
+            np.stack([data_2d.values[:, 0, 0], data_2d.values[:, 1, 1]], axis=0),
+            dims=["region", "time"],
+            coords={"time": data_2d.coords["time"], "region": ["a", "b"]},
+        )
+
+        mapper = SeedBasedMaps(seed_signals=signal, mask=mask).fit(data_2d)
+
+        assert mapper.seed_signals_.dims == ("time", "region")
+        np.testing.assert_array_equal(mapper.seed_signals_.coords["region"], ["a", "b"])
+
     def test_mask_cleans_only_masked_signals(self, data_2d, flat_labels, monkeypatch):
         """When mask is provided, cleaning is applied to `(time, space)` signals."""
         import confusius.connectivity.seed as seed_module

--- a/tests/unit/test_connectivity/test_seed.py
+++ b/tests/unit/test_connectivity/test_seed.py
@@ -536,6 +536,27 @@ class TestMask:
         outside = mapper.maps_.where(~mask, other=np.nan)
         np.testing.assert_array_equal(np.nan_to_num(outside.values), 0.0)
 
+    def test_masked_stacked_labels_handle_permuted_spatial_dim_order(
+        self, data_2d, stacked_labels
+    ):
+        """Masked label extraction aligns stacked labels to mask dim order."""
+        mask = xr.DataArray(
+            np.zeros((data_2d.sizes["z"], data_2d.sizes["x"]), dtype=bool),
+            dims=["z", "x"],
+            coords={"z": data_2d.coords["z"], "x": data_2d.coords["x"]},
+        )
+        mask.values[1:5, :] = True
+
+        mapper = SeedBasedMaps(
+            seed_masks=stacked_labels.transpose("mask", "x", "z"),
+            mask=mask,
+        ).fit(data_2d)
+
+        np.testing.assert_array_equal(
+            mapper.seed_signals_.coords["region"].values,
+            ["roi_a", "roi_b"],
+        )
+
     def test_masked_seed_signals_1d_is_expanded(self, data_2d):
         """Masked seed_signals path expands 1D signals to `(time, region)`."""
         mask = xr.DataArray(

--- a/tests/unit/test_decomposition/test_fastica.py
+++ b/tests/unit/test_decomposition/test_fastica.py
@@ -376,3 +376,75 @@ def test_reproducible_with_random_state():
 
     np.testing.assert_allclose(signals_1.values, signals_2.values)
     np.testing.assert_allclose(model_1.maps_.values, model_2.maps_.values)
+
+
+def test_mask_restricts_features(sample_4d_volume):
+    """mask restricts fitted feature count to selected voxels."""
+    mask = xr.DataArray(
+        np.zeros(
+            (
+                sample_4d_volume.sizes["z"],
+                sample_4d_volume.sizes["y"],
+                sample_4d_volume.sizes["x"],
+            ),
+            dtype=bool,
+        ),
+        dims=["z", "y", "x"],
+        coords={
+            "z": sample_4d_volume.coords["z"],
+            "y": sample_4d_volume.coords["y"],
+            "x": sample_4d_volume.coords["x"],
+        },
+    )
+    mask.values[:, :2, :] = True
+
+    model = FastICA(**FASTICA_TEST_KWARGS, mask=mask).fit(sample_4d_volume)
+
+    assert model.n_features_in_ == int(mask.values.sum())
+
+
+
+def test_masked_fit_reconstructs_full_geometry_with_zero_fill(sample_4d_volume):
+    """Masked FastICA keeps full geometry and fills outside-mask voxels with zero."""
+    mask = xr.DataArray(
+        np.zeros(
+            (
+                sample_4d_volume.sizes["z"],
+                sample_4d_volume.sizes["y"],
+                sample_4d_volume.sizes["x"],
+            ),
+            dtype=bool,
+        ),
+        dims=["z", "y", "x"],
+        coords={
+            "z": sample_4d_volume.coords["z"],
+            "y": sample_4d_volume.coords["y"],
+            "x": sample_4d_volume.coords["x"],
+        },
+    )
+    mask.values[:, :2, :] = True
+
+    model = FastICA(**FASTICA_TEST_KWARGS, mask=mask).fit(sample_4d_volume)
+    reconstructed = model.inverse_transform(model.transform(sample_4d_volume))
+
+    assert reconstructed.dims == sample_4d_volume.dims
+    np.testing.assert_array_equal(
+        reconstructed.where(~mask, other=np.nan).fillna(0.0).values,
+        0.0,
+    )
+    np.testing.assert_array_equal(
+        model.maps_.where(~mask, other=np.nan).fillna(0.0).values,
+        0.0,
+    )
+    np.testing.assert_array_equal(
+        model.mean_.where(~mask, other=np.nan).fillna(0.0).values,
+        0.0,
+    )
+
+
+def test_mask_mismatch_raises(sample_4d_volume):
+    """fit raises when mask does not match spatial dimensions."""
+    bad_mask = xr.DataArray(np.ones((3, 3), dtype=bool), dims=["y", "x"])
+
+    with pytest.raises(ValueError, match="missing from mask"):
+        FastICA(mask=bad_mask).fit(sample_4d_volume)

--- a/tests/unit/test_decomposition/test_pca.py
+++ b/tests/unit/test_decomposition/test_pca.py
@@ -348,3 +348,75 @@ def test_fit_raises_for_invalid_mode(sample_4d_volume):
     """fit raises for unsupported PCA mode."""
     with pytest.raises(ValueError, match="mode must be 'temporal' or 'spatial'"):
         PCA(mode="invalid").fit(sample_4d_volume)  # type: ignore[arg-type]
+
+
+def test_mask_restricts_features(sample_4d_volume):
+    """mask restricts fitted feature count to selected voxels."""
+    mask = xr.DataArray(
+        np.zeros(
+            (
+                sample_4d_volume.sizes["z"],
+                sample_4d_volume.sizes["y"],
+                sample_4d_volume.sizes["x"],
+            ),
+            dtype=bool,
+        ),
+        dims=["z", "y", "x"],
+        coords={
+            "z": sample_4d_volume.coords["z"],
+            "y": sample_4d_volume.coords["y"],
+            "x": sample_4d_volume.coords["x"],
+        },
+    )
+    mask.values[:2, :, :] = True
+
+    model = PCA(n_components=3, random_state=0, mask=mask).fit(sample_4d_volume)
+
+    assert model.n_features_in_ == int(mask.values.sum())
+
+
+
+def test_masked_fit_reconstructs_full_geometry_with_zero_fill(sample_4d_volume):
+    """Masked PCA keeps full geometry and fills outside-mask voxels with zero."""
+    mask = xr.DataArray(
+        np.zeros(
+            (
+                sample_4d_volume.sizes["z"],
+                sample_4d_volume.sizes["y"],
+                sample_4d_volume.sizes["x"],
+            ),
+            dtype=bool,
+        ),
+        dims=["z", "y", "x"],
+        coords={
+            "z": sample_4d_volume.coords["z"],
+            "y": sample_4d_volume.coords["y"],
+            "x": sample_4d_volume.coords["x"],
+        },
+    )
+    mask.values[:2, :, :] = True
+
+    model = PCA(n_components=3, random_state=0, mask=mask).fit(sample_4d_volume)
+    reconstructed = model.inverse_transform(model.transform(sample_4d_volume))
+
+    assert reconstructed.dims == sample_4d_volume.dims
+    np.testing.assert_array_equal(
+        reconstructed.where(~mask, other=np.nan).fillna(0.0).values,
+        0.0,
+    )
+    np.testing.assert_array_equal(
+        model.maps_.where(~mask, other=np.nan).fillna(0.0).values,
+        0.0,
+    )
+    np.testing.assert_array_equal(
+        model.mean_.where(~mask, other=np.nan).fillna(0.0).values,
+        0.0,
+    )
+
+
+def test_mask_mismatch_raises(sample_4d_volume):
+    """fit raises when mask does not match spatial dimensions."""
+    bad_mask = xr.DataArray(np.ones((3, 3), dtype=bool), dims=["y", "x"])
+
+    with pytest.raises(ValueError, match="missing from mask"):
+        PCA(mask=bad_mask).fit(sample_4d_volume)

--- a/tests/unit/test_decomposition/test_pca.py
+++ b/tests/unit/test_decomposition/test_pca.py
@@ -170,7 +170,11 @@ def test_mask_must_match_full_spatial_dims_in_order(sample_4d_volume):
     """Mask must span all spatial dims in the stacked feature order."""
     mask = xr.DataArray(
         np.ones(
-            (sample_4d_volume.sizes["y"], sample_4d_volume.sizes["z"], sample_4d_volume.sizes["x"]),
+            (
+                sample_4d_volume.sizes["y"],
+                sample_4d_volume.sizes["z"],
+                sample_4d_volume.sizes["x"],
+            ),
             dtype=bool,
         ),
         dims=["y", "z", "x"],
@@ -181,7 +185,7 @@ def test_mask_must_match_full_spatial_dims_in_order(sample_4d_volume):
         },
     )
 
-    with pytest.raises(ValueError, match="must match the full spatial dimensions"):
+    with pytest.raises(ValueError, match="must match all non-time dimensions"):
         PCA(mask=mask).fit(sample_4d_volume)
 
 
@@ -392,7 +396,6 @@ def test_mask_restricts_features(sample_4d_volume):
     model = PCA(n_components=3, random_state=0, mask=mask).fit(sample_4d_volume)
 
     assert model.n_features_in_ == int(mask.values.sum())
-
 
 
 def test_masked_fit_reconstructs_full_geometry_with_zero_fill(sample_4d_volume):

--- a/tests/unit/test_decomposition/test_pca.py
+++ b/tests/unit/test_decomposition/test_pca.py
@@ -166,6 +166,25 @@ def test_fit_requires_spatial_dimension():
         PCA().fit(only_time)
 
 
+def test_mask_must_match_full_spatial_dims_in_order(sample_4d_volume):
+    """Mask must span all spatial dims in the stacked feature order."""
+    mask = xr.DataArray(
+        np.ones(
+            (sample_4d_volume.sizes["y"], sample_4d_volume.sizes["z"], sample_4d_volume.sizes["x"]),
+            dtype=bool,
+        ),
+        dims=["y", "z", "x"],
+        coords={
+            "y": sample_4d_volume.coords["y"],
+            "z": sample_4d_volume.coords["z"],
+            "x": sample_4d_volume.coords["x"],
+        },
+    )
+
+    with pytest.raises(ValueError, match="must match the full spatial dimensions"):
+        PCA(mask=mask).fit(sample_4d_volume)
+
+
 def test_fit_rejects_unexpected_fit_params(sample_4d_volume):
     """fit raises when unexpected sklearn-style fit params are provided."""
     with pytest.raises(TypeError, match="unexpected keyword argument"):

--- a/tests/unit/test_decomposition/test_pca.py
+++ b/tests/unit/test_decomposition/test_pca.py
@@ -69,7 +69,7 @@ def test_wrapper_matches_sklearn_attributes(sample_4d_volume):
         sklearn_model.singular_values_,
     )
     assert model.n_components_ == sklearn_model.n_components_
-    assert model.noise_variance_ == sklearn_model.noise_variance_
+    np.testing.assert_allclose(model.noise_variance_, sklearn_model.noise_variance_)
 
 
 def test_inverse_transform_reconstructs_with_all_components(sample_4d_volume):

--- a/tests/unit/test_glm/test_first_level.py
+++ b/tests/unit/test_glm/test_first_level.py
@@ -97,6 +97,68 @@ class TestFirstLevelModelFit:
         assert_allclose(z_map.coords["y"].values, fusi_data.coords["y"].values)
         assert_allclose(z_map.coords["x"].values, fusi_data.coords["x"].values)
 
+    def test_fit_with_mask_sets_outside_voxels_to_zero(self, fusi_data, events):
+        """Mask limits fitted voxels and keeps full output geometry."""
+        mask = xr.DataArray(
+            np.zeros(
+                (
+                    fusi_data.sizes["z"],
+                    fusi_data.sizes["y"],
+                    fusi_data.sizes["x"],
+                ),
+                dtype=bool,
+            ),
+            dims=["z", "y", "x"],
+            coords={
+                "z": fusi_data.coords["z"],
+                "y": fusi_data.coords["y"],
+                "x": fusi_data.coords["x"],
+            },
+        )
+        mask.values[0, :, :] = True
+
+        model = FirstLevelModel(noise_model="ols", mask=mask)
+        model.fit(fusi_data, events=events)
+        z_map = model.compute_contrast("A")
+
+        outside = z_map.where(~mask, other=np.nan)
+        np.testing.assert_array_equal(np.nan_to_num(outside.values), 0.0)
+
+    def test_masked_f_contrast_effect_keeps_contrast_dim(self, fusi_data, events):
+        """Masked F-contrast effect maps keep `contrast_dim` and zero-fill outside mask."""
+        mask = xr.DataArray(
+            np.zeros(
+                (
+                    fusi_data.sizes["z"],
+                    fusi_data.sizes["y"],
+                    fusi_data.sizes["x"],
+                ),
+                dtype=bool,
+            ),
+            dims=["z", "y", "x"],
+            coords={
+                "z": fusi_data.coords["z"],
+                "y": fusi_data.coords["y"],
+                "x": fusi_data.coords["x"],
+            },
+        )
+        mask.values[:, 0, :] = True
+
+        model = FirstLevelModel(noise_model="ols", mask=mask)
+        model.fit(fusi_data, events=events)
+        dm = model.design_matrices_[0]
+        a_idx = list(dm.columns).index("A")
+        b_idx = list(dm.columns).index("B")
+        c = np.zeros((2, len(dm.columns)))
+        c[0, a_idx] = 1.0
+        c[1, b_idx] = 1.0
+
+        e_map = model.compute_contrast(c, stat_type="F", output_type="effect")
+
+        assert e_map.dims == ("contrast_dim", "z", "y", "x")
+        outside = e_map.where(~mask, other=np.nan)
+        np.testing.assert_array_equal(np.nan_to_num(outside.values), 0.0)
+
     def test_consensus_attrs_propagated_across_runs(self, fusi_data, events):
         """Attributes equal across all runs propagate to the contrast map."""
         run_a = fusi_data.copy()

--- a/tests/unit/test_glm/test_first_level.py
+++ b/tests/unit/test_glm/test_first_level.py
@@ -559,6 +559,27 @@ class TestFirstLevelModelErrors:
         with pytest.raises(ValueError, match="noise_model"):
             model.fit(fusi_data, events=events)
 
+    def test_mask_must_cover_all_non_time_dims(self, frame_times, events):
+        """Mask must span all non-time dims in GLM voxel order."""
+        data = xr.DataArray(
+            np.zeros((len(frame_times), 2, 3, 4)),
+            dims=["time", "z", "y", "x"],
+            coords={
+                "time": frame_times,
+                "z": np.arange(2) * 0.5,
+                "y": np.arange(3) * 0.1,
+                "x": np.arange(4) * 0.1,
+            },
+        )
+        mask = xr.DataArray(
+            np.ones((data.sizes["y"], data.sizes["x"]), dtype=bool),
+            dims=["y", "x"],
+            coords={"y": data.coords["y"], "x": data.coords["x"]},
+        )
+        model = FirstLevelModel(noise_model="ols", mask=mask)
+        with pytest.raises(ValueError, match="match all non-time dimensions"):
+            model.fit(data, events=events)
+
     def test_2d_contrast_too_wide_raises(self, fusi_data, events):
         """2D contrast wider than design columns raises ValueError."""
         model = FirstLevelModel(noise_model="ols")

--- a/tests/unit/test_validation/test_coordinates.py
+++ b/tests/unit/test_validation/test_coordinates.py
@@ -163,3 +163,30 @@ def test_validate_mask_accepts_scalar_attached_coordinate(sample_4d_volume):
     mask[0, 0, :, :] = 1
 
     validate_mask(mask.isel(mask=0), sample_4d_volume)
+
+
+def test_validate_mask_require_exact_dims_accepts_full_spatial_mask(sample_4d_volume):
+    """`require_exact_dims=True` accepts masks over all non-time dimensions."""
+    mask = xr.DataArray(
+        np.ones(sample_4d_volume.shape[1:], dtype=bool),
+        dims=["z", "y", "x"],
+        coords={
+            "z": sample_4d_volume.coords["z"],
+            "y": sample_4d_volume.coords["y"],
+            "x": sample_4d_volume.coords["x"],
+        },
+    )
+
+    validate_mask(mask, sample_4d_volume, require_exact_dims=True)
+
+
+def test_validate_mask_require_exact_dims_rejects_subset_dims(sample_4d_volume):
+    """`require_exact_dims=True` rejects subset spatial masks."""
+    mask = xr.DataArray(
+        np.ones(sample_4d_volume.shape[3], dtype=bool),
+        dims=["x"],
+        coords={"x": sample_4d_volume.coords["x"]},
+    )
+
+    with pytest.raises(ValueError, match="must match all non-time dimensions"):
+        validate_mask(mask, sample_4d_volume, require_exact_dims=True)


### PR DESCRIPTION
## Summary
Implements issue #137 by adding a `mask` argument across the relevant estimators so computations can be restricted to selected voxels.

### Included changes
- **Decomposition**
  - `confusius.decomposition.PCA`: add `mask` support
  - `confusius.decomposition.FastICA`: add `mask` support
  - shared masking behavior in `confusius.decomposition._base`
- **Connectivity**
  - `confusius.connectivity.SeedBasedMaps`: add `mask` support
  - optimized masked path to compute/clean on masked `(time, space)` signals
- **GLM**
  - `confusius.glm.FirstLevelModel`: add `mask` support in voxel fitting path

Closes #137
