### PR TITLE
docs: improve docs build caching (gallery + images)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -71,7 +71,32 @@ jobs:
         # one pass but not the other.
         run: uv run tools/prefetch_doc_datasets.py
 
+      - name: Ensure docs images directories exist
+        run: |
+          mkdir -p docs/images/gui
+          mkdir -p docs/images/qc
+          mkdir -p docs/images/visualization
+          mkdir -p docs/images/home
+
+      - name: Cache generated docs images
+        id: cache-doc-images
+        uses: actions/cache@v5
+        with:
+          path: |
+            docs/images/gui/*.png
+            docs/images/gui/*.gif
+            docs/images/qc/*.png
+            docs/images/qc/*.gif
+            docs/images/visualization/*.png
+            docs/images/visualization/*.gif
+            docs/images/home/*.png
+            docs/images/home/*.gif
+          key: ${{ runner.os }}-docs-images-${{ hashFiles('uv.lock', 'docs/images/**/generate.py', 'tools/prefetch_doc_datasets.py', 'src/**/*.py') }}
+          restore-keys: |
+            ${{ runner.os }}-docs-images-
+
       - name: Generate documentation images
+        if: steps.cache-doc-images.outputs.cache-hit != 'true'
         env:
           QT_QPA_PLATFORM: "xcb"
           PYOPENGL_PLATFORM: "glx"

--- a/tools/build_gallery.py
+++ b/tools/build_gallery.py
@@ -23,12 +23,14 @@ CACHE_ROOT = REPO_ROOT / ".gallery-cache"
 BINDER_REPO = "confusius-tools/confusius"
 
 
-def _deps_fingerprint(binder_ref: str) -> str:
-    """Return a string identifying gallery build inputs.
+def _deps_fingerprint() -> str:
+    """Return a string identifying gallery execution/render inputs.
 
     Uses ``uv.lock`` plus the gallery-builder source files directly. Any change to the
-    locked dependencies, the gallery pipeline, or the Binder launch ref forces a cache
-    miss so that rebuilt pages embed the new launcher URLs.
+    locked dependencies or gallery pipeline forces a cache miss.
+
+    Binder branch/ref is intentionally excluded so expensive gallery execution can be
+    reused across branches.
     """
     parts: list[str] = []
     lockfile = REPO_ROOT / "uv.lock"
@@ -43,7 +45,6 @@ def _deps_fingerprint(binder_ref: str) -> str:
 
     parts.append("\n# tools/build_gallery.py\n")
     parts.append(Path(__file__).read_text())
-    parts.append(f"\n# binder_ref={binder_ref}\n")
     return "".join(parts)
 
 
@@ -58,7 +59,7 @@ def main() -> int:
         examples_root=EXAMPLES_ROOT,
         built_dir=BUILT_DIR,
         cache_root=CACHE_ROOT,
-        deps_fingerprint=_deps_fingerprint(binder_ref),
+        deps_fingerprint=_deps_fingerprint(),
         repo_root=REPO_ROOT,
         binder_repo=BINDER_REPO,
         binder_ref=binder_ref,

--- a/tools/gallery/_pipeline.py
+++ b/tools/gallery/_pipeline.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import shutil
 import sys
 from pathlib import Path
@@ -75,6 +76,25 @@ def _write_cached_artifacts(
     return None
 
 
+def _rewrite_binder_button(md_path: Path, binder_url: str | None) -> None:
+    """Rewrite the Binder button URL in one rendered Markdown page.
+
+    This lets expensive gallery execution/render artifacts stay branch-agnostic in
+    cache while still stamping the current branch/ref into the final page.
+    """
+    if binder_url is None or not md_path.is_file():
+        return
+
+    markdown = md_path.read_text(encoding="utf-8")
+    updated = re.sub(
+        r"\[Launch in Binder\]\([^)]*\)\{ \.md-button \.md-button--primary \}",
+        f"[Launch in Binder]({binder_url}){{ .md-button .md-button--primary }}",
+        markdown,
+    )
+    if updated != markdown:
+        md_path.write_text(updated, encoding="utf-8")
+
+
 def _make_progress() -> Progress:
     """Return a rich Progress configured for the gallery builder."""
     return Progress(
@@ -130,6 +150,7 @@ def _build_one(
     if cache_entry.is_dir():
         progress.add_task(f"{spec.section}/{base_name} [cached]", total=1, completed=1)
         thumb = _write_cached_artifacts(cache_entry, out_dir, base_name)
+        _rewrite_binder_button(out_dir / f"{base_name}.md", binder_url)
         return RenderedExample(
             spec=spec,
             title=title,


### PR DESCRIPTION
## Summary

This PR improves docs CI caching in two ways:

1. Make gallery execution cache branch-agnostic
   - Remove Binder ref from gallery execution cache fingerprint so expensive notebook execution is reusable across branches/PRs.
   - Rewrite Binder URL in cached markdown at build time so links still target the current ref.

2. Cache generated user-guide images
   - Add a dedicated Actions cache for generated outputs under `docs/images/{home,gui,qc,visualization}`.
   - Skip the image-generation step on cache hit.

## Why

Recent docs runs showed low effective gallery cache reuse because cache entries were keyed by branch ref. Also, issue #154 asks to cache generated documentation images.

Closes #154.
