### PR TITLE
fix(iq): handle strongly overlapping IQ windows

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,6 +19,10 @@ Current development version for the next ConfUSIus release.
 
 ### :bug: Fixes
 
+- `process_iq_blocks` now handles strongly overlapping IQ windows without corrupting
+  the output time dimension, so power Doppler and related IQ reducers work when
+  `window_stride < window_width / 2`
+  ([#192](https://github.com/confusius-tools/confusius/pull/192)).
 - `load_nifti` now anchors `physical_to_qform` to the same physical frame as the
   primary (sform) coordinates, so the stored qform affine maps the array's
   physical coordinates to qform world space

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,9 +13,10 @@ Current development version for the next ConfUSIus release.
 ### :zap: Performance
 
 - [`process_iq_blocks`][confusius.iq.process.process_iq_blocks] now uses
-  `dask.array.map_blocks` for non-overlapping outer IQ windows and keeps
-  `dask.array.map_overlap` for overlapping cases, reducing Dask overhead in common
-  blockwise processing workflows ([#190](https://github.com/confusius-tools/confusius/pull/190)).
+  `dask.array.map_blocks` for non-overlapping outer IQ windows and batches
+  overlapping windows with explicit overlap before mapping blocks, reducing Dask
+  overhead in common blockwise processing workflows
+  ([#190](https://github.com/confusius-tools/confusius/pull/190)).
 
 ### :bug: Fixes
 

--- a/src/confusius/iq/process.py
+++ b/src/confusius/iq/process.py
@@ -988,8 +988,9 @@ def process_iq_blocks(
     """Process blocks of IQ data using sliding windows.
 
     This function applies a processing operation to IQ data using Dask. It uses
-    `dask.array.map_blocks` for non-overlapping windows and
-    `dask.array.map_overlap` when temporal overlap is required.
+    `dask.array.map_blocks` for non-overlapping windows. When temporal overlap is
+    required, it batches multiple sliding windows into each task, applies explicit
+    overlap between batches, and runs `process_func` on each window within the batch.
 
     !!! warning
         Depending on the window width and stride, some input volumes may be dropped if
@@ -1048,13 +1049,13 @@ def process_iq_blocks(
         )
         iq = iq[:total_volumes_in_windows]
 
-    chunks_volumes = (window_width,) + (window_stride,) * (n_windows - 1)
-    iq = iq.rechunk((chunks_volumes,) + iq.shape[1:])
-
-    dummy_result = process_func(iq.blocks[0].compute(), **kwargs)
-    meta = np.array((), dtype=dummy_result.dtype)
-
     if overlap_width == 0:
+        chunks_volumes = (window_width,) + (window_stride,) * (n_windows - 1)
+        iq = iq.rechunk((chunks_volumes,) + iq.shape[1:])
+
+        dummy_result = process_func(iq.blocks[0].compute(), **kwargs)
+        meta = np.array((), dtype=dummy_result.dtype)
+
         return da.map_blocks(
             process_func,
             iq,
@@ -1065,13 +1066,64 @@ def process_iq_blocks(
             **kwargs,
         )
 
-    return da.map_overlap(
-        process_func,
+    # Batch several overlapping windows into each task so every post-first chunk is at
+    # least as large as the requested overlap. Otherwise Dask auto-rechunks the tiny
+    # stride-sized chunks and breaks the expected one-output-block-per-input-block
+    # mapping.
+    min_windows_per_block = max(1, (overlap_width + window_stride - 1) // window_stride)
+    first_block_windows = n_windows % min_windows_per_block
+    if first_block_windows == 0:
+        first_block_windows = min_windows_per_block
+
+    windows_per_block = (first_block_windows,) + (min_windows_per_block,) * (
+        (n_windows - first_block_windows) // min_windows_per_block
+    )
+    chunks_volumes = (
+        window_width + (first_block_windows - 1) * window_stride,
+    ) + tuple(
+        n_block_windows * window_stride for n_block_windows in windows_per_block[1:]
+    )
+    iq = iq.rechunk((chunks_volumes,) + iq.shape[1:])
+    iq = da.overlap.overlap(
         iq,
         depth={0: (overlap_width, 0)},
         boundary="none",
-        trim=False,
-        chunks=dummy_result.shape,
+        allow_rechunk=False,
+    )
+
+    def process_overlapping_batch(
+        block: npt.NDArray, **batch_kwargs: Any
+    ) -> npt.NDArray:
+        """Apply `process_func` to every overlapping outer window in a batch."""
+        outputs = [
+            process_func(block[start : start + window_width], **batch_kwargs)
+            for start in range(0, block.shape[0] - window_width + 1, window_stride)
+        ]
+        return np.concatenate(outputs, axis=0)
+
+    first_block_index = (0,) * iq.ndim
+    dummy_result = process_overlapping_batch(
+        iq.blocks[first_block_index].compute(), **kwargs
+    )
+    meta = np.array((), dtype=dummy_result.dtype)
+
+    output_time_chunks = [dummy_result.shape[0]]
+    if len(windows_per_block) > 1:
+        next_block_index = (1,) + (0,) * (iq.ndim - 1)
+        repeated_dummy_result = process_overlapping_batch(
+            iq.blocks[next_block_index].compute(), **kwargs
+        )
+        output_time_chunks.extend(
+            [repeated_dummy_result.shape[0]] * (len(windows_per_block) - 1)
+        )
+
+    output_chunks = (tuple(output_time_chunks),) + tuple(
+        (axis_size,) for axis_size in dummy_result.shape[1:]
+    )
+    return da.map_blocks(
+        process_overlapping_batch,
+        iq,
+        chunks=output_chunks,
         drop_axis=drop_axis,
         new_axis=new_axis,
         meta=meta,

--- a/src/confusius/iq/process.py
+++ b/src/confusius/iq/process.py
@@ -1066,11 +1066,17 @@ def process_iq_blocks(
             **kwargs,
         )
 
+    overlap_window_width = window_width
+    overlap_window_stride = window_stride
+
     # Batch several overlapping windows into each task so every post-first chunk is at
     # least as large as the requested overlap. Otherwise Dask auto-rechunks the tiny
     # stride-sized chunks and breaks the expected one-output-block-per-input-block
     # mapping.
-    min_windows_per_block = max(1, (overlap_width + window_stride - 1) // window_stride)
+    min_windows_per_block = max(
+        1,
+        (overlap_width + overlap_window_stride - 1) // overlap_window_stride,
+    )
     first_block_windows = n_windows % min_windows_per_block
     if first_block_windows == 0:
         first_block_windows = min_windows_per_block
@@ -1079,9 +1085,10 @@ def process_iq_blocks(
         (n_windows - first_block_windows) // min_windows_per_block
     )
     chunks_volumes = (
-        window_width + (first_block_windows - 1) * window_stride,
+        overlap_window_width + (first_block_windows - 1) * overlap_window_stride,
     ) + tuple(
-        n_block_windows * window_stride for n_block_windows in windows_per_block[1:]
+        n_block_windows * overlap_window_stride
+        for n_block_windows in windows_per_block[1:]
     )
     iq = iq.rechunk((chunks_volumes,) + iq.shape[1:])
     iq = da.overlap.overlap(
@@ -1094,10 +1101,27 @@ def process_iq_blocks(
     def process_overlapping_batch(
         block: npt.NDArray, **batch_kwargs: Any
     ) -> npt.NDArray:
-        """Apply `process_func` to every overlapping outer window in a batch."""
+        """Apply `process_func` to every overlapping outer window in a batch.
+
+        Parameters
+        ----------
+        block : numpy.ndarray
+            Batched input block containing one or more overlapping windows.
+        **batch_kwargs
+            Additional keyword arguments passed to `process_func`.
+
+        Returns
+        -------
+        numpy.ndarray
+            Concatenated outputs from all sliding windows in `block`.
+        """
         outputs = [
-            process_func(block[start : start + window_width], **batch_kwargs)
-            for start in range(0, block.shape[0] - window_width + 1, window_stride)
+            process_func(block[start : start + overlap_window_width], **batch_kwargs)
+            for start in range(
+                0,
+                block.shape[0] - overlap_window_width + 1,
+                overlap_window_stride,
+            )
         ]
         return np.concatenate(outputs, axis=0)
 

--- a/tests/unit/test_iq/test_process.py
+++ b/tests/unit/test_iq/test_process.py
@@ -420,7 +420,9 @@ class TestProcessIqBlocks:
             return real_map_blocks(*args, **kwargs)
 
         def forbidden_map_overlap(*args, **kwargs):
-            raise AssertionError("map_overlap should not be used for non-overlapping windows")
+            raise AssertionError(
+                "map_overlap should not be used for non-overlapping windows"
+            )
 
         monkeypatch.setattr(da, "map_blocks", wrapped_map_blocks)
         monkeypatch.setattr(da, "map_overlap", forbidden_map_overlap)
@@ -457,7 +459,9 @@ class TestProcessIqBlocks:
             return real_map_blocks(*args, **kwargs)
 
         def forbidden_map_overlap(*args, **kwargs):
-            raise AssertionError("map_overlap should not be used for non-overlapping windows")
+            raise AssertionError(
+                "map_overlap should not be used for non-overlapping windows"
+            )
 
         monkeypatch.setattr(da, "map_blocks", wrapped_map_blocks)
         monkeypatch.setattr(da, "map_overlap", forbidden_map_overlap)
@@ -475,25 +479,12 @@ class TestProcessIqBlocks:
         assert map_blocks_called
         assert_array_equal(result.compute(), expected)
 
-    def test_overlapping_windows_keep_map_overlap(self, monkeypatch):
-        """Overlapping windows still dispatch to `dask.array.map_overlap`."""
+    def test_overlapping_windows_match_reference_implementation(self):
+        """Overlapping windows match a naive sliding-window reference."""
         iq = da.from_array(np.arange(21 * 2 * 3).reshape(21, 2, 3), chunks=(5, 2, 3))
-        map_overlap_called = False
-        real_map_overlap = da.map_overlap
 
         def process_func(block: np.ndarray, **kwargs) -> np.ndarray:
             return block.mean(axis=0, keepdims=True)
-
-        def forbidden_map_blocks(*args, **kwargs):
-            raise AssertionError("map_blocks should not be used for overlapping windows")
-
-        def wrapped_map_overlap(*args, **kwargs):
-            nonlocal map_overlap_called
-            map_overlap_called = True
-            return real_map_overlap(*args, **kwargs)
-
-        monkeypatch.setattr(da, "map_blocks", forbidden_map_blocks)
-        monkeypatch.setattr(da, "map_overlap", wrapped_map_overlap)
 
         result = process_iq_blocks(
             iq,
@@ -502,9 +493,15 @@ class TestProcessIqBlocks:
             window_stride=2,
         )
 
-        result.compute()
+        expected = np.stack(
+            [
+                iq.compute()[start : start + 5].mean(axis=0)
+                for start in range(0, 21 - 5 + 1, 2)
+            ],
+            axis=0,
+        )
 
-        assert map_overlap_called
+        assert_allclose(result.compute(), expected)
 
     def test_stride_greater_than_width_raises(self, sample_iq_dataarray):
         """window_stride > window_width raises ValueError."""
@@ -590,6 +587,45 @@ class TestProcessIqToPowerDoppler:
         ] == pytest.approx(0.2)
         assert result.attrs["power_doppler_integration_stride"] == pytest.approx(0.1)
         assert result.coords["time"].attrs["volume_acquisition_reference"] == "start"
+
+    def test_chunked_overlapping_windows_match_reference_implementation(
+        self, sample_iq_dataarray
+    ) -> None:
+        """Chunked overlapping power Doppler windows match a naive reference."""
+        iq = sample_iq_dataarray.copy(
+            data=da.from_array(sample_iq_dataarray.values, chunks=(5, 4, 6, 8))
+        )
+
+        result = process_iq_to_power_doppler(
+            iq,
+            clutter_window_width=6,
+            clutter_window_stride=1,
+            doppler_window_width=2,
+            doppler_window_stride=2,
+        ).compute()
+
+        expected = np.concatenate(
+            [
+                compute_power_doppler_volume(
+                    sample_iq_dataarray.values[start : start + 6],
+                    doppler_window_width=2,
+                    doppler_window_stride=2,
+                )
+                for start in range(0, sample_iq_dataarray.sizes["time"] - 6 + 1)
+            ],
+            axis=0,
+        )
+        expected_times, _ = compute_processed_volume_timings(
+            sample_iq_dataarray,
+            clutter_window_width=6,
+            clutter_window_stride=1,
+            inner_window_width=2,
+            inner_window_stride=2,
+        )
+
+        assert result.sizes["time"] == expected.shape[0] == expected_times.shape[0]
+        assert_allclose(result.values, expected)
+        assert_allclose(result.coords["time"].values, expected_times)
 
     def test_butterworth_uses_time_coord_step_as_fs(self, sample_iq_dataarray):
         """Butterworth filter design uses the time coordinate step, not scanner provenance."""

--- a/tests/unit/test_iq/test_process.py
+++ b/tests/unit/test_iq/test_process.py
@@ -493,9 +493,38 @@ class TestProcessIqBlocks:
             window_stride=2,
         )
 
+        iq_values = iq.compute()
         expected = np.stack(
             [
-                iq.compute()[start : start + 5].mean(axis=0)
+                iq_values[start : start + 5].mean(axis=0)
+                for start in range(0, 21 - 5 + 1, 2)
+            ],
+            axis=0,
+        )
+
+        assert_allclose(result.compute(), expected)
+
+    def test_overlapping_windows_match_reference_with_spatial_chunks(self):
+        """Overlapping windows remain correct for spatially chunked inputs."""
+        iq = da.from_array(
+            np.arange(21 * 4 * 6 * 8).reshape(21, 4, 6, 8),
+            chunks=(5, 2, 3, 4),
+        )
+
+        def process_func(block: np.ndarray, **kwargs) -> np.ndarray:
+            return block.mean(axis=0, keepdims=True)
+
+        result = process_iq_blocks(
+            iq,
+            process_func=process_func,
+            window_width=5,
+            window_stride=2,
+        )
+
+        iq_values = iq.compute()
+        expected = np.stack(
+            [
+                iq_values[start : start + 5].mean(axis=0)
                 for start in range(0, 21 - 5 + 1, 2)
             ],
             axis=0,

--- a/tests/unit/test_iq/test_process.py
+++ b/tests/unit/test_iq/test_process.py
@@ -419,13 +419,7 @@ class TestProcessIqBlocks:
             map_blocks_called = True
             return real_map_blocks(*args, **kwargs)
 
-        def forbidden_map_overlap(*args, **kwargs):
-            raise AssertionError(
-                "map_overlap should not be used for non-overlapping windows"
-            )
-
         monkeypatch.setattr(da, "map_blocks", wrapped_map_blocks)
-        monkeypatch.setattr(da, "map_overlap", forbidden_map_overlap)
 
         result = process_iq_blocks(
             iq,
@@ -458,13 +452,7 @@ class TestProcessIqBlocks:
             map_blocks_called = True
             return real_map_blocks(*args, **kwargs)
 
-        def forbidden_map_overlap(*args, **kwargs):
-            raise AssertionError(
-                "map_overlap should not be used for non-overlapping windows"
-            )
-
         monkeypatch.setattr(da, "map_blocks", wrapped_map_blocks)
-        monkeypatch.setattr(da, "map_overlap", forbidden_map_overlap)
 
         result = process_iq_blocks(
             iq,


### PR DESCRIPTION
## Summary
- batch overlapping IQ windows before applying Dask overlap
- keep output chunk sizes aligned with the true number of sliding-window outputs
- add regression tests for overlapping `process_iq_blocks` and chunked power Doppler processing

Closes #191.