### PR TITLE
fix(docs): make gallery build CI-friendly

### DIFF
--- a/docs/examples/02_registration/01_register_volume_same_subject.py
+++ b/docs/examples/02_registration/01_register_volume_same_subject.py
@@ -60,10 +60,11 @@ def _load_angio_for_registration(session: str) -> xr.DataArray:
 
 
 fixed = _load_angio_for_registration(sessions[0])
-moving = _load_angio_for_registration(sessions[1])
 
 fixed
 # %%
+moving = _load_angio_for_registration(sessions[1])
+
 moving
 
 # %% [markdown]

--- a/justfile
+++ b/justfile
@@ -10,8 +10,14 @@ gallery:
     uv run python tools/build_gallery.py
 
 # Remove generated gallery artifacts and the gallery cache.
+[unix]
 clean-gallery:
-    rm -rf docs/examples/_built docs/examples/index.md .cache/gallery
+    rm -rf docs/examples/_built docs/examples/index.md .gallery-cache
+
+# Remove generated gallery artifacts and the gallery cache.
+[windows]
+clean-gallery:
+    foreach ($p in 'docs/examples/_built', 'docs/examples/index.md', '.gallery-cache') { if (Test-Path $p) { Remove-Item -Recurse -Force $p } }
 
 # Build documentation.
 docs: gallery
@@ -22,9 +28,14 @@ serve-docs: gallery
     uv run zensical serve
 
 # Clean documentation build artifacts.
+[unix]
 clean-docs: clean-gallery
-    rm -rf .cache/
-    rm -rf site/
+    rm -rf .cache/ site/
+
+# Clean documentation build artifacts.
+[windows]
+clean-docs: clean-gallery
+    foreach ($p in '.cache', 'site') { if (Test-Path $p) { Remove-Item -Recurse -Force $p } }
 
 # Generate documentation images.
 generate-doc-images:
@@ -42,8 +53,15 @@ test-verbose:
     uv run pytest tests/ -v --mpl
 
 # Generate baseline images for visual regression tests.
+[unix]
 generate-baselines:
     rm -f tests/unit/test_plotting/baseline/*.png
+    uv run pytest --mpl-generate-path=tests/unit/test_plotting/baseline tests/unit/test_plotting/test_image.py::TestPlotVolumeVisualRegression tests/unit/test_plotting/test_image.py::TestPlotContoursVisualRegression
+
+# Generate baseline images for visual regression tests.
+[windows]
+generate-baselines:
+    if (Test-Path tests/unit/test_plotting/baseline/*.png) { Remove-Item -Force tests/unit/test_plotting/baseline/*.png }
     uv run pytest --mpl-generate-path=tests/unit/test_plotting/baseline tests/unit/test_plotting/test_image.py::TestPlotVolumeVisualRegression tests/unit/test_plotting/test_image.py::TestPlotContoursVisualRegression
 
 # Run all pre-commit hooks.

--- a/tests/integration/test_gallery/test_build_gallery.py
+++ b/tests/integration/test_gallery/test_build_gallery.py
@@ -64,6 +64,43 @@ def test_build_gallery_produces_expected_artifacts(gallery_paths: GalleryPaths) 
 
 
 @pytest.mark.slow
+def test_build_gallery_prints_progress_when_non_interactive(
+    gallery_paths: GalleryPaths, capsys: pytest.CaptureFixture[str]
+) -> None:
+    examples_root, built_dir, cache_root = gallery_paths
+
+    _seed_example(
+        examples_root,
+        "io",
+        "hello",
+        "# %% [markdown]\n# # Hello\n\n# %%\nprint('hi')\n",
+    )
+
+    # Under pytest stdout is captured and reports ``isatty() == False``, so the
+    # builder takes its non-interactive path and emits plain progress lines
+    # instead of the rich live bar.
+    build_gallery(
+        examples_root=examples_root,
+        built_dir=built_dir,
+        cache_root=cache_root,
+        deps_fingerprint="testdeps==1.0",
+    )
+    fresh = capsys.readouterr().out
+    assert "-> io/hello" in fresh
+    assert "done in" in fresh
+
+    # A second run hits the cache and announces it.
+    shutil.rmtree(built_dir)
+    build_gallery(
+        examples_root=examples_root,
+        built_dir=built_dir,
+        cache_root=cache_root,
+        deps_fingerprint="testdeps==1.0",
+    )
+    assert "[cached]" in capsys.readouterr().out
+
+
+@pytest.mark.slow
 def test_build_gallery_embeds_binder_launch_url(gallery_paths: GalleryPaths) -> None:
     examples_root, built_dir, cache_root = gallery_paths
     repo_root = examples_root.parent.parent

--- a/tests/integration/test_gallery/test_render.py
+++ b/tests/integration/test_gallery/test_render.py
@@ -1,0 +1,54 @@
+"""Unit tests for the gallery Markdown renderer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import nbformat
+import pytest
+
+from tools.gallery.render import render_notebook
+
+
+def _notebook_with_outputs(outputs: list[dict[str, object]]) -> nbformat.NotebookNode:
+    """Return a one-code-cell notebook whose single cell carries ``outputs``."""
+    cell = nbformat.v4.new_code_cell("print('x')")
+    cell.outputs = outputs
+    nb = nbformat.v4.new_notebook()
+    nb.cells = [cell]
+    return nb
+
+
+def test_render_notebook_shows_outputs_on_count_mismatch(tmp_path: Path) -> None:
+    """A light/dark output-count mismatch reports the actual outputs, not just counts."""
+    source = _notebook_with_outputs([])
+    light = _notebook_with_outputs(
+        [
+            {"output_type": "stream", "name": "stdout", "text": "shared"},
+            {
+                "output_type": "stream",
+                "name": "stderr",
+                "text": "only-in-light warning",
+            },
+        ]
+    )
+    dark = _notebook_with_outputs(
+        [{"output_type": "stream", "name": "stdout", "text": "shared"}]
+    )
+
+    with pytest.raises(ValueError, match="2 light outputs and 1 dark") as excinfo:
+        render_notebook(
+            source,
+            light,
+            dark,
+            out_dir=tmp_path,
+            base_name="demo",
+            runtime_seconds=1.0,
+        )
+
+    message = str(excinfo.value)
+    # The richer message exists so the offending extra output is visible; a
+    # counts-only message would not contain the stray warning text.
+    assert "only-in-light warning" in message
+    assert "Light outputs (2):" in message
+    assert "Dark outputs (1):" in message

--- a/tools/gallery/_pipeline.py
+++ b/tools/gallery/_pipeline.py
@@ -95,13 +95,40 @@ def _rewrite_binder_button(md_path: Path, binder_url: str | None) -> None:
         md_path.write_text(updated, encoding="utf-8")
 
 
-def _make_progress() -> Progress:
-    """Return a rich Progress configured for the gallery builder."""
+def _is_interactive() -> bool:
+    """Whether stdout is an interactive terminal where a live bar is usable.
+
+    Returns
+    -------
+    bool
+        Whether `sys.stdout` is attached to a TTY. This is `False` in CI (e.g.
+        GitHub Actions) and whenever output is redirected/piped, which is exactly
+        when the rich live bar produces no useful incremental output.
+    """
+    return sys.stdout.isatty()
+
+
+def _make_progress(interactive: bool) -> Progress:
+    """Return a rich Progress configured for the gallery builder.
+
+    Parameters
+    ----------
+    interactive : bool
+        Whether stdout is an interactive terminal. When `False`, the live bar is
+        disabled so it does not emit control characters into non-TTY logs; plain
+        per-example lines are printed instead (see `_build_one`).
+
+    Returns
+    -------
+    rich.progress.Progress
+        The configured progress instance.
+    """
     return Progress(
         TextColumn("  {task.description}"),
         BarColumn(),
         TextColumn("{task.completed}/{task.total} cells"),
         TimeElapsedColumn(),
+        disable=not interactive,
     )
 
 
@@ -127,6 +154,7 @@ def _build_one(
     cache_root: Path,
     deps_fingerprint: str,
     progress: Progress,
+    interactive: bool,
     binder_url: str | None = None,
 ) -> RenderedExample:
     """Build one example and return its rendered metadata."""
@@ -149,6 +177,10 @@ def _build_one(
 
     if cache_entry.is_dir():
         progress.add_task(f"{spec.section}/{base_name} [cached]", total=1, completed=1)
+        # The live bar already conveys this interactively; in CI/non-TTY the bar is
+        # disabled, so emit a plain flushed line instead.
+        if not interactive:
+            print(f"-> {spec.section}/{base_name} [cached]", flush=True)
         thumb = _write_cached_artifacts(cache_entry, out_dir, base_name)
         _rewrite_binder_button(out_dir / f"{base_name}.md", binder_url)
         return RenderedExample(
@@ -158,6 +190,11 @@ def _build_one(
             md_path=out_dir / f"{base_name}.md",
             thumbnail_light=thumb[0] if thumb is not None else None,
             thumbnail_dark=thumb[1] if thumb is not None else None,
+        )
+
+    if not interactive:
+        print(
+            f"-> {spec.section}/{base_name} ({n_cells} cells, light+dark)", flush=True
         )
 
     light_task = progress.add_task(f"{spec.section}/{base_name} (light)", total=n_cells)
@@ -172,6 +209,9 @@ def _build_one(
         theme="dark",
         on_cell_executed=_advance_on_cell(progress, dark_task),
     )
+
+    if not interactive:
+        print(f"   done in {light_seconds:.1f}s", flush=True)
 
     scratch = cache_root / "_scratch" / spec.section / base_name
     if scratch.exists():
@@ -232,7 +272,8 @@ def build_gallery(
     cache_root.mkdir(parents=True, exist_ok=True)
 
     rendered: list[RenderedExample] = []
-    with _make_progress() as progress:
+    interactive = _is_interactive()
+    with _make_progress(interactive) as progress:
         for spec in specs:
             binder_url = (
                 _binder_url(
@@ -251,6 +292,7 @@ def build_gallery(
                     cache_root=cache_root,
                     deps_fingerprint=deps_fingerprint,
                     progress=progress,
+                    interactive=interactive,
                     binder_url=binder_url,
                 )
             )

--- a/tools/gallery/render.py
+++ b/tools/gallery/render.py
@@ -128,6 +128,62 @@ def _clean_stream_text(text: str) -> str:
     return "\n".join(cleaned_lines).strip("\n")
 
 
+def _summarize_output(output: dict[str, object]) -> str:
+    """Return a one-line human-readable summary of one notebook output.
+
+    Used to build a useful error message when the light and dark runs disagree on
+    the number of outputs for a cell: showing what each side actually produced makes
+    the offending extra (a stray warning, a one-shot download log, etc.) obvious.
+
+    Parameters
+    ----------
+    output : dict[str, object]
+        One nbformat output node (a dict with an `output_type` key).
+
+    Returns
+    -------
+    str
+        A short, single-line description of the output's type and content.
+    """
+    output_type = output.get("output_type")
+    if output_type == "stream":
+        name = output.get("name", "stdout")
+        text = str(output.get("text", "")).replace("\n", "\\n")
+        return f"stream[{name}]: {text[:200]}"
+    if output_type in {"execute_result", "display_data"}:
+        data = output.get("data", {})
+        keys = sorted(data) if isinstance(data, dict) else []
+        summary = f"{output_type}: {{{', '.join(keys)}}}"
+        if isinstance(data, dict) and "text/plain" in data:
+            preview = str(data["text/plain"]).replace("\n", "\\n")
+            summary += f" -> {preview[:120]}"
+        return summary
+    if output_type == "error":
+        return f"error: {output.get('ename')}: {output.get('evalue')}"
+    return str(output_type)
+
+
+def _summarize_outputs(outputs: list[dict[str, object]]) -> str:
+    """Return a numbered, indented summary of a cell's outputs.
+
+    Parameters
+    ----------
+    outputs : list[dict[str, object]]
+        The outputs of one notebook cell.
+
+    Returns
+    -------
+    str
+        One `_summarize_output` line per output, numbered and indented, or `(none)`
+        when the cell produced no outputs.
+    """
+    if not outputs:
+        return "  (none)"
+    return "\n".join(
+        f"  {i}. {_summarize_output(output)}" for i, output in enumerate(outputs, 1)
+    )
+
+
 def render_notebook(
     source_notebook: nbformat.NotebookNode,
     light_notebook: nbformat.NotebookNode,
@@ -185,7 +241,11 @@ def render_notebook(
                 "dark outputs. Light/dark executions must be deterministic; "
                 "make sure any one-shot side effects (dataset downloads, "
                 "first-import warnings, etc.) happen before the gallery "
-                "build."
+                "build.\n"
+                f"Light outputs ({len(light_outputs)}):\n"
+                f"{_summarize_outputs(light_outputs)}\n"
+                f"Dark outputs ({len(dark_outputs)}):\n"
+                f"{_summarize_outputs(dark_outputs)}"
             )
         for output_index, (light_output, dark_output) in enumerate(
             zip(light_outputs, dark_outputs)


### PR DESCRIPTION
- Close #178

## Summary

Two fixes to the examples-gallery build tooling, prompted by an opaque CI build step.

### 1. CI-friendly progress output
The builder used a `rich` live progress bar, which emits nothing useful in non-TTY environments (which is where our actions run). The step looked **silent until it built or failed**.

Now `tools/gallery/_pipeline.py` detects whether stdout is interactive (`sys.stdout.isatty()`):
- **Interactive** → unchanged live `rich` bar.
- **Non-interactive (CI / piped)** → the bar is disabled and plain, flushed per-example lines are printed instead:
  ```
  -> io/confusius_xarray_101 (12 cells, light+dark)
     done in 4.2s
  -> qc/foo [cached]
  ```

### 2. Show outputs on a light/dark parity mismatch
When the light and dark runs produce a different *number* of outputs for a cell, the builder raised a `ValueError` that reported only the counts — unhelpful for finding the culprit. The message now lists the actual outputs on each side:
```
demo: cell 1 produced 2 light outputs and 1 dark outputs. ...
Light outputs (2):
  1. stream[stdout]: line0
  2. stream[stderr]: only-in-light warning
Dark outputs (1):
  1. stream[stdout]: line0
```
so a stray one-shot warning / download log is obvious.

## Tests
Added tests and verification of the GA output helped me fixed a non deterministic bug sometimes happening with warnings in the registration example (1885d7cc9b3ea34180815b31b4c94b81d4173d1e)