### PR TITLE
fix: coerce mask to boolean after validation

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -27,9 +27,9 @@ Current development version for the next ConfUSIus release.
 ### :bug: Fixes
 
 - Masks are now coerced to boolean by `validate_mask` (added `return_dtype_as_bool`
-  parameter that defaults to `True`), to avoid DataArrays to use *positional indexing*
-  instead. Previously these masks could select the wrong voxels or, for
-  `register_volume`, silently disable the metric mask
+  parameter that defaults to `True`) to avoid DataArrays using *positional indexing*.
+  Previously these masks could select the wrong voxels or, for `register_volume`,
+  silently disable the metric mask
   ([#197](https://github.com/confusius-tools/confusius/pull/197)).
 - `load_nifti` now anchors `physical_to_qform` to the same physical frame as the
   primary (sform) coordinates, so the stored qform affine maps the array's

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,6 +19,11 @@ Current development version for the next ConfUSIus release.
 
 ### :bug: Fixes
 
+- Masks are now coerced to boolean by `validate_mask` (added `return_dtype_as_bool`
+  parameter that defaults to `True`), to avoid DataArrays to use *positional indexing*
+  instead. Previously these masks could select the wrong voxels or, for
+  `register_volume`, silently disable the metric mask
+  ([#197](https://github.com/confusius-tools/confusius/pull/197)).
 - `load_nifti` now anchors `physical_to_qform` to the same physical frame as the
   primary (sform) coordinates, so the stored qform affine maps the array's
   physical coordinates to qform world space

--- a/src/confusius/decomposition/_base.py
+++ b/src/confusius/decomposition/_base.py
@@ -264,15 +264,14 @@ class _BaseFUSIDecomposer(BaseEstimator, TransformerMixin):
 
         X_ordered = X.transpose("time", *spatial_dims)
 
-        if getattr(self, "mask", None) is not None:
-            mask = self.mask
-            assert mask is not None
-            validate_mask(mask, X_ordered, "mask", require_exact_dims=True)
-        else:
+        mask = getattr(self, "mask", None)
+        if mask is None:
             mask = xr.ones_like(X_ordered[0], dtype=bool)
+        else:
+            mask = validate_mask(mask, X_ordered, "mask", require_exact_dims=True)
 
         X_proc = extract_with_mask(X_ordered, mask).values
-        return X_proc, spatial_dims, mask.values.ravel().astype(bool)
+        return X_proc, spatial_dims, mask.values.ravel()
 
     def _reshape_component_matrix(
         self,

--- a/src/confusius/extract/mask.py
+++ b/src/confusius/extract/mask.py
@@ -78,7 +78,7 @@ def extract_with_mask(data: xr.DataArray, mask: xr.DataArray) -> xr.DataArray:
     >>> pose_signals.dims
     ("time", "pose", "space")
     """
-    validate_mask(mask, data, "mask")
+    mask = validate_mask(mask, data, "mask")
 
     spatial_dims = list(mask.dims)
     non_spatial_dims = [d for d in data.dims if d not in spatial_dims]
@@ -106,11 +106,11 @@ def extract_with_mask(data: xr.DataArray, mask: xr.DataArray) -> xr.DataArray:
         )
 
     if "space" in data.dims and set(spatial_dims) == {"space"}:
-        mask_flat = mask_aligned.values.astype(bool)
+        mask_flat = mask_aligned.values
         return data.isel(space=mask_flat)
 
     data_flat = data.stack(space=spatial_dims)
-    mask_flat = mask_aligned.values.ravel().astype(bool)
+    mask_flat = mask_aligned.values.ravel()
     # Rebuild the space index from the selected voxel coordinates so unstack() uses the
     # reduced grid implied by the extracted mask.
     return data_flat.isel(space=mask_flat).set_xindex(spatial_dims)

--- a/src/confusius/iq/clutter_filters.py
+++ b/src/confusius/iq/clutter_filters.py
@@ -770,8 +770,8 @@ def compute_svd_cumulative_energy_threshold(
 
     mask_array: npt.NDArray[np.bool_] | None = None
     if clutter_mask is not None:
-        validate_mask(clutter_mask, iq, "clutter_mask")
-        mask_array = clutter_mask.values.astype(bool)
+        clutter_mask = validate_mask(clutter_mask, iq, "clutter_mask")
+        mask_array = clutter_mask.values
 
     dask_iq = iq.data
     if not isinstance(dask_iq, da.Array):

--- a/src/confusius/iq/process.py
+++ b/src/confusius/iq/process.py
@@ -1200,8 +1200,8 @@ def process_iq_to_power_doppler(
 
     clutter_mask_array = None
     if clutter_mask is not None:
-        validate_mask(clutter_mask, iq, "clutter_mask")
-        clutter_mask_array = clutter_mask.values.astype(bool)
+        clutter_mask = validate_mask(clutter_mask, iq, "clutter_mask")
+        clutter_mask_array = clutter_mask.values
 
     dask_iq: Array = iq.data
     if not isinstance(dask_iq, Array):
@@ -1549,8 +1549,8 @@ def process_iq_to_axial_velocity(
 
     clutter_mask_array = None
     if clutter_mask is not None:
-        validate_mask(clutter_mask, iq, "clutter_mask")
-        clutter_mask_array = clutter_mask.values.astype(bool)
+        clutter_mask = validate_mask(clutter_mask, iq, "clutter_mask")
+        clutter_mask_array = clutter_mask.values
 
     dask_iq: Array = iq.data
     if not isinstance(dask_iq, Array):

--- a/src/confusius/iq/process.py
+++ b/src/confusius/iq/process.py
@@ -1201,7 +1201,7 @@ def process_iq_to_power_doppler(
     clutter_mask_array = None
     if clutter_mask is not None:
         validate_mask(clutter_mask, iq, "clutter_mask")
-        clutter_mask_array = clutter_mask.values
+        clutter_mask_array = clutter_mask.values.astype(bool)
 
     dask_iq: Array = iq.data
     if not isinstance(dask_iq, Array):
@@ -1550,7 +1550,7 @@ def process_iq_to_axial_velocity(
     clutter_mask_array = None
     if clutter_mask is not None:
         validate_mask(clutter_mask, iq, "clutter_mask")
-        clutter_mask_array = clutter_mask.values
+        clutter_mask_array = clutter_mask.values.astype(bool)
 
     dask_iq: Array = iq.data
     if not isinstance(dask_iq, Array):

--- a/src/confusius/registration/volume.py
+++ b/src/confusius/registration/volume.py
@@ -37,7 +37,7 @@ def _validate_register_volume_inputs(
     shrink_factors: Sequence[int],
     smoothing_sigmas: Sequence[int],
     resample_interpolation: Literal["linear", "bspline"],
-) -> None:
+) -> tuple[xr.DataArray | None, xr.DataArray | None]:
     """Validate all inputs to `register_volume` before any computation.
 
     Parameters
@@ -70,6 +70,13 @@ def _validate_register_volume_inputs(
         Smoothing sigmas per pyramid level.
     resample_interpolation : {"linear", "bspline"}
         Interpolator name used when resampling.
+
+    Returns
+    -------
+    fixed_mask : xarray.DataArray or None
+        `fixed_mask` coerced to boolean dtype, or None if not provided.
+    moving_mask : xarray.DataArray or None
+        `moving_mask` coerced to boolean dtype, or None if not provided.
 
     Raises
     ------
@@ -175,9 +182,9 @@ def _validate_register_volume_inputs(
     from confusius.validation import validate_mask
 
     if fixed_mask is not None:
-        validate_mask(fixed_mask, fixed, "fixed_mask")
+        fixed_mask = validate_mask(fixed_mask, fixed, "fixed_mask")
     if moving_mask is not None:
-        validate_mask(moving_mask, moving, "moving_mask")
+        moving_mask = validate_mask(moving_mask, moving, "moving_mask")
 
     # --- Multi-resolution consistency ---
     if len(shrink_factors) != len(smoothing_sigmas):
@@ -185,6 +192,8 @@ def _validate_register_volume_inputs(
             f"shrink_factors and smoothing_sigmas must have the same length; "
             f"got {len(shrink_factors)} and {len(smoothing_sigmas)}."
         )
+
+    return fixed_mask, moving_mask
 
 
 def _expand_thin_dims(img: "sitk.Image", min_size: int = 4) -> "sitk.Image":
@@ -521,7 +530,7 @@ def register_volume(
     """
     import SimpleITK as sitk
 
-    _validate_register_volume_inputs(
+    fixed_mask, moving_mask = _validate_register_volume_inputs(
         moving=moving,
         fixed=fixed,
         fixed_mask=fixed_mask,

--- a/src/confusius/signal/confounds.py
+++ b/src/confusius/signal/confounds.py
@@ -540,8 +540,8 @@ def compute_compcor_confounds(
     selected_voxels = np.ones(n_voxels, dtype=bool)
 
     if noise_mask is not None:
-        validate_mask(noise_mask, signals, "noise_mask")
-        noise_mask_flat = noise_mask.values.flatten().astype(bool)
+        noise_mask = validate_mask(noise_mask, signals, "noise_mask")
+        noise_mask_flat = noise_mask.values.flatten()
 
         if noise_mask_flat.shape[0] != n_voxels:
             raise ValueError(

--- a/src/confusius/signal/confounds.py
+++ b/src/confusius/signal/confounds.py
@@ -13,8 +13,8 @@ import xarray as xr
 from confusius.signal._utils import remove_zero_variance_voxels
 from confusius.signal.detrending import detrend as detrend_signals
 from confusius.signal.standardization import standardize
-from confusius.validation.coordinates import validate_matching_coordinates
 from confusius.validation import validate_mask, validate_time_series
+from confusius.validation.coordinates import validate_matching_coordinates
 
 
 def _validate_confounds(signals: xr.DataArray, confounds: xr.DataArray) -> np.ndarray:
@@ -541,7 +541,7 @@ def compute_compcor_confounds(
 
     if noise_mask is not None:
         validate_mask(noise_mask, signals, "noise_mask")
-        noise_mask_flat = noise_mask.values.flatten()
+        noise_mask_flat = noise_mask.values.flatten().astype(bool)
 
         if noise_mask_flat.shape[0] != n_voxels:
             raise ValueError(
@@ -549,7 +549,7 @@ def compute_compcor_confounds(
                 f"signals spatial size ({n_voxels})."
             )
 
-        selected_voxels = selected_voxels & noise_mask_flat
+        selected_voxels = np.logical_and(selected_voxels, noise_mask_flat)
 
     if variance_threshold is not None:
         if not (0 < variance_threshold < 1):

--- a/src/confusius/validation/mask.py
+++ b/src/confusius/validation/mask.py
@@ -75,7 +75,8 @@ def validate_mask(
     rtol: float = 1e-5,
     atol: float = 1e-8,
     require_exact_dims: bool = False,
-) -> None:
+    return_dtype_as_bool: bool = True,
+) -> xr.DataArray:
     """Validate that a mask matches data spatial dimensions and coordinates.
 
     Parameters
@@ -96,6 +97,17 @@ def validate_mask(
     require_exact_dims : bool, default: False
         Whether `mask.dims` must match all non-`time` dimensions of `data` in the same
         order.
+    return_dtype_as_bool : bool, default: True
+        Whether to coerce the returned `mask` to boolean dtype. Single-label integer
+        masks (`{0, region_id}`) become `{False, True}` so callers can index with the
+        result without the integer label being misread as a positional index. When
+        False, `mask` is returned with its original dtype unchanged.
+
+    Returns
+    -------
+    xarray.DataArray
+        The validated `mask`, coerced to boolean dtype when `return_dtype_as_bool` is
+        True (the default), otherwise returned with its original dtype.
 
     Raises
     ------
@@ -136,6 +148,12 @@ def validate_mask(
                 f"{mask_name} dimensions must match all non-time dimensions of data "
                 f"in the same order. Expected {expected_dims}, got {mask_dims}."
             )
+
+    # Coerce after validation so callers never index with a raw single-label integer
+    # mask (which xarray.isel would treat as positional indices). See PR #197.
+    if return_dtype_as_bool:
+        return mask.astype(bool)
+    return mask
 
 
 def validate_labels(

--- a/src/confusius/validation/mask.py
+++ b/src/confusius/validation/mask.py
@@ -75,7 +75,7 @@ def validate_mask(
     rtol: float = 1e-5,
     atol: float = 1e-8,
     require_exact_dims: bool = False,
-    return_dtype_as_bool: bool = True,
+    coerce_bool: bool = True,
 ) -> xr.DataArray:
     """Validate that a mask matches data spatial dimensions and coordinates.
 
@@ -97,7 +97,7 @@ def validate_mask(
     require_exact_dims : bool, default: False
         Whether `mask.dims` must match all non-`time` dimensions of `data` in the same
         order.
-    return_dtype_as_bool : bool, default: True
+    coerce_bool : bool, default: True
         Whether to coerce the returned `mask` to boolean dtype. Single-label integer
         masks (`{0, region_id}`) become `{False, True}` so callers can index with the
         result without the integer label being misread as a positional index. When
@@ -106,8 +106,8 @@ def validate_mask(
     Returns
     -------
     xarray.DataArray
-        The validated `mask`, coerced to boolean dtype when `return_dtype_as_bool` is
-        True (the default), otherwise returned with its original dtype.
+        The validated `mask`, coerced to boolean dtype when `coerce_bool` is `True` (the
+        default), otherwise returned with its original dtype.
 
     Raises
     ------
@@ -151,7 +151,7 @@ def validate_mask(
 
     # Coerce after validation so callers never index with a raw single-label integer
     # mask (which xarray.isel would treat as positional indices). See PR #197.
-    if return_dtype_as_bool:
+    if coerce_bool:
         return mask.astype(bool)
     return mask
 

--- a/tests/unit/test_registration/test_volume.py
+++ b/tests/unit/test_registration/test_volume.py
@@ -177,6 +177,30 @@ class TestRegisterVolumeMask:
         assert not np.allclose(affine_bool, np.eye(3), atol=1e-2)
         assert_allclose(affine_int, affine_bool)
 
+    def test_both_masks_coerced_to_bool(
+        self, sample_2d_image, sample_2d_dataarray_spatial
+    ):
+        """Both fixed_mask and moving_mask are coerced to boolean."""
+        shift = 2
+        shifted = np.roll(np.roll(sample_2d_image, shift, axis=0), shift, axis=1)
+        fixed = sample_2d_dataarray_spatial
+        moving = xr.DataArray(shifted, dims=fixed.dims, coords=fixed.coords)
+
+        region = np.zeros(fixed.shape, dtype=bool)
+        region[4:28, 4:28] = True
+        fixed_mask = xr.DataArray(region, dims=fixed.dims, coords=fixed.coords)
+        moving_mask = xr.DataArray(region, dims=fixed.dims, coords=fixed.coords)
+
+        _, affine, _ = register_volume(
+            moving,
+            fixed,
+            fixed_mask=fixed_mask,
+            moving_mask=moving_mask,
+            transform_type="translation",
+            resample=False,
+        )
+        assert not np.allclose(affine, np.eye(3), atol=1e-2)
+
 
 class TestRegisterVolumeResample:
     """Behaviour of the resample parameter."""

--- a/tests/unit/test_registration/test_volume.py
+++ b/tests/unit/test_registration/test_volume.py
@@ -131,6 +131,53 @@ class TestRegisterVolumeOutput:
         )
 
 
+class TestRegisterVolumeMask:
+    """Metric masks for register_volume."""
+
+    def test_integer_label_mask_matches_boolean_mask(
+        self, sample_2d_image, sample_2d_dataarray_spatial
+    ):
+        """A single-label integer mask registers identically to its boolean form.
+
+        Guards against single-label integer masks (e.g. ``{0, 512}`` from
+        `Atlas.get_masks`) reaching SimpleITK's metric mask uncoerced: 512 wraps to 0
+        under the `numpy.uint8` cast, which silently empties the mask and turns
+        registration into a no-op.
+        """
+        shift = 2
+        shifted = np.roll(np.roll(sample_2d_image, shift, axis=0), shift, axis=1)
+        fixed = sample_2d_dataarray_spatial
+        moving = xr.DataArray(shifted, dims=fixed.dims, coords=fixed.coords)
+
+        region = np.zeros(fixed.shape, dtype=bool)
+        region[4:28, 4:28] = True  # covers the bright square in both volumes
+        bool_mask = xr.DataArray(region, dims=fixed.dims, coords=fixed.coords)
+        # 512 is a multiple of 256: a uint8 cast of the raw integer mask wraps it to 0.
+        int_mask = xr.DataArray(
+            region.astype(np.int32) * 512, dims=fixed.dims, coords=fixed.coords
+        )
+
+        _, affine_bool, _ = register_volume(
+            moving,
+            fixed,
+            fixed_mask=bool_mask,
+            transform_type="translation",
+            resample=False,
+        )
+        _, affine_int, _ = register_volume(
+            moving,
+            fixed,
+            fixed_mask=int_mask,
+            transform_type="translation",
+            resample=False,
+        )
+
+        # The masked registration must actually recover the planted shift; otherwise the
+        # equality check would also pass for a silently-emptied (no-op) mask.
+        assert not np.allclose(affine_bool, np.eye(3), atol=1e-2)
+        assert_allclose(affine_int, affine_bool)
+
+
 class TestRegisterVolumeResample:
     """Behaviour of the resample parameter."""
 

--- a/tests/unit/test_signal/test_compcor.py
+++ b/tests/unit/test_signal/test_compcor.py
@@ -123,6 +123,38 @@ def test_compute_compcor_xarray_noise_mask(sample_timeseries):
     assert components.shape == (100, 5)
 
 
+@pytest.mark.parametrize("region_id", [1009, 1008])
+def test_compute_compcor_integer_label_mask(sample_timeseries, region_id):
+    """Integer single-label masks ({0, region_id}) must select only in-region voxels.
+
+    `Atlas.get_masks` returns integer masks whose foreground voxels carry the region
+    id rather than `True`. The selection must be identical to the equivalent boolean
+    mask and must not fall back to selecting every voxel. Both odd and even region ids
+    are checked because a bitwise (rather than logical) AND is parity-dependent.
+    """
+    signals = sample_timeseries(n_time=100, n_voxels=50)
+
+    int_values = np.zeros(50, dtype=np.int32)
+    int_values[10:20] = region_id
+    int_mask = _create_mask_like(signals.isel(time=0), int_values)
+    bool_mask = _create_mask_like(signals.isel(time=0), int_values.astype(bool))
+
+    from_int = compute_compcor_confounds(signals, noise_mask=int_mask, n_components=3)
+    from_bool = compute_compcor_confounds(signals, noise_mask=bool_mask, n_components=3)
+    explicit = compute_compcor_confounds(
+        signals.isel(space=slice(10, 20)),
+        noise_mask=_create_mask_like(
+            signals.isel(time=0, space=slice(10, 20)), np.ones(10, dtype=bool)
+        ),
+        n_components=3,
+    )
+
+    assert from_int.shape == (100, 3)
+    # Absolute value guards against arbitrary SVD sign flips.
+    assert_allclose(np.abs(from_int.values), np.abs(from_bool.values))
+    assert_allclose(np.abs(from_int.values), np.abs(explicit.values))
+
+
 def test_compute_compcor_requires_mode():
     """Test error when neither noise_mask nor variance_threshold specified."""
     signals = xr.DataArray(

--- a/tests/unit/test_validation/test_mask.py
+++ b/tests/unit/test_validation/test_mask.py
@@ -1,0 +1,87 @@
+"""Tests for confusius.validation.validate_mask."""
+
+import numpy as np
+import pytest
+import xarray as xr
+from numpy.testing import assert_array_equal
+
+from confusius.validation import validate_mask
+
+
+def _data_and_mask(values):
+    """Build a (time, space) data array and a matching space mask.
+
+    Parameters
+    ----------
+    values : array_like
+        Mask values laid out along the `space` dimension.
+
+    Returns
+    -------
+    data : xarray.DataArray
+        A (3, len(values)) (time, space) array sharing the mask's `space` coords.
+    mask : xarray.DataArray
+        A 1D `space` mask wrapping `values`.
+    """
+    space = np.arange(len(values))
+    data = xr.DataArray(
+        np.zeros((3, len(values))),
+        dims=("time", "space"),
+        coords={"time": [0, 1, 2], "space": space},
+    )
+    mask = xr.DataArray(np.asarray(values), dims=("space",), coords={"space": space})
+    return data, mask
+
+
+@pytest.mark.parametrize("region_id", [1, 7, 256, 512, 1009])
+def test_coerces_integer_label_to_boolean(region_id):
+    """A single-label integer mask {0, region_id} is returned as a boolean mask.
+
+    Region ids that are multiples of 256 (256, 512) are included because casting the
+    raw integer mask to `numpy.uint8` would wrap them to 0; the boolean coercion must
+    not depend on the label value.
+    """
+    raw = np.zeros(8, dtype=np.int32)
+    raw[2:5] = region_id
+    data, mask = _data_and_mask(raw)
+
+    result = validate_mask(mask, data)
+
+    assert result.dtype == bool
+    assert_array_equal(result.values, raw != 0)
+
+
+def test_passes_boolean_through():
+    """A boolean mask is returned as boolean with its values unchanged."""
+    raw = np.zeros(8, dtype=bool)
+    raw[1:4] = True
+    data, mask = _data_and_mask(raw)
+
+    result = validate_mask(mask, data)
+
+    assert result.dtype == bool
+    assert_array_equal(result.values, raw)
+
+
+def test_return_dtype_as_bool_false_preserves_dtype():
+    """With return_dtype_as_bool=False the mask is returned with its original dtype."""
+    raw = np.zeros(8, dtype=np.int32)
+    raw[2:5] = 512
+    data, mask = _data_and_mask(raw)
+
+    result = validate_mask(mask, data, return_dtype_as_bool=False)
+
+    assert result.dtype == np.int32
+    assert_array_equal(result.values, raw)
+
+
+def test_coerced_mask_preserves_dims_and_coords():
+    """The coerced mask keeps the input dimensions and coordinates."""
+    raw = np.zeros(6, dtype=np.int32)
+    raw[3:] = 512
+    data, mask = _data_and_mask(raw)
+
+    result = validate_mask(mask, data)
+
+    assert result.dims == mask.dims
+    assert_array_equal(result.coords["space"].values, mask.coords["space"].values)

--- a/tests/unit/test_validation/test_mask.py
+++ b/tests/unit/test_validation/test_mask.py
@@ -69,7 +69,7 @@ def test_return_dtype_as_bool_false_preserves_dtype():
     raw[2:5] = 512
     data, mask = _data_and_mask(raw)
 
-    result = validate_mask(mask, data, return_dtype_as_bool=False)
+    result = validate_mask(mask, data, coerce_bool=False)
 
     assert result.dtype == np.int32
     assert_array_equal(result.values, raw)


### PR DESCRIPTION
- Closes #196 

## Description

Indexing DataArrays with masks the way we do regularly in ConfUSIus demands a boolean mask. Instead of transforming the `dtype` of the mask every time after validation, `validate_mask` now return the input mask. The return type can be controlled with `return_dtype_as_bool` which is `True` as a default.

This fixes several points where the mask could be used as an indexer with an `int` dtype, 

## Checklist

- [x] Tests pass locally (`just t`)
- [x] Pre-commit hooks pass (`just pc`)
- [x] New public API is documented (NumPy docstring, type hints)
- [x] Changelog updated if user-facing
