### PR TITLE
feat(datasets): add Huang 2025 template fetcher

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -29,6 +29,9 @@ Current development version for the next ConfUSIus release.
 - Added `datatypes` filter to `fetch_cybis_pereira_2026`, allowing downloads to be
   scoped to specific BIDS datatype directories (`"fusi"`, `"angio"`, `"motion"`)
   ([#141](https://github.com/confusius-tools/confusius/pull/141)).
+- Added `fetch_template_huang_2025` for downloading and loading the Huang et al.
+  vascular mouse template from OSF, with cache/refresh behavior matching existing
+  template fetchers.
 - Added `show_progress` to volumewise registration so joblib progress output can be
   disabled in scripted or quiet workflows
   ([#126](https://github.com/confusius-tools/confusius/pull/126)).
@@ -85,7 +88,7 @@ Current development version for the next ConfUSIus release.
 
 ## 0.2.0
 
-Released 2026-05-05.
+*Released 2026-05-05.*
 
 First official public beta release of ConfUSIus.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -31,7 +31,7 @@ Current development version for the next ConfUSIus release.
   ([#141](https://github.com/confusius-tools/confusius/pull/141)).
 - Added `fetch_template_huang_2025` for downloading and loading the Huang et al.
   vascular mouse template from OSF, with cache/refresh behavior matching existing
-  template fetchers.
+  template fetchers ([#162](https://github.com/confusius-tools/confusius/pull/162)).
 - Added `show_progress` to volumewise registration so joblib progress output can be
   disabled in scripted or quiet workflows
   ([#126](https://github.com/confusius-tools/confusius/pull/126)).

--- a/docs/citing.md
+++ b/docs/citing.md
@@ -139,22 +139,63 @@ Or in BibTeX format:
 The [`fetch_nunez_elizalde_2022`][confusius.datasets.fetch_nunez_elizalde_2022]
 function provides an fUSI-BIDS conversion of this dataset. If you use it, please cite:
 
-> Nunez-Elizalde, A.O. et al. (2022). Neural correlates of blood flow measured by
-> ultrasound. *Neuron*, 110(10), 1631–1640.
+> Nunez-Elizalde, A. O., Krumin, M., Reddy, C. B., Montaldo, G., Urban, A., Harris,
+> K. D., & Carandini, M. (2022). Neural correlates of blood flow measured by
+> ultrasound. *Neuron*, 110(10), 1631–1640.e4.
 > https://doi.org/10.1016/j.neuron.2022.02.012
 
-License: **CC BY 4.0**.
+Or in BibTeX format:
 
-### Cybis Pereira et al. (2026)
+```bibtex
+@article{nunez-elizalde_neural_2022,
+  title = {Neural correlates of blood flow measured by ultrasound},
+  volume = {110},
+  issn = {08966273},
+  url = {https://linkinghub.elsevier.com/retrieve/pii/S0896627322001775},
+  doi = {10.1016/j.neuron.2022.02.012},
+  language = {en},
+  number = {10},
+  journal = {Neuron},
+  author = {Nunez-Elizalde, Anwar O. and Krumin, Michael and Reddy, Charu Bai and
+            Montaldo, Gabriel and Urban, Alan and Harris, Kenneth D. and Carandini, Matteo},
+  month = may,
+  year = {2022},
+  pages = {1631--1640.e4},
+}
+```
+
+License: **[CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)**.
+
+### Cybis Pereira et al. (2025)
 
 The [`fetch_cybis_pereira_2026`][confusius.datasets.fetch_cybis_pereira_2026]
 function provides an fUSI-BIDS conversion of this dataset. If you use it, please cite:
 
-> Cybis Pereira, F. et al. (2026). A vascular code for speed in the spatial navigation
-> system. *Cell Reports*, 45(1).
-> https://doi.org/10.1016/j.celrep.2025.116791
+> Cybis Pereira, F., Castedo, S. H., Le Meur-Diebolt, S., Ialy-Radio, N.,
+> Bhattacharya, S., Ferrier, J., Osmanski, B. F., Cocco, S., Monasson, R.,
+> Pezet, S., & Tanter, M. (2025). Speed vascular patterns in the spatial navigation
+> system. *bioRxiv*.
+> https://doi.org/10.1101/2025.07.15.663536
 
-License: **CC BY 4.0**.
+Or in BibTeX format:
+
+```bibtex
+@misc{cybis_pereira_speed_2025,
+  title = {Speed Vascular Patterns in the Spatial Navigation System},
+  copyright = {http://creativecommons.org/licenses/by/4.0/},
+  url = {http://biorxiv.org/lookup/doi/10.1101/2025.07.15.663536},
+  doi = {10.1101/2025.07.15.663536},
+  language = {en},
+  author = {Cybis Pereira, Felipe and Castedo, Sebastian H. and Le Meur-Diebolt, Samuel and
+            Ialy-Radio, Nathalie and Bhattacharya, Soumee and Ferrier, Jeremy and
+            Osmanski, Bruno Félix and Cocco, Simona and Monasson, Remi and Pezet, Sophie and
+            Tanter, Mickaël},
+  month = jul,
+  year = {2025},
+}
+```
+
+License: **[CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)**.
 
 ## Templates
 
@@ -164,12 +205,32 @@ The [`fetch_template_huang_2025`][confusius.datasets.fetch_template_huang_2025]
 function provides a vascular mouse template derived from OpenfUSAnalyzer. If you use
 this template in your research, please cite:
 
-> Huang, Y.-A. et al. (2025). OfUSA: OpenfUS Analyzer, a versatile open-source
-> framework for the analysis and visualization of functional ultrasound imaging data
-> across animal models. *bioRxiv*.
+> Huang, Y.-A., Lambert, T., Verbeyst, D., Fitzgerald, N. E., Grillet, M.,
+> Brunner, C., Montaldo, G., Vanduffel, W., & Urban, A. (2025). OfUSA: OpenfUS
+> Analyzer, a versatile open-source framework for the analysis and visualization of
+> functional ultrasound imaging data across animal models. *bioRxiv*.
 > https://doi.org/10.1101/2025.09.16.676515
 
-License: **CC BY-NC-SA 4.0**.
+Or in BibTeX format:
+
+```bibtex
+@misc{huang_ofusa:_2025,
+  title = {OfUSA: OpenfUS Analyzer, a versatile open-source framework for the analysis and
+           visualization of functional ultrasound imaging data across animal models},
+  copyright = {http://creativecommons.org/licenses/by-nc/4.0/},
+  shorttitle = {OfUSA},
+  url = {http://biorxiv.org/lookup/doi/10.1101/2025.09.16.676515},
+  doi = {10.1101/2025.09.16.676515},
+  language = {en},
+  author = {Huang, Yun-An and Lambert, Théo and Verbeyst, Damon and Fitzgerald, Nora Eilis and
+            Grillet, Micheline and Brunner, Clément and Montaldo, Gabriel and
+            Vanduffel, Wim and Urban, Alan},
+  month = sep,
+  year = {2025},
+}
+```
+
+License: **[CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/)**.
 
 ### Pepe, Mariani et al. (2026)
 
@@ -177,12 +238,11 @@ The [`fetch_template_pepe_mariani_2026`][confusius.datasets.fetch_template_pepe_
 function provides a mouse fUSI template derived from Pepe, Mariani et al. (2026). If you use
 this template in your research, please also cite the corresponding article:
 
-> Pepe, C., Mariani, J.-C., Urosevic, M., Gini, S., Stuefer, A., Ricci, F., Galbusera, A.,
-> Iurilli, G., & Gozzi, A. (2026). Structural and dynamic embedding of the mouse functional
-> connectome revealed by functional ultrasound imaging (fUSI). *bioRxiv*.
+> Pepe, C., Mariani, J.-C., Urosevic, M., Gini, S., Stuefer, A., Ricci, F.,
+> Galbusera, A., Iurilli, G., & Gozzi, A. (2026). Structural and dynamic embedding
+> of the mouse functional connectome revealed by functional ultrasound imaging
+> (fUSI). *bioRxiv*.
 > https://doi.org/10.64898/2026.02.05.704055
-
-License: **CC BY 4.0**.
 
 Or in BibTeX format:
 
@@ -200,3 +260,5 @@ Or in BibTeX format:
   url       = {https://doi.org/10.64898/2026.02.05.704055}
 }
 ```
+
+License: **[CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)**.

--- a/docs/citing.md
+++ b/docs/citing.md
@@ -132,7 +132,44 @@ Or in BibTeX format:
 }
 ```
 
+## Datasets
+
+### Nunez-Elizalde et al. (2022)
+
+The [`fetch_nunez_elizalde_2022`][confusius.datasets.fetch_nunez_elizalde_2022]
+function provides an fUSI-BIDS conversion of this dataset. If you use it, please cite:
+
+> Nunez-Elizalde, A.O. et al. (2022). Neural correlates of blood flow measured by
+> ultrasound. *Neuron*, 110(10), 1631–1640.
+> https://doi.org/10.1016/j.neuron.2022.02.012
+
+License: **CC BY 4.0**.
+
+### Cybis Pereira et al. (2026)
+
+The [`fetch_cybis_pereira_2026`][confusius.datasets.fetch_cybis_pereira_2026]
+function provides an fUSI-BIDS conversion of this dataset. If you use it, please cite:
+
+> Cybis Pereira, F. et al. (2026). A vascular code for speed in the spatial navigation
+> system. *Cell Reports*, 45(1).
+> https://doi.org/10.1016/j.celrep.2025.116791
+
+License: **CC BY 4.0**.
+
 ## Templates
+
+### Huang et al. (2025)
+
+The [`fetch_template_huang_2025`][confusius.datasets.fetch_template_huang_2025]
+function provides a vascular mouse template derived from OpenfUSAnalyzer. If you use
+this template in your research, please cite:
+
+> Huang, Y.-A. et al. (2025). OfUSA: OpenfUS Analyzer, a versatile open-source
+> framework for the analysis and visualization of functional ultrasound imaging data
+> across animal models. *bioRxiv*.
+> https://doi.org/10.1101/2025.09.16.676515
+
+License: **CC BY-NC-SA 4.0**.
 
 ### Pepe, Mariani et al. (2026)
 
@@ -144,6 +181,8 @@ this template in your research, please also cite the corresponding article:
 > Iurilli, G., & Gozzi, A. (2026). Structural and dynamic embedding of the mouse functional
 > connectome revealed by functional ultrasound imaging (fUSI). *bioRxiv*.
 > https://doi.org/10.64898/2026.02.05.704055
+
+License: **CC BY 4.0**.
 
 Or in BibTeX format:
 

--- a/docs/citing.md
+++ b/docs/citing.md
@@ -166,32 +166,33 @@ Or in BibTeX format:
 
 License: **[CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)**.
 
-### Cybis Pereira et al. (2025)
+### Cybis Pereira et al. (2026)
 
 The [`fetch_cybis_pereira_2026`][confusius.datasets.fetch_cybis_pereira_2026]
 function provides an fUSI-BIDS conversion of this dataset. If you use it, please cite:
 
-> Cybis Pereira, F., Castedo, S. H., Le Meur-Diebolt, S., Ialy-Radio, N.,
-> Bhattacharya, S., Ferrier, J., Osmanski, B. F., Cocco, S., Monasson, R.,
-> Pezet, S., & Tanter, M. (2025). Speed vascular patterns in the spatial navigation
-> system. *bioRxiv*.
-> https://doi.org/10.1101/2025.07.15.663536
+> Cybis Pereira, F., Castedo, S. H., Meur-Diebolt, S. L., Ialy-Radio, N., Bhattacharya,
+> S., Ferrier, J., Osmanski, B. F., Cocco, S., Monasson, R., Pezet, S., & Tanter, M.
+> (2026). A vascular code for speed in the spatial navigation system. *Cell Reports*,
+> 45(1). https://doi.org/10.1016/j.celrep.2025.116791
 
 Or in BibTeX format:
 
 ```bibtex
-@misc{cybis_pereira_speed_2025,
-  title = {Speed Vascular Patterns in the Spatial Navigation System},
-  copyright = {http://creativecommons.org/licenses/by/4.0/},
-  url = {http://biorxiv.org/lookup/doi/10.1101/2025.07.15.663536},
-  doi = {10.1101/2025.07.15.663536},
-  language = {en},
-  author = {Cybis Pereira, Felipe and Castedo, Sebastian H. and Le Meur-Diebolt, Samuel and
-            Ialy-Radio, Nathalie and Bhattacharya, Soumee and Ferrier, Jeremy and
-            Osmanski, Bruno Félix and Cocco, Simona and Monasson, Remi and Pezet, Sophie and
-            Tanter, Mickaël},
-  month = jul,
-  year = {2025},
+@article{cybispereiraVascularCodeSpeed2026,
+  title = {A Vascular Code for Speed in the Spatial Navigation System},
+  author = {Cybis Pereira, Felipe and Castedo, Sebastian H. and {Meur-Diebolt}, Samuel Le and {Ialy-Radio}, Nathalie and Bhattacharya, Soumee and Ferrier, Jeremy and Osmanski, Bruno F{\'e}lix and Cocco, Simona and Monasson, Remi and Pezet, Sophie and Tanter, Micka{\"e}l},
+  year = 2026,
+  month = jan,
+  journal = {Cell Reports},
+  volume = {45},
+  number = {1},
+  publisher = {Elsevier},
+  issn = {2211-1247},
+  doi = {10.1016/j.celrep.2025.116791},
+  urldate = {2025-12-30},
+  langid = {english},
+  keywords = {animal speed,cerebral blood volume,continuous attractor network,CP: neuroscience,freely moving,functional ultrasound imaging,hippocampus,locomotion,path integration,spatial navigation},
 }
 ```
 

--- a/docs/user-guide/datasets.md
+++ b/docs/user-guide/datasets.md
@@ -86,6 +86,7 @@ list_datasets()
 ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━┩
 │ fetch_cybis_pereira_2026         │ 12.88 GB │    ✗    │
 │ fetch_nunez_elizalde_2022        │ 6.983 GB │    ✗    │
+│ fetch_template_huang_2025        │ 16.34 MB │    ✗    │
 │ fetch_template_pepe_mariani_2026 │ 5.508 MB │    ✗    │
 └──────────────────────────────────┴──────────┴─────────┘
 ```
@@ -206,6 +207,27 @@ Existing local files are never re-downloaded—`refresh=True` only adds what is 
 
 ## Available Templates
 
+=== "Huang 2025"
+
+    A vascular mouse fUSI template derived from Huang et al. (2025)[^huang2025] and
+    distributed as a single ConfUSIus-compatible NIfTI on
+    [OSF (am3jw)](https://osf.io/am3jw/). Total size: **~16.3 MB**.
+
+    Use [`fetch_template_huang_2025`][confusius.datasets.fetch_template_huang_2025] to
+    download and load the template directly:
+
+    ```python
+    from confusius.atlas import Atlas
+    from confusius.datasets import fetch_template_huang_2025
+
+    template = fetch_template_huang_2025()
+    atlas = Atlas.from_brainglobe("allen_mouse_50um")
+    resampled_atlas = atlas.resample_like(
+        template,
+        template.attrs["affines"]["physical_to_sform"],
+    )
+    ```
+
 === "Pepe Mariani 2026"
 
     A mouse fUSI template derived from Pepe, Mariani et al. (2026)[^pepe_mariani2026] and
@@ -241,6 +263,12 @@ parameters and return types.
     Cybis Pereira, F. et al. (2026). A vascular code for speed in the spatial
     navigation system. *Cell Reports*, 45(1).
     <https://doi.org/10.1016/j.celrep.2025.116791>
+
+[^huang2025]:
+    Huang, Y.-A. et al. (2025). OfUSA: OpenfUS Analyzer, a versatile open-source
+    framework for the analysis and visualization of functional ultrasound imaging data
+    across animal models.
+    <https://doi.org/10.1101/2025.09.16.676515>
 
 [^pepe_mariani2026]:
     Pepe, C. et al. (2026). Structural and dynamic embedding of the mouse

--- a/src/confusius/datasets/__init__.py
+++ b/src/confusius/datasets/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from ._cybis_pereira_2026 import fetch_cybis_pereira_2026
+from ._huang_2025 import fetch_template_huang_2025
 from ._nunez_elizalde_2022 import fetch_nunez_elizalde_2022
 from ._pepe_mariani_2026 import fetch_template_pepe_mariani_2026
 from ._registry import list_datasets
@@ -11,6 +12,7 @@ from ._utils import get_datasets_dir
 __all__ = [
     "fetch_cybis_pereira_2026",
     "fetch_nunez_elizalde_2022",
+    "fetch_template_huang_2025",
     "fetch_template_pepe_mariani_2026",
     "get_datasets_dir",
     "list_datasets",

--- a/src/confusius/datasets/_cybis_pereira_2026.py
+++ b/src/confusius/datasets/_cybis_pereira_2026.py
@@ -257,6 +257,10 @@ def fetch_cybis_pereira_2026(
 
     [^2]:
         fUSI-BIDS dataset on OSF: [https://osf.io/2v6f7/](https://osf.io/2v6f7/)
+
+    [^3]:
+        Dataset license (CC BY 4.0):
+        [https://creativecommons.org/licenses/by/4.0/](https://creativecommons.org/licenses/by/4.0/)
     """
     bids_dir = get_datasets_dir(data_dir) / _BIDS_ROOT
     bids_dir.mkdir(parents=True, exist_ok=True)

--- a/src/confusius/datasets/_huang_2025.py
+++ b/src/confusius/datasets/_huang_2025.py
@@ -1,4 +1,4 @@
-"""Fetcher for the Pepe, Mariani et al. (2026) fUSI template."""
+"""Fetcher for the Huang et al. (2025) vascular fUSI template."""
 
 from __future__ import annotations
 
@@ -13,10 +13,10 @@ from confusius.io.loadsave import load
 from ._pooch import quiet_pooch_logger, retrieve_with_retries
 from ._utils import get_datasets_dir
 
-_OSF_PROJECT_ID = "43tu9"
-_TEMPLATE_ROOT = "pepe-mariani-2026-template"
-_FILENAME = "pepe-mariani-2026-fusi-template.nii.gz"
-_TOTAL_SIZE_BYTES = 5_507_550
+_OSF_PROJECT_ID = "am3jw"
+_TEMPLATE_ROOT = "huang-2025-template"
+_FILENAME = "huang-2026-space-allen50_desc-vascular.nii.gz"
+_TOTAL_SIZE_BYTES = 16_338_947
 
 
 def resolve_template_url(project_id: str = _OSF_PROJECT_ID) -> str:
@@ -24,13 +24,13 @@ def resolve_template_url(project_id: str = _OSF_PROJECT_ID) -> str:
 
     Parameters
     ----------
-    project_id : str, default: "43tu9"
+    project_id : str, default: "am3jw"
         OSF project identifier.
 
     Returns
     -------
     str
-        Direct download URL for `pepe-mariani-2026-fusi-template.nii.gz`.
+        Direct download URL for `huang-2026-space-allen50_desc-vascular.nii.gz`.
 
     Raises
     ------
@@ -49,11 +49,11 @@ def resolve_template_url(project_id: str = _OSF_PROJECT_ID) -> str:
     raise RuntimeError(f"Could not find {_FILENAME!r} in OSF project {project_id}.")
 
 
-def fetch_template_pepe_mariani_2026(
+def fetch_template_huang_2025(
     data_dir: str | Path | None = None,
     refresh: bool = False,
 ) -> xr.DataArray:
-    """Fetch the Pepe, Mariani et al. (2026) mouse fUSI template.
+    """Fetch the Huang et al. (2025) mouse vascular fUSI template.
 
     Downloads the template from OSF on first call, caches it locally, and returns the
     loaded NIfTI as an Xarray DataArray.
@@ -71,22 +71,22 @@ def fetch_template_pepe_mariani_2026(
     Returns
     -------
     xarray.DataArray
-        Template with `physical_to_sform` affine transform required for resampling to
-        the Allen Mouse Brain atlas space.
+        Vascular template aligned to Allen CCF space.
 
     References
     ----------
     [^1]:
-        Pepe, C. et al. (2026). Structural and dynamic embedding of the mouse
-        functional connectome revealed by functional ultrasound imaging (fUSI).
-        [https://doi.org/10.64898/2026.02.05.704055](https://doi.org/10.64898/2026.02.05.704055)
+        Huang, Y.-A. et al. (2025). OfUSA: OpenfUS Analyzer, a versatile open-source
+        framework for the analysis and visualization of functional ultrasound imaging
+        data across animal models.
+        [https://doi.org/10.1101/2025.09.16.676515](https://doi.org/10.1101/2025.09.16.676515)
 
     [^2]:
-        Template hosted on OSF: [https://osf.io/43tu9/](https://osf.io/43tu9/)
+        Template hosted on OSF: [https://osf.io/am3jw/](https://osf.io/am3jw/)
 
     [^3]:
-        Template license (CC BY 4.0):
-        [https://creativecommons.org/licenses/by/4.0/](https://creativecommons.org/licenses/by/4.0/)
+        Template license (CC BY-NC-SA 4.0):
+        [https://creativecommons.org/licenses/by-nc-sa/4.0/](https://creativecommons.org/licenses/by-nc-sa/4.0/)
     """
     dataset_dir = get_datasets_dir(data_dir) / _TEMPLATE_ROOT
     dataset_dir.mkdir(parents=True, exist_ok=True)

--- a/src/confusius/datasets/_nunez_elizalde_2022.py
+++ b/src/confusius/datasets/_nunez_elizalde_2022.py
@@ -180,6 +180,10 @@ def fetch_nunez_elizalde_2022(
 
     [^2]:
         fUSI-BIDS dataset on OSF: [https://osf.io/43skw/](https://osf.io/43skw/)
+
+    [^3]:
+        Dataset license (CC BY 4.0):
+        [https://creativecommons.org/licenses/by/4.0/](https://creativecommons.org/licenses/by/4.0/)
     """
     bids_dir = get_datasets_dir(data_dir) / _BIDS_ROOT
     bids_dir.mkdir(parents=True, exist_ok=True)

--- a/src/confusius/datasets/_registry.py
+++ b/src/confusius/datasets/_registry.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 from ._cybis_pereira_2026 import _BIDS_ROOT as _cybis_pereira_2026_bids_root
 from ._cybis_pereira_2026 import _TOTAL_SIZE_BYTES as _cybis_pereira_2026_size
+from ._huang_2025 import _TEMPLATE_ROOT as _huang_2025_template_root
+from ._huang_2025 import _TOTAL_SIZE_BYTES as _huang_2025_size
 from ._nunez_elizalde_2022 import _BIDS_ROOT as _nunez_elizalde_2022_bids_root
 from ._nunez_elizalde_2022 import _TOTAL_SIZE_BYTES as _nunez_elizalde_2022_size
 from ._pepe_mariani_2026 import _TEMPLATE_ROOT as _pepe_mariani_2026_template_root
@@ -26,6 +28,11 @@ _REGISTRY: tuple[RegistryEntry, ...] = (
         "fetch_nunez_elizalde_2022",
         _nunez_elizalde_2022_size,
         _nunez_elizalde_2022_bids_root,
+    ),
+    (
+        "fetch_template_huang_2025",
+        _huang_2025_size,
+        _huang_2025_template_root,
     ),
     (
         "fetch_template_pepe_mariani_2026",

--- a/tests/unit/test_datasets/test_huang_2025.py
+++ b/tests/unit/test_datasets/test_huang_2025.py
@@ -1,0 +1,128 @@
+"""Unit tests for confusius.datasets._huang_2025."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from confusius.datasets import fetch_template_huang_2025
+from confusius.datasets._huang_2025 import (
+    _FILENAME,
+    _OSF_PROJECT_ID,
+    _TEMPLATE_ROOT,
+    resolve_template_url,
+)
+
+
+class _Response:
+    def __init__(self, payload: dict):
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict:
+        return self._payload
+
+
+def test_resolve_template_url_returns_download_link() -> None:
+    payload = {
+        "data": [
+            {
+                "attributes": {"name": _FILENAME},
+                "links": {"download": "https://files.osf.io/template"},
+            }
+        ]
+    }
+    with patch(
+        "confusius.datasets._huang_2025.requests.get",
+        return_value=_Response(payload),
+    ) as mock_get:
+        assert resolve_template_url() == "https://files.osf.io/template"
+
+    mock_get.assert_called_once_with(
+        f"https://api.osf.io/v2/nodes/{_OSF_PROJECT_ID}/files/osfstorage/"
+    )
+
+
+def test_resolve_template_url_raises_when_missing() -> None:
+    with patch(
+        "confusius.datasets._huang_2025.requests.get",
+        return_value=_Response({"data": []}),
+    ):
+        with pytest.raises(RuntimeError, match=_FILENAME):
+            resolve_template_url()
+
+
+@pytest.fixture
+def mock_resolve() -> object:
+    with patch(
+        "confusius.datasets._huang_2025.resolve_template_url",
+        return_value="https://files.osf.io/template",
+    ) as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_retrieve(tmp_path: Path):
+    def _retrieve(url, dest, logger, progressbar=False, on_retry=None):
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.touch()
+
+    with patch(
+        "confusius.datasets._huang_2025.retrieve_with_retries",
+        side_effect=_retrieve,
+    ) as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_load():
+    sentinel = object()
+    with patch("confusius.datasets._huang_2025.load", return_value=sentinel) as mock:
+        yield sentinel, mock
+
+
+def test_fetch_downloads_missing_template(tmp_path, mock_resolve, mock_retrieve, mock_load):
+    sentinel, mock_load_fn = mock_load
+    result = fetch_template_huang_2025(data_dir=tmp_path)
+    dest = tmp_path / _TEMPLATE_ROOT / _FILENAME
+
+    assert result is sentinel
+    mock_resolve.assert_called_once_with()
+    mock_retrieve.assert_called_once()
+    mock_load_fn.assert_called_once_with(dest)
+    assert dest.exists()
+
+
+def test_fetch_skips_download_when_cached(tmp_path, mock_resolve, mock_retrieve, mock_load):
+    sentinel, mock_load_fn = mock_load
+    dest = tmp_path / _TEMPLATE_ROOT / _FILENAME
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.touch()
+
+    result = fetch_template_huang_2025(data_dir=tmp_path)
+
+    assert result is sentinel
+    mock_resolve.assert_not_called()
+    mock_retrieve.assert_not_called()
+    mock_load_fn.assert_called_once_with(dest)
+
+
+def test_fetch_refresh_redownloads_cached_template(
+    tmp_path, mock_resolve, mock_retrieve, mock_load
+):
+    sentinel, mock_load_fn = mock_load
+    dest = tmp_path / _TEMPLATE_ROOT / _FILENAME
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text("old")
+
+    result = fetch_template_huang_2025(data_dir=tmp_path, refresh=True)
+
+    assert result is sentinel
+    mock_resolve.assert_called_once_with()
+    mock_retrieve.assert_called_once()
+    mock_load_fn.assert_called_once_with(dest)
+    assert dest.exists()


### PR DESCRIPTION
## Summary
- add `fetch_template_huang_2025` for OSF project `am3jw`
- export/register fetcher and add unit tests
- update datasets + citing docs (including dataset/template license notes)
- add license links in fetcher docstrings

Closes #161