### PR TITLE
fix(napari): restore accordion transitions

### DIFF
--- a/src/confusius/_napari/_constants.py
+++ b/src/confusius/_napari/_constants.py
@@ -1,0 +1,4 @@
+"""Shared napari UI constants."""
+
+ACCORDION_ANIMATION_DURATION_MS = 200
+"""Duration of accordion expand/collapse animations, in milliseconds."""

--- a/src/confusius/_napari/_constants.py
+++ b/src/confusius/_napari/_constants.py
@@ -1,4 +1,0 @@
-"""Shared napari UI constants."""
-
-ACCORDION_ANIMATION_DURATION_MS = 200
-"""Duration of accordion expand/collapse animations, in milliseconds."""

--- a/src/confusius/_napari/_tour.py
+++ b/src/confusius/_napari/_tour.py
@@ -453,19 +453,8 @@ class GuidedTour(QObject):
         # the final geometry — including animations started by a previous
         # step. Connections die with the short-lived animation objects.
         for anim in self._animations_source():
-            anim.valueChanged.connect(self._on_animation_frame)
-            anim.finished.connect(self._on_animation_frame)
-
-    def _on_animation_frame(self, _value: object = None) -> None:
-        """Track an animation frame by recomputing the current step geometry.
-
-        Parameters
-        ----------
-        _value : object, optional
-            Animated value emitted by `valueChanged`; unused (the `finished`
-            signal emits nothing).
-        """
-        self._reposition_current()
+            anim.valueChanged.connect(lambda _value: self._reposition_current())
+            anim.finished.connect(self._reposition_current)
 
     def _position_step(self, index: int, generation: int) -> None:
         """Measure target geometry and place the spotlight + tooltip."""

--- a/src/confusius/_napari/_tour.py
+++ b/src/confusius/_napari/_tour.py
@@ -10,8 +10,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from qtpy.QtCore import QEvent, QObject, QPoint, QRect, Qt, QTimer, Signal
-
-from confusius._napari._widget import _ACCORDION_ANIMATION_DURATION_MS
 from qtpy.QtGui import QColor, QFont, QPainter, QPen
 from qtpy.QtWidgets import (
     QDockWidget,
@@ -21,6 +19,8 @@ from qtpy.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
+
+from confusius._napari._constants import ACCORDION_ANIMATION_DURATION_MS
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -53,9 +53,10 @@ class TourStep:
         Optional callable returning the widget used only for tooltip placement.
         This lets the spotlight track a small control while the tooltip is
         positioned relative to a larger container such as the napari dock.
-    pre_action : Callable[[], None] | None
+    pre_action : Callable[[], bool] | None
         Optional callback executed before this step is shown (e.g. to expand
-        an accordion section so the target widget becomes visible).
+        an accordion section so the target widget becomes visible). Returns
+        whether the action triggered an accordion animation.
     """
 
     target: Callable[[], QWidget | None]
@@ -64,7 +65,7 @@ class TourStep:
     anchor: str = "right"
     spotlight_rect: Callable[[], QRect | None] | None = None
     tooltip_target: Callable[[], QWidget | None] | None = None
-    pre_action: Callable[[], None] | None = None
+    pre_action: Callable[[], bool] | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -436,14 +437,15 @@ class GuidedTour(QObject):
         step = self._steps[index]
 
         if step.pre_action is not None:
-            step.pre_action()
-            # Accordion sections expand/collapse with animation, so measuring on the
-            # next event-loop turn can capture stale geometry before headers and the
-            # opened panel settle into their final positions.
-            QTimer.singleShot(
-                _ACCORDION_ANIMATION_DURATION_MS + 20,
-                lambda g=gen: self._position_step(index, g),
-            )
+            did_animate = step.pre_action()
+            self._position_step(index, gen)
+            if did_animate:
+                # Accordion sections expand/collapse with animation, so measure once
+                # immediately and then again after the panel settles.
+                QTimer.singleShot(
+                    ACCORDION_ANIMATION_DURATION_MS + 20,
+                    lambda g=gen: self._position_step(index, g),
+                )
         else:
             self._position_step(index, gen)
 
@@ -633,11 +635,13 @@ def build_default_tour(
 
         return _find
 
-    def _expand_section(label: str) -> Callable[[], None]:
-        def _action() -> None:
+    def _expand_section(label: str) -> Callable[[], bool]:
+        def _action() -> bool:
             for btn, _icon in getattr(plugin_widget, "_accordion_btns", []):
                 if btn.text() == label and not btn.isChecked():
                     btn.click()
+                    return True
+            return False
 
         return _action
 

--- a/src/confusius/_napari/_tour.py
+++ b/src/confusius/_napari/_tour.py
@@ -10,6 +10,8 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from qtpy.QtCore import QEvent, QObject, QPoint, QRect, Qt, QTimer, Signal
+
+from confusius._napari._widget import _ACCORDION_ANIMATION_DURATION_MS
 from qtpy.QtGui import QColor, QFont, QPainter, QPen
 from qtpy.QtWidgets import (
     QDockWidget,
@@ -435,8 +437,13 @@ class GuidedTour(QObject):
 
         if step.pre_action is not None:
             step.pre_action()
-            # Let Qt finish any visibility or layout changes before measuring.
-            QTimer.singleShot(0, lambda g=gen: self._position_step(index, g))
+            # Accordion sections expand/collapse with animation, so measuring on the
+            # next event-loop turn can capture stale geometry before headers and the
+            # opened panel settle into their final positions.
+            QTimer.singleShot(
+                _ACCORDION_ANIMATION_DURATION_MS + 20,
+                lambda g=gen: self._position_step(index, g),
+            )
         else:
             self._position_step(index, gen)
 

--- a/src/confusius/_napari/_tour.py
+++ b/src/confusius/_napari/_tour.py
@@ -20,11 +20,10 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
-from confusius._napari._constants import ACCORDION_ANIMATION_DURATION_MS
-
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterable
 
+    from qtpy.QtCore import QVariantAnimation
     from qtpy.QtGui import QMouseEvent, QPaintEvent
 
 
@@ -53,10 +52,9 @@ class TourStep:
         Optional callable returning the widget used only for tooltip placement.
         This lets the spotlight track a small control while the tooltip is
         positioned relative to a larger container such as the napari dock.
-    pre_action : Callable[[], bool] | None
+    pre_action : Callable[[], None] | None
         Optional callback executed before this step is shown (e.g. to expand
-        an accordion section so the target widget becomes visible). Returns
-        whether the action triggered an accordion animation.
+        an accordion section so the target widget becomes visible).
     """
 
     target: Callable[[], QWidget | None]
@@ -65,7 +63,7 @@ class TourStep:
     anchor: str = "right"
     spotlight_rect: Callable[[], QRect | None] | None = None
     tooltip_target: Callable[[], QWidget | None] | None = None
-    pre_action: Callable[[], bool] | None = None
+    pre_action: Callable[[], None] | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -321,6 +319,12 @@ class GuidedTour(QObject):
     on_close : Callable[[], None] | None
         Optional callback invoked when the tour ends (skip or finish). Use
         this to restore any UI state changed by the tour's pre-actions.
+    animations_source : Callable[[], Iterable[QVariantAnimation]] | None
+        Optional callable returning the UI animations currently in flight
+        (e.g. accordion panels expanding). After showing a step, the tour
+        subscribes to these animations and repositions the spotlight on
+        every frame so it settles on the final geometry. If not provided,
+        each step is positioned once when shown.
     """
 
     finished = Signal()
@@ -332,10 +336,12 @@ class GuidedTour(QObject):
         *,
         is_dark: bool = True,
         on_close: Callable[[], None] | None = None,
+        animations_source: Callable[[], Iterable[QVariantAnimation]] | None = None,
     ) -> None:
         super().__init__(parent_window)
         self._steps = steps
         self._window = parent_window
+        self._animations_source = animations_source
         self._current = 0
         # Incremented on every _show_step call so stale QTimer callbacks from
         # rapid next/back clicks are discarded.
@@ -437,17 +443,29 @@ class GuidedTour(QObject):
         step = self._steps[index]
 
         if step.pre_action is not None:
-            did_animate = step.pre_action()
-            self._position_step(index, gen)
-            if did_animate:
-                # Accordion sections expand/collapse with animation, so measure once
-                # immediately and then again after the panel settles.
-                QTimer.singleShot(
-                    ACCORDION_ANIMATION_DURATION_MS + 20,
-                    lambda g=gen: self._position_step(index, g),
-                )
-        else:
-            self._position_step(index, gen)
+            step.pre_action()
+        self._position_step(index, gen)
+
+        if self._animations_source is None:
+            return
+        # Follow any in-flight panel animation (e.g. an accordion section
+        # expanding) so the spotlight grows with the panel and settles on
+        # the final geometry — including animations started by a previous
+        # step. Connections die with the short-lived animation objects.
+        for anim in self._animations_source():
+            anim.valueChanged.connect(self._on_animation_frame)
+            anim.finished.connect(self._on_animation_frame)
+
+    def _on_animation_frame(self, _value: object = None) -> None:
+        """Track an animation frame by recomputing the current step geometry.
+
+        Parameters
+        ----------
+        _value : object, optional
+            Animated value emitted by `valueChanged`; unused (the `finished`
+            signal emits nothing).
+        """
+        self._reposition_current()
 
     def _position_step(self, index: int, generation: int) -> None:
         """Measure target geometry and place the spotlight + tooltip."""
@@ -635,13 +653,12 @@ def build_default_tour(
 
         return _find
 
-    def _expand_section(label: str) -> Callable[[], bool]:
-        def _action() -> bool:
+    def _expand_section(label: str) -> Callable[[], None]:
+        def _action() -> None:
             for btn, _icon in getattr(plugin_widget, "_accordion_btns", []):
                 if btn.text() == label and not btn.isChecked():
                     btn.click()
-                    return True
-            return False
+                    break
 
         return _action
 
@@ -911,4 +928,13 @@ def build_default_tour(
         ),
     ]
 
-    return GuidedTour(steps, window, is_dark=is_dark, on_close=_restore_state)
+    def _accordion_animations() -> list[QVariantAnimation]:
+        return list(getattr(plugin_widget, "_accordion_anims", {}).values())
+
+    return GuidedTour(
+        steps,
+        window,
+        is_dark=is_dark,
+        on_close=_restore_state,
+        animations_source=_accordion_animations,
+    )

--- a/src/confusius/_napari/_widget.py
+++ b/src/confusius/_napari/_widget.py
@@ -585,7 +585,4 @@ class ConfUSIusWidget(QWidget):
         # Exposed so the guided tour can follow in-flight panel animations.
         self._accordion_anims = panel_anims
 
-        # Store so GuidedTour can be told when accordion animations finish
-        self._accordion_anims = panel_anims
-
         return container

--- a/src/confusius/_napari/_widget.py
+++ b/src/confusius/_napari/_widget.py
@@ -4,9 +4,17 @@ from __future__ import annotations
 
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
-from qtpy.QtCore import QByteArray, QRectF, QSize, Qt, QTimer
+from qtpy.QtCore import (
+    QByteArray,
+    QEasingCurve,
+    QPropertyAnimation,
+    QRectF,
+    QSize,
+    Qt,
+    QTimer,
+)
 from qtpy.QtGui import QFont, QImage, QPainter, QPixmap
 from qtpy.QtSvg import QSvgRenderer as _QSvgRenderer
 from qtpy.QtWidgets import (
@@ -29,6 +37,7 @@ if TYPE_CHECKING:
     from confusius._napari._tour import GuidedTour
 
 _ASSETS_DIR = Path(__file__).parent / "assets"
+_ACCORDION_ANIMATION_DURATION_MS = 200
 
 
 def _build_stylesheet(is_dark: bool, napari_bg: str | None = None) -> str:  # noqa: C901
@@ -449,6 +458,7 @@ class ConfUSIusWidget(QWidget):
         from confusius._napari._video._video_panel import VideoPanel
 
         container = QWidget()
+        setattr(container, "_anims", [])
         layout = QVBoxLayout(container)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
@@ -497,6 +507,7 @@ class ConfUSIusWidget(QWidget):
             panel.setSizePolicy(
                 QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding
             )
+            panel.setMinimumHeight(0)
             panel.setVisible(i == 0)
             btns.append(btn)
 
@@ -504,17 +515,68 @@ class ConfUSIusWidget(QWidget):
         # buttons stack at the top of the accordion area.
         layout.addStretch(1)
 
+        def _drop_anim(anim: QPropertyAnimation) -> None:
+            anims = cast(list[QPropertyAnimation], getattr(container, "_anims"))
+            try:
+                anims.remove(anim)
+            except ValueError:
+                pass
+
         def _activate_panel(panel_index: int) -> None:
             # Clicking the already-open panel collapses it (all closed).
             already_open = panels[panel_index].isVisible()
-            target = -1 if already_open else panel_index  # -1 means all collapsed
+            target = -1 if already_open else panel_index
+            available_height = max(
+                container.height() - sum(b.height() for b in btns), 50
+            )
 
-            for j, (b, p) in enumerate(zip(btns, panels)):
+            for j, (button, panel) in enumerate(zip(btns, panels)):
                 active = j == target
-                b.blockSignals(True)
-                b.setChecked(active)
-                b.blockSignals(False)
-                p.setVisible(active)
+                button.blockSignals(True)
+                button.setChecked(active)
+                button.blockSignals(False)
+
+                if active and not panel.isVisible():
+                    panel.setMaximumHeight(0)
+                    panel.show()
+                    anim = QPropertyAnimation(panel, b"maximumHeight")
+                    anim.setDuration(_ACCORDION_ANIMATION_DURATION_MS)
+                    anim.setStartValue(0)
+                    anim.setEndValue(available_height)
+                    anim.setEasingCurve(QEasingCurve.Type.InOutCubic)
+
+                    def _on_expand_done(
+                        target_panel: QWidget = panel,
+                        target_anim: QPropertyAnimation = anim,
+                    ) -> None:
+                        target_panel.setMaximumHeight(16777215)
+                        _drop_anim(target_anim)
+
+                    anim.finished.connect(_on_expand_done)
+                    cast(list[QPropertyAnimation], getattr(container, "_anims")).append(
+                        anim
+                    )
+                    anim.start()
+                elif not active and panel.isVisible():
+                    anim = QPropertyAnimation(panel, b"maximumHeight")
+                    anim.setDuration(_ACCORDION_ANIMATION_DURATION_MS)
+                    anim.setStartValue(panel.height())
+                    anim.setEndValue(0)
+                    anim.setEasingCurve(QEasingCurve.Type.InOutCubic)
+
+                    def _on_collapse_done(
+                        target_panel: QWidget = panel,
+                        target_anim: QPropertyAnimation = anim,
+                    ) -> None:
+                        target_panel.hide()
+                        target_panel.setMaximumHeight(16777215)
+                        _drop_anim(target_anim)
+
+                    anim.finished.connect(_on_collapse_done)
+                    cast(list[QPropertyAnimation], getattr(container, "_anims")).append(
+                        anim
+                    )
+                    anim.start()
 
         for i, btn in enumerate(btns):
             btn.clicked.connect(lambda _checked, i=i: _activate_panel(i))

--- a/src/confusius/_napari/_widget.py
+++ b/src/confusius/_napari/_widget.py
@@ -18,6 +18,7 @@ from qtpy.QtCore import (
 from qtpy.QtGui import QFont, QImage, QPainter, QPixmap
 from qtpy.QtSvg import QSvgRenderer as _QSvgRenderer
 from qtpy.QtWidgets import (
+    QWIDGETSIZE_MAX,
     QApplication,
     QHBoxLayout,
     QLabel,
@@ -25,11 +26,9 @@ from qtpy.QtWidgets import (
     QScrollArea,
     QSizePolicy,
     QVBoxLayout,
-    QWIDGETSIZE_MAX,
     QWidget,
 )
 
-from confusius._napari._constants import ACCORDION_ANIMATION_DURATION_MS
 from confusius._napari._theme import make_lucide_icon
 from confusius._napari._time_overlay import _TimeOverlay
 
@@ -39,6 +38,9 @@ if TYPE_CHECKING:
     from confusius._napari._tour import GuidedTour
 
 _ASSETS_DIR = Path(__file__).parent / "assets"
+
+ACCORDION_ANIMATION_DURATION_MS = 200
+"""Duration of accordion expand/collapse animations, in milliseconds."""
 
 
 def _build_stylesheet(is_dark: bool, napari_bg: str | None = None) -> str:  # noqa: C901
@@ -580,5 +582,10 @@ class ConfUSIusWidget(QWidget):
         # Store for icon re-tinting on theme change and tour access.
         self._accordion_btns = list(zip(btns, [e[1] for e in tab_entries]))
         self._accordion_panels = dict(zip([e[0] for e in tab_entries], panels))
+        # Exposed so the guided tour can follow in-flight panel animations.
+        self._accordion_anims = panel_anims
+
+        # Store so GuidedTour can be told when accordion animations finish
+        self._accordion_anims = panel_anims
 
         return container

--- a/src/confusius/_napari/_widget.py
+++ b/src/confusius/_napari/_widget.py
@@ -28,6 +28,7 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
+from confusius._napari._constants import ACCORDION_ANIMATION_DURATION_MS
 from confusius._napari._theme import make_lucide_icon
 from confusius._napari._time_overlay import _TimeOverlay
 
@@ -37,7 +38,6 @@ if TYPE_CHECKING:
     from confusius._napari._tour import GuidedTour
 
 _ASSETS_DIR = Path(__file__).parent / "assets"
-_ACCORDION_ANIMATION_DURATION_MS = 200
 
 
 def _build_stylesheet(is_dark: bool, napari_bg: str | None = None) -> str:  # noqa: C901
@@ -459,6 +459,7 @@ class ConfUSIusWidget(QWidget):
 
         container = QWidget()
         setattr(container, "_anims", [])
+        setattr(container, "_panel_anims", {})
         layout = QVBoxLayout(container)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
@@ -522,6 +523,25 @@ class ConfUSIusWidget(QWidget):
             except ValueError:
                 pass
 
+        def _panel_anim(panel: QWidget) -> QPropertyAnimation | None:
+            panel_anims = cast(
+                dict[QWidget, QPropertyAnimation], getattr(container, "_panel_anims")
+            )
+            return panel_anims.get(panel)
+
+        def _replace_panel_anim(
+            panel: QWidget, anim: QPropertyAnimation | None
+        ) -> None:
+            panel_anims = cast(
+                dict[QWidget, QPropertyAnimation], getattr(container, "_panel_anims")
+            )
+            previous = panel_anims.pop(panel, None)
+            if previous is not None:
+                previous.stop()
+                _drop_anim(previous)
+            if anim is not None:
+                panel_anims[panel] = anim
+
         def _activate_panel(panel_index: int) -> None:
             # Clicking the already-open panel collapses it (all closed).
             already_open = panels[panel_index].isVisible()
@@ -540,16 +560,20 @@ class ConfUSIusWidget(QWidget):
                     panel.setMaximumHeight(0)
                     panel.show()
                     anim = QPropertyAnimation(panel, b"maximumHeight")
-                    anim.setDuration(_ACCORDION_ANIMATION_DURATION_MS)
+                    anim.setDuration(ACCORDION_ANIMATION_DURATION_MS)
                     anim.setStartValue(0)
                     anim.setEndValue(available_height)
                     anim.setEasingCurve(QEasingCurve.Type.InOutCubic)
+                    _replace_panel_anim(panel, anim)
 
                     def _on_expand_done(
                         target_panel: QWidget = panel,
                         target_anim: QPropertyAnimation = anim,
                     ) -> None:
+                        if _panel_anim(target_panel) is not target_anim:
+                            return
                         target_panel.setMaximumHeight(16777215)
+                        _replace_panel_anim(target_panel, None)
                         _drop_anim(target_anim)
 
                     anim.finished.connect(_on_expand_done)
@@ -559,17 +583,21 @@ class ConfUSIusWidget(QWidget):
                     anim.start()
                 elif not active and panel.isVisible():
                     anim = QPropertyAnimation(panel, b"maximumHeight")
-                    anim.setDuration(_ACCORDION_ANIMATION_DURATION_MS)
+                    anim.setDuration(ACCORDION_ANIMATION_DURATION_MS)
                     anim.setStartValue(panel.height())
                     anim.setEndValue(0)
                     anim.setEasingCurve(QEasingCurve.Type.InOutCubic)
+                    _replace_panel_anim(panel, anim)
 
                     def _on_collapse_done(
                         target_panel: QWidget = panel,
                         target_anim: QPropertyAnimation = anim,
                     ) -> None:
+                        if _panel_anim(target_panel) is not target_anim:
+                            return
                         target_panel.hide()
                         target_panel.setMaximumHeight(16777215)
+                        _replace_panel_anim(target_panel, None)
                         _drop_anim(target_anim)
 
                     anim.finished.connect(_on_collapse_done)

--- a/src/confusius/_napari/_widget.py
+++ b/src/confusius/_napari/_widget.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from qtpy.QtCore import (
     QByteArray,
@@ -25,6 +25,7 @@ from qtpy.QtWidgets import (
     QScrollArea,
     QSizePolicy,
     QVBoxLayout,
+    QWIDGETSIZE_MAX,
     QWidget,
 )
 
@@ -458,8 +459,6 @@ class ConfUSIusWidget(QWidget):
         from confusius._napari._video._video_panel import VideoPanel
 
         container = QWidget()
-        setattr(container, "_anims", [])
-        setattr(container, "_panel_anims", {})
         layout = QVBoxLayout(container)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
@@ -508,6 +507,8 @@ class ConfUSIusWidget(QWidget):
             panel.setSizePolicy(
                 QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding
             )
+            # Allow the collapse animation to shrink the panel below its
+            # content's minimum size hint.
             panel.setMinimumHeight(0)
             panel.setVisible(i == 0)
             btns.append(btn)
@@ -516,31 +517,41 @@ class ConfUSIusWidget(QWidget):
         # buttons stack at the top of the accordion area.
         layout.addStretch(1)
 
-        def _drop_anim(anim: QPropertyAnimation) -> None:
-            anims = cast(list[QPropertyAnimation], getattr(container, "_anims"))
-            try:
-                anims.remove(anim)
-            except ValueError:
-                pass
-
-        def _panel_anim(panel: QWidget) -> QPropertyAnimation | None:
-            panel_anims = cast(
-                dict[QWidget, QPropertyAnimation], getattr(container, "_panel_anims")
-            )
-            return panel_anims.get(panel)
+        # Maps each panel to its in-flight animation; also keeps the Python-side
+        # reference alive until the animation finishes or is replaced.
+        panel_anims: dict[QWidget, QPropertyAnimation] = {}
 
         def _replace_panel_anim(
             panel: QWidget, anim: QPropertyAnimation | None
         ) -> None:
-            panel_anims = cast(
-                dict[QWidget, QPropertyAnimation], getattr(container, "_panel_anims")
-            )
             previous = panel_anims.pop(panel, None)
             if previous is not None:
                 previous.stop()
-                _drop_anim(previous)
             if anim is not None:
                 panel_anims[panel] = anim
+
+        def _animate_panel(
+            panel: QWidget, start: int, end: int, *, hide_on_done: bool
+        ) -> None:
+            anim = QPropertyAnimation(panel, b"maximumHeight")
+            anim.setDuration(ACCORDION_ANIMATION_DURATION_MS)
+            anim.setStartValue(start)
+            anim.setEndValue(end)
+            anim.setEasingCurve(QEasingCurve.Type.InOutCubic)
+            _replace_panel_anim(panel, anim)
+
+            def _on_done() -> None:
+                # Stale callback — this animation was replaced (stop() also
+                # emits finished).
+                if panel_anims.get(panel) is not anim:
+                    return
+                if hide_on_done:
+                    panel.hide()
+                panel.setMaximumHeight(QWIDGETSIZE_MAX)
+                _replace_panel_anim(panel, None)
+
+            anim.finished.connect(_on_done)
+            anim.start()
 
         def _activate_panel(panel_index: int) -> None:
             # Clicking the already-open panel collapses it (all closed).
@@ -559,52 +570,9 @@ class ConfUSIusWidget(QWidget):
                 if active and not panel.isVisible():
                     panel.setMaximumHeight(0)
                     panel.show()
-                    anim = QPropertyAnimation(panel, b"maximumHeight")
-                    anim.setDuration(ACCORDION_ANIMATION_DURATION_MS)
-                    anim.setStartValue(0)
-                    anim.setEndValue(available_height)
-                    anim.setEasingCurve(QEasingCurve.Type.InOutCubic)
-                    _replace_panel_anim(panel, anim)
-
-                    def _on_expand_done(
-                        target_panel: QWidget = panel,
-                        target_anim: QPropertyAnimation = anim,
-                    ) -> None:
-                        if _panel_anim(target_panel) is not target_anim:
-                            return
-                        target_panel.setMaximumHeight(16777215)
-                        _replace_panel_anim(target_panel, None)
-                        _drop_anim(target_anim)
-
-                    anim.finished.connect(_on_expand_done)
-                    cast(list[QPropertyAnimation], getattr(container, "_anims")).append(
-                        anim
-                    )
-                    anim.start()
+                    _animate_panel(panel, 0, available_height, hide_on_done=False)
                 elif not active and panel.isVisible():
-                    anim = QPropertyAnimation(panel, b"maximumHeight")
-                    anim.setDuration(ACCORDION_ANIMATION_DURATION_MS)
-                    anim.setStartValue(panel.height())
-                    anim.setEndValue(0)
-                    anim.setEasingCurve(QEasingCurve.Type.InOutCubic)
-                    _replace_panel_anim(panel, anim)
-
-                    def _on_collapse_done(
-                        target_panel: QWidget = panel,
-                        target_anim: QPropertyAnimation = anim,
-                    ) -> None:
-                        if _panel_anim(target_panel) is not target_anim:
-                            return
-                        target_panel.hide()
-                        target_panel.setMaximumHeight(16777215)
-                        _replace_panel_anim(target_panel, None)
-                        _drop_anim(target_anim)
-
-                    anim.finished.connect(_on_collapse_done)
-                    cast(list[QPropertyAnimation], getattr(container, "_anims")).append(
-                        anim
-                    )
-                    anim.start()
+                    _animate_panel(panel, panel.height(), 0, hide_on_done=True)
 
         for i, btn in enumerate(btns):
             btn.clicked.connect(lambda _checked, i=i: _activate_panel(i))


### PR DESCRIPTION
## Summary
- restore smooth open/close animation for napari accordion sections
- keep guided tour highlighting in sync with the post-animation layout
- share the accordion animation duration constant between the widget and tour

Closes #169
