### PR TITLE
WIP: prototype CTI-backed voxel-affine geometry

### DIFF
--- a/scripts/try_voxel_affine_loading.py
+++ b/scripts/try_voxel_affine_loading.py
@@ -1,0 +1,96 @@
+# %%
+"""Minimal iPython-friendly voxel-affine 3D loading demo."""
+
+import tempfile
+from pathlib import Path
+
+import nibabel as nib
+import numpy as np
+
+import confusius as cf
+from confusius.plotting import plot_volume
+
+# %%
+# Build a synthetic 3D volume in NIfTI (x, y, z) array order.
+rng = np.random.default_rng(0)
+nx, ny, nz = 48, 40, 24
+x = np.linspace(-1.0, 1.0, nx)
+y = np.linspace(-1.0, 1.0, ny)
+z = np.linspace(-1.0, 1.0, nz)
+xx, yy, zz = np.meshgrid(x, y, z, indexing="ij")
+blob1 = np.exp(-((xx + 0.25) ** 2 + (yy - 0.15) ** 2 + (zz + 0.2) ** 2) / 0.12)
+blob2 = 0.7 * np.exp(-((xx - 0.2) ** 2 + (yy + 0.25) ** 2 + (zz - 0.1) ** 2) / 0.05)
+blob3 = 0.4 * np.exp(-((xx + 0.1) ** 2 + (yy + 0.05) ** 2 + (zz - 0.35) ** 2) / 0.03)
+data = (blob1 + blob2 + blob3 + 0.03 * rng.standard_normal((nx, ny, nz))).astype(
+    np.float32
+)
+
+# %%
+# Oblique qform in mm. Disable sform so qform is the primary xform on load.
+rz = np.deg2rad(30.0)
+rx = np.deg2rad(-20.0)
+rot_z = np.array(
+    [
+        [np.cos(rz), -np.sin(rz), 0.0],
+        [np.sin(rz), np.cos(rz), 0.0],
+        [0.0, 0.0, 1.0],
+    ]
+)
+rot_x = np.array(
+    [
+        [1.0, 0.0, 0.0],
+        [0.0, np.cos(rx), -np.sin(rx)],
+        [0.0, np.sin(rx), np.cos(rx)],
+    ]
+)
+rotation = rot_z @ rot_x
+spacing = np.diag([0.12, 0.08, 0.25])
+affine = np.eye(4)
+affine[:3, :3] = rotation @ spacing
+affine[:3, 3] = [10.0, 20.0, 30.0]
+
+# %%
+# Save to a temporary NIfTI and reload with the voxel-affine coordinate model.
+tmpdir = tempfile.TemporaryDirectory()
+path = Path(tmpdir.name) / "rotated_qform_demo_3d.nii.gz"
+image = nib.Nifti1Image(data, affine)
+image.set_qform(affine, code=1)
+image.set_sform(np.eye(4), code=0)
+image.header.set_xyzt_units(xyz="mm")
+image.to_filename(path)
+
+da = cf.load(path, coordinate_model="voxel_affine")
+da
+
+# %%
+print("dims:", da.dims)
+print("coord names:", list(da.coords))
+print("voxel_to_physical:\n", np.asarray(da.attrs["voxel_to_physical"]))
+print("affine keys:", list(da.attrs.get("affines", {})))
+print("k range:", float(da.k.min()), "->", float(da.k.max()))
+print("j range:", float(da.j.min()), "->", float(da.j.max()))
+print("i range:", float(da.i.min()), "->", float(da.i.max()))
+
+# %%
+# Slice along k: constant k, plot the native (j, i) plane in its projected in-plane geometry.
+plot_volume(
+    da,
+    slice_mode="k",
+    show_colorbar=False,
+).show()
+
+# %%
+# Slice along j: constant j, plot the native (k, i) plane.
+plot_volume(
+    da,
+    slice_mode="j",
+    show_colorbar=False,
+).show()
+
+# %%
+# Slice along i: constant i, plot the native (k, j) plane.
+plot_volume(
+    da,
+    slice_mode="i",
+    show_colorbar=False,
+).show()

--- a/scripts/try_voxel_affine_loading.py
+++ b/scripts/try_voxel_affine_loading.py
@@ -9,6 +9,7 @@ import numpy as np
 
 import confusius as cf
 from confusius.plotting import plot_volume
+from confusius.validation import validate_fusi_dataarray
 
 # %%
 # Build a synthetic 3D volume in NIfTI (x, y, z) array order.
@@ -70,6 +71,12 @@ print("affine keys:", list(da.attrs.get("affines", {})))
 print("k range:", float(da.k.min()), "->", float(da.k.max()))
 print("j range:", float(da.j.min()), "->", float(da.j.max()))
 print("i range:", float(da.i.min()), "->", float(da.i.max()))
+print("origin:", da.fusi.origin)
+print("spacing:", da.fusi.spacing)
+print("direction:\n", da.fusi.direction)
+
+validate_fusi_dataarray(da, require_regular_spacing=True, regular_spacing_dims="space")
+print("validate_fusi_dataarray(...): ok")
 
 # %%
 # Slice along k: constant k, plot the native (j, i) plane in its projected in-plane geometry.
@@ -78,6 +85,9 @@ plot_volume(
     slice_mode="k",
     show_colorbar=False,
 ).show()
+
+# `slice_mode="z"` is intentionally not supported yet for voxel-affine data:
+# slicing is native voxel-plane only for now.
 
 # %%
 # Slice along j: constant j, plot the native (k, i) plane.

--- a/src/confusius/_utils/geometry.py
+++ b/src/confusius/_utils/geometry.py
@@ -270,13 +270,15 @@ def add_physical_coords_from_voxel_affine(
             )
         voxel_coords[dim] = np.asarray(coord.values, dtype=np.float64)
 
+    voxel_to_physical_array = np.asarray(voxel_to_physical, dtype=np.float64)
     transform = VoxelSpaceAffineTransform(
         voxel_coords,
-        voxel_to_physical,
+        voxel_to_physical_array,
         physical_coord_names=physical_coord_names,
     )
     physical_coords = xr.Coordinates.from_xindex(CoordinateTransformIndex(transform))
     result = data.assign_coords(physical_coords)
+    result.attrs["voxel_to_physical"] = voxel_to_physical_array
 
     if physical_coord_attrs is not None:
         for name, attrs in physical_coord_attrs.items():

--- a/src/confusius/_utils/geometry.py
+++ b/src/confusius/_utils/geometry.py
@@ -1,0 +1,407 @@
+"""Geometry helpers for voxel-space to physical-space transforms.
+
+This module prototypes a geometry model where a DataArray keeps 1D voxel-space
+coordinates (for example `i`, `j`, `k`) and stores a single affine that maps
+those voxel-space coordinates into physical-space coordinates (for example
+`x`, `y`, `z`).
+
+The physical coordinates are exposed lazily via Xarray's
+`CoordinateTransformIndex`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Hashable, Mapping
+from typing import Any
+
+import numpy as np
+import numpy.typing as npt
+import xarray as xr
+from xarray.indexes import CoordinateTransform, CoordinateTransformIndex
+
+from confusius._utils.coordinates import get_representative_step
+
+
+class VoxelSpaceAffineTransform(CoordinateTransform):
+    """Coordinate transform from voxel-space coordinates to physical space.
+
+    The transform combines:
+
+    1. a dense array-position -> voxel-space lookup using the 1D coordinate arrays
+       attached to each dimension, and
+    2. a homogeneous affine that maps voxel-space coordinates to physical-space
+       coordinates.
+
+    This lets a dense array with dimensions like `(j, i)` or `(k, j, i)` carry
+    irregular voxel-space coordinates such as `i = [0, 2, 3]`, while still exposing
+    exact physical coordinates through Xarray's
+    `CoordinateTransformIndex`.
+
+    Parameters
+    ----------
+    voxel_coords : mapping[str, array-like]
+        Ordered mapping from dimension name to its 1D voxel-space coordinates. The key
+        order defines the column order of the affine input space.
+    voxel_to_physical : (N+1, N+1) numpy.ndarray
+        Homogeneous affine mapping voxel-space coordinates to physical-space
+        coordinates. The input column order must match `voxel_coords`. The output row
+        order must match `physical_coord_names`.
+    physical_coord_names : tuple[Hashable, ...], optional
+        Names of the physical-space coordinates exposed by the transform. If not
+        provided, defaults to `("z", "y", "x")` for 3D and `("y", "x")` for 2D.
+
+    Raises
+    ------
+    ValueError
+        If any voxel coordinate is not 1D, not strictly increasing, or if the affine
+        shape does not match the number of voxel-space dimensions.
+    """
+
+    voxel_coords: dict[str, npt.NDArray[np.float64]]
+    voxel_to_physical: npt.NDArray[np.float64]
+
+    def __init__(
+        self,
+        voxel_coords: Mapping[str, npt.ArrayLike],
+        voxel_to_physical: npt.ArrayLike,
+        physical_coord_names: tuple[Hashable, ...] | None = None,
+    ) -> None:
+        voxel_coords_np = {
+            str(dim): np.asarray(values, dtype=np.float64)
+            for dim, values in voxel_coords.items()
+        }
+        ndim = len(voxel_coords_np)
+
+        if ndim not in {2, 3}:
+            raise ValueError(
+                f"VoxelSpaceAffineTransform only supports 2D or 3D inputs, got {ndim}."
+            )
+
+        for dim, values in voxel_coords_np.items():
+            if values.ndim != 1:
+                raise ValueError(
+                    f"Voxel coordinate {dim!r} must be 1D, got shape {values.shape}."
+                )
+            if values.size > 1 and not np.all(np.diff(values) > 0):
+                raise ValueError(
+                    f"Voxel coordinate {dim!r} must be strictly increasing."
+                )
+
+        if physical_coord_names is None:
+            physical_coord_names = ("y", "x") if ndim == 2 else ("z", "y", "x")
+
+        if len(physical_coord_names) != ndim:
+            raise ValueError(
+                "physical_coord_names must have one entry per voxel dimension; got "
+                f"{len(physical_coord_names)} names for {ndim} dimensions."
+            )
+
+        affine = np.asarray(voxel_to_physical, dtype=np.float64)
+        expected_shape = (ndim + 1, ndim + 1)
+        if affine.shape != expected_shape:
+            raise ValueError(
+                f"voxel_to_physical must have shape {expected_shape}, got {affine.shape}."
+            )
+
+        super().__init__(
+            coord_names=tuple(physical_coord_names),
+            dim_size={dim: len(values) for dim, values in voxel_coords_np.items()},
+        )
+        self.voxel_coords = voxel_coords_np
+        self.voxel_to_physical = affine
+
+    def forward(self, dim_positions: dict[str, Any]) -> dict[Hashable, Any]:
+        """Transform dense array positions into physical coordinates.
+
+        Parameters
+        ----------
+        dim_positions : dict[str, Any]
+            Dense integer array positions keyed by the dimensions in `self.dims`.
+
+        Returns
+        -------
+        dict[Hashable, Any]
+            Physical-space coordinate values keyed by `self.coord_names`.
+        """
+        voxel_values = [
+            self.voxel_coords[dim][np.asarray(dim_positions[dim])] for dim in self.dims
+        ]
+        shape = np.asarray(voxel_values[0]).shape
+        ones = np.ones(shape, dtype=np.float64)
+        stacked = np.stack([*voxel_values, ones], axis=0).reshape(
+            len(self.dims) + 1, -1
+        )
+        transformed = (self.voxel_to_physical @ stacked).reshape(
+            (len(self.coord_names) + 1, *shape)
+        )
+        return {name: transformed[i] for i, name in enumerate(self.coord_names)}
+
+    def reverse(self, coord_labels: dict[Hashable, Any]) -> dict[str, Any]:
+        """Transform physical coordinates back into dense array positions.
+
+        The returned positions are floating-point dense positions. Xarray rounds them
+        during nearest-neighbour selection.
+
+        Parameters
+        ----------
+        coord_labels : dict[Hashable, Any]
+            Physical-space coordinate labels keyed by `self.coord_names`.
+
+        Returns
+        -------
+        dict[str, Any]
+            Dense array positions keyed by `self.dims`.
+        """
+        physical_values = [np.asarray(coord_labels[name]) for name in self.coord_names]
+        shape = np.asarray(physical_values[0]).shape
+        ones = np.ones(shape, dtype=np.float64)
+        stacked = np.stack([*physical_values, ones], axis=0).reshape(
+            len(self.coord_names) + 1, -1
+        )
+        voxel_values = (np.linalg.inv(self.voxel_to_physical) @ stacked).reshape(
+            (len(self.dims) + 1, *shape)
+        )
+
+        dim_positions: dict[str, Any] = {}
+        for i, dim in enumerate(self.dims):
+            voxel_axis = self.voxel_coords[dim]
+            dim_positions[dim] = np.interp(
+                voxel_values[i].reshape(-1),
+                voxel_axis,
+                np.arange(voxel_axis.size, dtype=np.float64),
+            ).reshape(shape)
+        return dim_positions
+
+    def equals(
+        self,
+        other: CoordinateTransform,
+        *,
+        exclude: frozenset[Hashable] | None = None,
+    ) -> bool:
+        """Check equality with another voxel-space affine transform.
+
+        Parameters
+        ----------
+        other : xarray.indexes.CoordinateTransform
+            Transform to compare against.
+        exclude : frozenset[Hashable], optional
+            Unused compatibility argument required by Xarray's transform API.
+
+        Returns
+        -------
+        bool
+            Whether the two transforms have identical coordinate names, dimensions,
+            voxel-space coordinates, and affine.
+        """
+        if not isinstance(other, VoxelSpaceAffineTransform):
+            return False
+        return (
+            self.coord_names == other.coord_names
+            and self.dims == other.dims
+            and all(
+                np.array_equal(self.voxel_coords[dim], other.voxel_coords[dim])
+                for dim in self.dims
+            )
+            and np.allclose(self.voxel_to_physical, other.voxel_to_physical)
+        )
+
+    def __repr__(self) -> str:
+        """Return a compact repr."""
+        return (
+            f"VoxelSpaceAffineTransform(dims={self.dims!r}, "
+            f"coord_names={self.coord_names!r})"
+        )
+
+
+def add_physical_coords_from_voxel_affine(
+    data: xr.DataArray,
+    voxel_to_physical: npt.ArrayLike,
+    *,
+    voxel_dims: tuple[str, ...],
+    physical_coord_names: tuple[Hashable, ...] | None = None,
+    physical_coord_attrs: Mapping[str, Mapping[str, Any]] | None = None,
+) -> xr.DataArray:
+    """Attach lazy physical coordinates to a DataArray.
+
+    Parameters
+    ----------
+    data : xarray.DataArray
+        Input array that already carries 1D voxel-space coordinates on `voxel_dims`.
+    voxel_to_physical : (N+1, N+1) numpy.ndarray
+        Homogeneous affine mapping voxel-space coordinates to physical-space
+        coordinates.
+    voxel_dims : tuple[str, ...]
+        Dimension names whose coordinates define voxel space. The order determines the
+        affine input-space column order.
+    physical_coord_names : tuple[Hashable, ...], optional
+        Names of the physical coordinates to attach lazily. If not provided, defaults
+        to `("z", "y", "x")` for 3D and `("y", "x")` for 2D.
+    physical_coord_attrs : mapping[str, mapping[str, Any]], optional
+        Attributes to attach to the derived physical coordinates, keyed by physical
+        coordinate name.
+
+    Returns
+    -------
+    xarray.DataArray
+        A new DataArray with lazily generated physical coordinates attached via a
+        `CoordinateTransformIndex`.
+
+    Raises
+    ------
+    ValueError
+        If `voxel_dims` are missing from the DataArray or if their coordinates are not
+        1D dimension coordinates.
+    """
+    voxel_coords: dict[str, npt.NDArray[np.float64]] = {}
+    for dim in voxel_dims:
+        if dim not in data.dims:
+            raise ValueError(
+                f"Voxel dimension {dim!r} is not present in the DataArray."
+            )
+        if dim not in data.coords:
+            raise ValueError(
+                f"Voxel dimension {dim!r} must have a matching 1D coordinate."
+            )
+        coord = data.coords[dim]
+        if coord.dims != (dim,):
+            raise ValueError(
+                f"Voxel coordinate {dim!r} must be a 1D dimension coordinate; got "
+                f"dims {coord.dims!r}."
+            )
+        voxel_coords[dim] = np.asarray(coord.values, dtype=np.float64)
+
+    transform = VoxelSpaceAffineTransform(
+        voxel_coords,
+        voxel_to_physical,
+        physical_coord_names=physical_coord_names,
+    )
+    physical_coords = xr.Coordinates.from_xindex(CoordinateTransformIndex(transform))
+    result = data.assign_coords(physical_coords)
+
+    if physical_coord_attrs is not None:
+        for name, attrs in physical_coord_attrs.items():
+            if name in result.coords:
+                result.coords[name].attrs.update(dict(attrs))
+
+    return result
+
+
+def get_affine_origin(
+    voxel_to_physical: npt.ArrayLike,
+) -> npt.NDArray[np.float64]:
+    """Return the physical location of the voxel-space origin.
+
+    Parameters
+    ----------
+    voxel_to_physical : (N+1, N+1) numpy.ndarray
+        Homogeneous affine mapping voxel space to physical space.
+
+    Returns
+    -------
+    (N,) numpy.ndarray
+        Physical coordinates corresponding to voxel-space origin `(0, ..., 0)`.
+    """
+    affine = np.asarray(voxel_to_physical, dtype=np.float64)
+    return affine[:-1, -1].copy()
+
+
+def get_affine_axis_vectors(
+    voxel_to_physical: npt.ArrayLike,
+    voxel_dims: tuple[str, ...],
+) -> dict[str, npt.NDArray[np.float64]]:
+    """Return the physical step vector for one voxel-space unit along each axis.
+
+    Parameters
+    ----------
+    voxel_to_physical : (N+1, N+1) numpy.ndarray
+        Homogeneous affine mapping voxel space to physical space.
+    voxel_dims : tuple[str, ...]
+        Voxel-space dimension names in affine column order.
+
+    Returns
+    -------
+    dict[str, numpy.ndarray]
+        Physical step vectors keyed by voxel-space dimension name.
+    """
+    affine = np.asarray(voxel_to_physical, dtype=np.float64)
+    linear = affine[:-1, :-1]
+    return {dim: linear[:, i].copy() for i, dim in enumerate(voxel_dims)}
+
+
+def get_affine_axis_scalings(
+    voxel_to_physical: npt.ArrayLike,
+    voxel_dims: tuple[str, ...],
+) -> dict[str, float]:
+    """Return physical distance per one voxel-space unit along each axis.
+
+    Parameters
+    ----------
+    voxel_to_physical : (N+1, N+1) numpy.ndarray
+        Homogeneous affine mapping voxel space to physical space.
+    voxel_dims : tuple[str, ...]
+        Voxel-space dimension names in affine column order.
+
+    Returns
+    -------
+    dict[str, float]
+        Euclidean norms of the affine column vectors, keyed by voxel-space dimension.
+    """
+    vectors = get_affine_axis_vectors(voxel_to_physical, voxel_dims)
+    return {dim: float(np.linalg.norm(vector)) for dim, vector in vectors.items()}
+
+
+def get_affine_orientation_matrix(
+    voxel_to_physical: npt.ArrayLike,
+) -> npt.NDArray[np.float64]:
+    """Return unit physical-space axis directions from a voxel-to-physical affine.
+
+    Parameters
+    ----------
+    voxel_to_physical : (N+1, N+1) numpy.ndarray
+        Homogeneous affine mapping voxel space to physical space.
+
+    Returns
+    -------
+    (N, N) numpy.ndarray
+        Matrix whose columns are unit physical-space vectors for each voxel-space axis.
+        Zero-length columns are preserved as zeros.
+    """
+    affine = np.asarray(voxel_to_physical, dtype=np.float64)
+    linear = affine[:-1, :-1].copy()
+    norms = np.linalg.norm(linear, axis=0)
+    nonzero = norms > 0
+    linear[:, nonzero] /= norms[nonzero]
+    linear[:, ~nonzero] = 0.0
+    return linear
+
+
+def get_physical_spacings(
+    voxel_coords: Mapping[str, npt.ArrayLike],
+    voxel_to_physical: npt.ArrayLike,
+) -> dict[str, float | None]:
+    """Return physical spacing for regularly sampled voxel axes.
+
+    Parameters
+    ----------
+    voxel_coords : mapping[str, array-like]
+        Ordered mapping from voxel-space dimension name to its 1D coordinates.
+    voxel_to_physical : (N+1, N+1) numpy.ndarray
+        Homogeneous affine mapping voxel space to physical space.
+
+    Returns
+    -------
+    dict[str, float | None]
+        Physical spacing keyed by voxel-space dimension. Returns `None` when the
+        voxel-space coordinate is irregular or has fewer than two samples.
+    """
+    scalings = get_affine_axis_scalings(voxel_to_physical, tuple(voxel_coords))
+    spacings: dict[str, float | None] = {}
+    for dim, values in voxel_coords.items():
+        step, approximate = get_representative_step(
+            np.asarray(values, dtype=np.float64)
+        )
+        if step is None or approximate:
+            spacings[dim] = None
+        else:
+            spacings[dim] = abs(step) * scalings[dim]
+    return spacings

--- a/src/confusius/_utils/geometry.py
+++ b/src/confusius/_utils/geometry.py
@@ -5,7 +5,9 @@ coordinates (for example `i`, `j`, `k`) and stores a single affine that maps
 those voxel-space coordinates into physical-space coordinates (for example
 `x`, `y`, `z`).
 
-The physical coordinates are exposed lazily via Xarray's
+For axis-aligned affines, the derived physical coordinates are attached as 1D
+coordinates with ordinary Xarray indexes so `.sel(...)` remains convenient. For
+oblique affines, the physical coordinates are exposed lazily via Xarray's
 `CoordinateTransformIndex`.
 """
 
@@ -213,6 +215,25 @@ class VoxelSpaceAffineTransform(CoordinateTransform):
         )
 
 
+def _is_axis_aligned_affine(voxel_to_physical: npt.ArrayLike) -> bool:
+    """Return whether the affine has no cross-axis mixing.
+
+    Parameters
+    ----------
+    voxel_to_physical : (N+1, N+1) numpy.ndarray
+        Homogeneous affine mapping voxel space to physical space.
+
+    Returns
+    -------
+    bool
+        Whether the affine linear part is diagonal up to floating-point noise.
+    """
+    affine = np.asarray(voxel_to_physical, dtype=np.float64)
+    linear = affine[:-1, :-1]
+    diagonal = np.diag(np.diag(linear))
+    return np.allclose(linear, diagonal, rtol=1e-10, atol=1e-12)
+
+
 def add_physical_coords_from_voxel_affine(
     data: xr.DataArray,
     voxel_to_physical: npt.ArrayLike,
@@ -221,7 +242,7 @@ def add_physical_coords_from_voxel_affine(
     physical_coord_names: tuple[Hashable, ...] | None = None,
     physical_coord_attrs: Mapping[str, Mapping[str, Any]] | None = None,
 ) -> xr.DataArray:
-    """Attach lazy physical coordinates to a DataArray.
+    """Attach physical coordinates to a DataArray.
 
     Parameters
     ----------
@@ -243,7 +264,9 @@ def add_physical_coords_from_voxel_affine(
     Returns
     -------
     xarray.DataArray
-        A new DataArray with lazily generated physical coordinates attached via a
+        A new DataArray with derived physical coordinates attached. Axis-aligned
+        affines produce ordinary 1D coordinates with standard Xarray indexes;
+        oblique affines produce lazily generated coordinates attached via a
         `CoordinateTransformIndex`.
 
     Raises
@@ -270,14 +293,36 @@ def add_physical_coords_from_voxel_affine(
             )
         voxel_coords[dim] = np.asarray(coord.values, dtype=np.float64)
 
+    if physical_coord_names is None:
+        physical_coord_names = ("y", "x") if len(voxel_dims) == 2 else ("z", "y", "x")
+
     voxel_to_physical_array = np.asarray(voxel_to_physical, dtype=np.float64)
-    transform = VoxelSpaceAffineTransform(
-        voxel_coords,
-        voxel_to_physical_array,
-        physical_coord_names=physical_coord_names,
-    )
-    physical_coords = xr.Coordinates.from_xindex(CoordinateTransformIndex(transform))
-    result = data.assign_coords(physical_coords)
+
+    if _is_axis_aligned_affine(voxel_to_physical_array):
+        affine = voxel_to_physical_array
+        axis_coords = {
+            name: (
+                dim,
+                affine[i, i] * voxel_coords[dim] + affine[i, -1],
+            )
+            for i, (dim, name) in enumerate(
+                zip(voxel_dims, physical_coord_names, strict=True)
+            )
+        }
+        result = data.assign_coords(axis_coords)
+        for name in physical_coord_names:
+            result = result.set_xindex(name)
+    else:
+        transform = VoxelSpaceAffineTransform(
+            voxel_coords,
+            voxel_to_physical_array,
+            physical_coord_names=physical_coord_names,
+        )
+        physical_coords = xr.Coordinates.from_xindex(
+            CoordinateTransformIndex(transform)
+        )
+        result = data.assign_coords(physical_coords)
+
     result.attrs["voxel_to_physical"] = voxel_to_physical_array
 
     if physical_coord_attrs is not None:
@@ -289,7 +334,7 @@ def add_physical_coords_from_voxel_affine(
 
 
 def restore_physical_coords_from_voxel_affine(data: xr.DataArray) -> xr.DataArray:
-    """Rebuild lazy CTI physical coordinates from stored voxel-affine metadata.
+    """Rebuild derived physical coordinates from stored voxel-affine metadata.
 
     Parameters
     ----------
@@ -301,7 +346,7 @@ def restore_physical_coords_from_voxel_affine(data: xr.DataArray) -> xr.DataArra
     -------
     xarray.DataArray
         `data` unchanged when the required voxel-affine metadata is absent, otherwise a
-        DataArray with lazy CTI-derived physical coordinates restored.
+        DataArray with physical coordinates and indexes restored.
     """
     if "voxel_to_physical" not in data.attrs:
         return data
@@ -382,14 +427,15 @@ def get_voxel_affine_physical_coord_names(data: xr.DataArray) -> tuple[str, ...]
         Physical coordinate names in affine row order.
     """
     voxel_dims = get_voxel_affine_spatial_dims(data)
+    default_names = ("y", "x") if len(voxel_dims) == 2 else ("z", "y", "x")
     physical_coord_names = tuple(
-        dim
-        for dim in ("z", "y", "x")
-        if dim in data.coords and data.coords[dim].dims == voxel_dims
+        name
+        for name, dim in zip(default_names, voxel_dims, strict=True)
+        if name in data.coords and data.coords[name].dims in {voxel_dims, (dim,)}
     )
-    if physical_coord_names:
+    if len(physical_coord_names) == len(voxel_dims):
         return physical_coord_names
-    return ("y", "x") if len(voxel_dims) == 2 else ("z", "y", "x")
+    return default_names
 
 
 def get_voxel_affine_origin(data: xr.DataArray) -> dict[str, float]:

--- a/src/confusius/_utils/geometry.py
+++ b/src/confusius/_utils/geometry.py
@@ -288,6 +288,174 @@ def add_physical_coords_from_voxel_affine(
     return result
 
 
+def restore_physical_coords_from_voxel_affine(data: xr.DataArray) -> xr.DataArray:
+    """Rebuild lazy CTI physical coordinates from stored voxel-affine metadata.
+
+    Parameters
+    ----------
+    data : xarray.DataArray
+        DataArray that may carry `attrs["voxel_to_physical"]` plus 1D voxel-space
+        coordinates on `k`, `j`, and/or `i`.
+
+    Returns
+    -------
+    xarray.DataArray
+        `data` unchanged when the required voxel-affine metadata is absent, otherwise a
+        DataArray with lazy CTI-derived physical coordinates restored.
+    """
+    if "voxel_to_physical" not in data.attrs:
+        return data
+
+    voxel_dims = get_voxel_affine_spatial_dims(data)
+    if len(voxel_dims) not in {2, 3}:
+        return data
+    if any(
+        dim not in data.coords or data.coords[dim].dims != (dim,) for dim in voxel_dims
+    ):
+        return data
+
+    physical_coord_names = get_voxel_affine_physical_coord_names(data)
+    physical_coord_attrs = {
+        name: dict(data.coords[name].attrs)
+        for name in physical_coord_names
+        if name in data.coords
+    }
+
+    return add_physical_coords_from_voxel_affine(
+        data,
+        data.attrs["voxel_to_physical"],
+        voxel_dims=voxel_dims,
+        physical_coord_names=physical_coord_names,
+        physical_coord_attrs=physical_coord_attrs,
+    )
+
+
+def has_voxel_affine_geometry(data: xr.DataArray) -> bool:
+    """Return whether a DataArray carries canonical voxel-affine metadata.
+
+    Parameters
+    ----------
+    data : xarray.DataArray
+        DataArray to inspect.
+
+    Returns
+    -------
+    bool
+        Whether `data` stores a `voxel_to_physical` affine and has 2D or 3D voxel-space
+        dimensions drawn from `("k", "j", "i")`.
+    """
+    return "voxel_to_physical" in data.attrs and len(
+        get_voxel_affine_spatial_dims(data)
+    ) in {
+        2,
+        3,
+    }
+
+
+def get_voxel_affine_spatial_dims(data: xr.DataArray) -> tuple[str, ...]:
+    """Return voxel-space dimensions present on a voxel-affine DataArray.
+
+    Parameters
+    ----------
+    data : xarray.DataArray
+        DataArray to inspect.
+
+    Returns
+    -------
+    tuple[str, ...]
+        Present voxel-space dimensions in canonical affine column order.
+    """
+    return tuple(dim for dim in ("k", "j", "i") if dim in data.dims)
+
+
+def get_voxel_affine_physical_coord_names(data: xr.DataArray) -> tuple[str, ...]:
+    """Return physical coordinate names exposed by voxel-affine geometry.
+
+    Parameters
+    ----------
+    data : xarray.DataArray
+        DataArray to inspect.
+
+    Returns
+    -------
+    tuple[str, ...]
+        Physical coordinate names in affine row order.
+    """
+    voxel_dims = get_voxel_affine_spatial_dims(data)
+    physical_coord_names = tuple(
+        dim
+        for dim in ("z", "y", "x")
+        if dim in data.coords and data.coords[dim].dims == voxel_dims
+    )
+    if physical_coord_names:
+        return physical_coord_names
+    return ("y", "x") if len(voxel_dims) == 2 else ("z", "y", "x")
+
+
+def get_voxel_affine_origin(data: xr.DataArray) -> dict[str, float]:
+    """Return the physical location of the first sampled voxel.
+
+    Parameters
+    ----------
+    data : xarray.DataArray
+        Voxel-affine DataArray.
+
+    Returns
+    -------
+    dict[str, float]
+        Physical origin keyed by physical coordinate name.
+
+    Notes
+    -----
+    This returns the physical location of array index `(0, ..., 0)`, i.e. the first
+    sampled voxel, not necessarily the affine translation at voxel-space `(0, ..., 0)`.
+    The two coincide only when the voxel coordinates themselves start at zero.
+    """
+    voxel_dims = get_voxel_affine_spatial_dims(data)
+    physical_coord_names = get_voxel_affine_physical_coord_names(data)
+    first_voxel = np.array(
+        [float(np.asarray(data.coords[dim].values)[0]) for dim in voxel_dims] + [1.0],
+        dtype=np.float64,
+    )
+    origin = np.asarray(data.attrs["voxel_to_physical"], dtype=np.float64) @ first_voxel
+    return {name: float(origin[i]) for i, name in enumerate(physical_coord_names)}
+
+
+def get_voxel_affine_spacing(data: xr.DataArray) -> dict[str, float | None]:
+    """Return physical spacing per voxel-space axis for a voxel-affine DataArray.
+
+    Parameters
+    ----------
+    data : xarray.DataArray
+        Voxel-affine DataArray.
+
+    Returns
+    -------
+    dict[str, float | None]
+        Physical spacing keyed by voxel-space dimension.
+    """
+    voxel_dims = get_voxel_affine_spatial_dims(data)
+    voxel_coords = {dim: data.coords[dim].values for dim in voxel_dims}
+    return get_physical_spacings(voxel_coords, data.attrs["voxel_to_physical"])
+
+
+def get_voxel_affine_direction_matrix(data: xr.DataArray) -> npt.NDArray[np.float64]:
+    """Return the physical-space direction matrix of a voxel-affine DataArray.
+
+    Parameters
+    ----------
+    data : xarray.DataArray
+        Voxel-affine DataArray.
+
+    Returns
+    -------
+    (N, N) numpy.ndarray
+        Unit direction vectors in physical-space row order and voxel-space column
+        order.
+    """
+    return get_affine_orientation_matrix(data.attrs["voxel_to_physical"])
+
+
 def get_affine_origin(
     voxel_to_physical: npt.ArrayLike,
 ) -> npt.NDArray[np.float64]:

--- a/src/confusius/io/loadsave.py
+++ b/src/confusius/io/loadsave.py
@@ -1,16 +1,23 @@
 """Generic file loading and saving dispatcher."""
 
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import xarray as xr
 
 import confusius.io.nifti as _nifti
 import confusius.io.scan as _scan
+from confusius._utils.geometry import restore_physical_coords_from_voxel_affine
 from confusius.io.utils import check_path
 
 
-def load(path: str | Path, variable: str | None = None, **kwargs: Any) -> xr.DataArray:
+def load(
+    path: str | Path,
+    variable: str | None = None,
+    *,
+    coordinate_model: Literal["legacy", "voxel_affine"] = "legacy",
+    **kwargs: Any,
+) -> xr.DataArray:
     """Load a fUSI DataArray from file, dispatching by extension.
 
     Supported formats:
@@ -28,6 +35,13 @@ def load(path: str | Path, variable: str | None = None, **kwargs: Any) -> xr.Dat
     variable : str, optional
         Zarr only. Name of the variable to extract as a DataArray. If not provided, the
         first variable in the dataset is returned.
+    coordinate_model : {"legacy", "voxel_affine"}, default: "legacy"
+        Spatial coordinate representation to construct or restore.
+
+        - `"legacy"` keeps ConfUSIus' current axis-aligned coordinate model.
+        - `"voxel_affine"` requests the voxel-space plus CTI-derived physical
+          coordinate model. For Zarr, this rebuilds the CTI from stored
+          `voxel_to_physical` metadata when available.
     **kwargs
         Additional keyword arguments forwarded to the underlying loader.
 
@@ -45,15 +59,19 @@ def load(path: str | Path, variable: str | None = None, **kwargs: Any) -> xr.Dat
     name = path.name
 
     if name.endswith(".nii") or name.endswith(".nii.gz"):
-        return _nifti.load_nifti(path, **kwargs)
+        return _nifti.load_nifti(path, coordinate_model=coordinate_model, **kwargs)
     if name.endswith(".scan"):
-        return _scan.load_scan(path, **kwargs)
+        return _scan.load_scan(path, coordinate_model=coordinate_model, **kwargs)
     if name.endswith(".zarr"):
         ds = xr.open_zarr(path, **kwargs)
         if variable is not None:
-            return ds[variable]
-        first_var = next(iter(ds.data_vars))
-        return ds[first_var]
+            data = ds[variable]
+        else:
+            first_var = next(iter(ds.data_vars))
+            data = ds[first_var]
+        if coordinate_model == "voxel_affine":
+            return restore_physical_coords_from_voxel_affine(data)
+        return data
 
     raise ValueError(
         f"Unsupported file extension in {name!r}. Supported"

--- a/src/confusius/io/nifti.py
+++ b/src/confusius/io/nifti.py
@@ -22,6 +22,7 @@ from confusius._utils.coordinates import (
     get_coordinate_spacing_info,
     get_representative_step,
 )
+from confusius._utils.geometry import add_physical_coords_from_voxel_affine
 from confusius._utils.stack import find_stack_level
 from confusius.bids import (
     DIM_TO_SLICE_ENCODING_DIRECTION,
@@ -385,6 +386,145 @@ def _create_spatial_coords_from_nifti(
     return coords, extra_attrs
 
 
+def _subset_confusius_affine(
+    affine: npt.NDArray[np.floating],
+    spatial_axes: tuple[str, ...],
+) -> npt.NDArray[np.float64]:
+    """Extract a 2D or 3D ConfUSIus-order affine for present spatial axes.
+
+    Parameters
+    ----------
+    affine : (4, 4) numpy.ndarray
+        Full 3D affine in ConfUSIus `(z, y, x)` order.
+    spatial_axes : tuple[str, ...]
+        Present physical axes in ConfUSIus order, e.g. `("z", "y", "x")` or
+        `("y", "x")`.
+
+    Returns
+    -------
+    (N+1, N+1) numpy.ndarray
+        Homogeneous affine restricted to the selected axes.
+    """
+    axis_to_index = {"z": 0, "y": 1, "x": 2}
+    indices = [axis_to_index[axis] for axis in spatial_axes]
+    result = np.eye(len(indices) + 1, dtype=np.float64)
+    full_affine = np.asarray(affine, dtype=np.float64)
+    result[:-1, :-1] = full_affine[np.ix_(indices, indices)]
+    result[:-1, -1] = full_affine[indices, 3]
+    return result
+
+
+def _create_voxel_affine_geometry_from_nifti(
+    img: "nib.nifti1.Nifti1Image | nib.nifti2.Nifti2Image",
+    extractor: "_NiftiHeaderExtractor",
+    dims: tuple[str, ...],
+) -> tuple[
+    dict[str, xr.DataArray],
+    tuple[str, ...],
+    tuple[str, ...],
+    npt.NDArray[np.float64],
+    dict[str, dict[str, Any]],
+    dict[str, Any],
+]:
+    """Create voxel-space coords and a voxel-to-physical affine for NIfTI loading.
+
+    Parameters
+    ----------
+    img : nibabel.nifti1.Nifti1Image or nibabel.nifti2.Nifti2Image
+        Loaded NiBabel NIfTI image.
+    extractor : _NiftiHeaderExtractor
+        Header extractor for `img`.
+    dims : tuple[str, ...]
+        Dimension names in NIfTI order `(x, y, z[, time])`.
+
+    Returns
+    -------
+    voxel_coords : dict[str, xarray.DataArray]
+        One-dimensional voxel-space coordinates keyed by voxel dimension name.
+    voxel_dims : tuple[str, ...]
+        Voxel-space dimension names in DataArray order.
+    physical_coord_names : tuple[str, ...]
+        Physical coordinate names in ConfUSIus order.
+    voxel_to_physical : (N+1, N+1) numpy.ndarray
+        Homogeneous affine from voxel space to physical space.
+    physical_coord_attrs : dict[str, dict[str, Any]]
+        Attributes to attach to the derived physical coordinates.
+    extra_attrs : dict[str, Any]
+        Affine-derived DataArray attributes.
+    """
+    voxel_sizes = extractor.get_voxel_dimensions()
+    space_unit, _ = extractor.get_unit_strings()
+    primary_affine, secondary_affine = _select_affines(img.header)
+
+    physical_coord_names = tuple(dim for dim in ("z", "y", "x") if dim in dims)
+    voxel_dims = tuple(
+        {"z": "k", "y": "j", "x": "i"}[dim] for dim in physical_coord_names
+    )
+    conf_to_nifti_axis = {"x": 0, "y": 1, "z": 2}
+    voxel_coords = {
+        voxel_dim: xr.DataArray(
+            np.arange(img.shape[conf_to_nifti_axis[physical_dim]], dtype=np.float64),
+            dims=[voxel_dim],
+        )
+        for physical_dim, voxel_dim in zip(
+            physical_coord_names, voxel_dims, strict=True
+        )
+    }
+
+    physical_coord_attrs: dict[str, dict[str, Any]] = {}
+    if space_unit is not None:
+        physical_coord_attrs = {
+            dim: {"units": space_unit} for dim in physical_coord_names
+        }
+
+    extra_attrs: dict[str, Any] = {}
+
+    if primary_affine is None:
+        warnings.warn(
+            "Both sform_code and qform_code are 0 in the NIfTI header. Coordinates "
+            "will be computed from the voxel dimensions only, which may not reflect "
+            "the true spatial orientation of the data.",
+            stacklevel=find_stack_level(),
+        )
+        full_conf_affine = np.eye(4, dtype=np.float64)
+        full_conf_affine[0, 0] = voxel_sizes.get("z", 1.0)
+        full_conf_affine[1, 1] = voxel_sizes.get("y", 1.0)
+        full_conf_affine[2, 2] = voxel_sizes.get("x", 1.0)
+    else:
+        full_conf_affine = np.asarray(primary_affine, dtype=np.float64)[[2, 1, 0, 3]][
+            :, [2, 1, 0, 3]
+        ]
+
+        _, sform_code = img.header.get_sform(coded=True)
+        primary_prefix = "sform" if sform_code > 0 else "qform"
+        affines_dict: dict[str, npt.NDArray[np.float64]] = {
+            f"physical_to_{primary_prefix}": np.eye(
+                len(physical_coord_names) + 1, dtype=np.float64
+            )
+        }
+        if secondary_affine is not None:
+            secondary_conf_affine = np.asarray(secondary_affine, dtype=np.float64)[
+                [2, 1, 0, 3]
+            ][:, [2, 1, 0, 3]]
+            relative_affine = secondary_conf_affine @ np.linalg.inv(full_conf_affine)
+            affines_dict["physical_to_qform"] = _subset_confusius_affine(
+                relative_affine, physical_coord_names
+            )
+        extra_attrs["affines"] = affines_dict
+
+    voxel_to_physical = _subset_confusius_affine(full_conf_affine, physical_coord_names)
+    extra_attrs["voxel_to_physical"] = voxel_to_physical
+
+    return (
+        voxel_coords,
+        voxel_dims,
+        physical_coord_names,
+        voxel_to_physical,
+        physical_coord_attrs,
+        extra_attrs,
+    )
+
+
 def _create_temporal_coords_from_nifti(
     img: "nib.nifti1.Nifti1Image | nib.nifti2.Nifti2Image",
     extractor: "_NiftiHeaderExtractor",
@@ -704,7 +844,9 @@ def _get_volume_acquisition_reference(
 
 
 def load_nifti(
-    path: str | Path, chunks: int | tuple[int, ...] | str | None = "auto"
+    path: str | Path,
+    chunks: int | tuple[int, ...] | str | None = "auto",
+    coordinate_model: Literal["legacy", "voxel_affine"] = "legacy",
 ) -> xr.DataArray:
     """Load a NIfTI file as a lazy Xarray DataArray.
 
@@ -733,12 +875,21 @@ def load_nifti(
           determined.
         - `-1` or `None` as a blocksize indicate the size of the corresponding
           dimension.
+    coordinate_model : {"legacy", "voxel_affine"}, default: "legacy"
+        Spatial coordinate representation to construct.
+
+        - `"legacy"` keeps ConfUSIus' current axis-aligned 1D physical coordinates.
+        - `"voxel_affine"` creates 1D voxel-space coordinates (`k`, `j`, `i`) plus
+          lazy physical coordinates (`z`, `y`, `x`) derived from a single
+          `attrs["voxel_to_physical"]` affine.
 
     Returns
     -------
     xarray.DataArray
-        Lazy DataArray with dimensions in ConfUSIus order. Data is wrapped in a Dask
-        array for out-of-core computation.
+        Lazy DataArray with dimensions in ConfUSIus order for
+        `coordinate_model="legacy"`, or voxel-space dimensions for
+        `coordinate_model="voxel_affine"`. Data is wrapped in a Dask array for
+        out-of-core computation.
 
     Notes
     -----
@@ -796,26 +947,91 @@ def load_nifti(
     # NIfTI dim order is (x, y, z, time, ...); ConfUSIus order is the reverse.
     nifti_dims = _NIFTI_DIM_ORDER[: dask_arr.ndim]
 
-    spatial_coords, affine_attrs = _create_spatial_coords_from_nifti(
-        img=img, extractor=extractor, dims=nifti_dims
-    )
-    attrs.update(affine_attrs)
+    if coordinate_model == "legacy":
+        spatial_coords, affine_attrs = _create_spatial_coords_from_nifti(
+            img=img, extractor=extractor, dims=nifti_dims
+        )
+        attrs.update(affine_attrs)
 
-    if "time" in nifti_dims:
-        temporal_coords, attrs = _create_temporal_coords_from_nifti(
-            img=img, extractor=extractor, attrs=attrs
+        if "time" in nifti_dims:
+            temporal_coords, attrs = _create_temporal_coords_from_nifti(
+                img=img, extractor=extractor, attrs=attrs
+            )
+            coords = {**spatial_coords, **temporal_coords}
+        else:
+            scalar_temporal_coords, attrs = _create_scalar_temporal_coords_from_nifti(
+                extractor=extractor, attrs=attrs
+            )
+            coords = {**spatial_coords, **scalar_temporal_coords}
+
+        data_dims = nifti_dims[::-1]
+        physical_geometry: (
+            tuple[
+                npt.NDArray[np.float64],
+                tuple[str, ...],
+                tuple[str, ...],
+                dict[str, dict[str, Any]],
+            ]
+            | None
+        ) = None
+    elif coordinate_model == "voxel_affine":
+        (
+            voxel_coords,
+            voxel_dims,
+            physical_coord_names,
+            voxel_to_physical,
+            physical_coord_attrs,
+            affine_attrs,
+        ) = _create_voxel_affine_geometry_from_nifti(
+            img=img, extractor=extractor, dims=nifti_dims
         )
-        coords = {**spatial_coords, **temporal_coords}
+        attrs.update(affine_attrs)
+
+        if "time" in nifti_dims:
+            temporal_coords, attrs = _create_temporal_coords_from_nifti(
+                img=img, extractor=extractor, attrs=attrs
+            )
+            coords = {**voxel_coords, **temporal_coords}
+        else:
+            scalar_temporal_coords, attrs = _create_scalar_temporal_coords_from_nifti(
+                extractor=extractor, attrs=attrs
+            )
+            coords = {**voxel_coords, **scalar_temporal_coords}
+
+        data_dims = tuple(
+            {"z": "k", "y": "j", "x": "i"}.get(dim, dim) for dim in nifti_dims[::-1]
+        )
+        physical_geometry = (
+            voxel_to_physical,
+            voxel_dims,
+            physical_coord_names,
+            physical_coord_attrs,
+        )
     else:
-        scalar_temporal_coords, attrs = _create_scalar_temporal_coords_from_nifti(
-            extractor=extractor, attrs=attrs
+        raise ValueError(
+            f"Unknown coordinate_model {coordinate_model!r}. Expected 'legacy' or "
+            "'voxel_affine'."
         )
-        coords = {**spatial_coords, **scalar_temporal_coords}
 
     nifti_name = path.with_suffix("").stem if path.suffix == ".gz" else path.stem
     data_array = xr.DataArray(
-        dask_arr, dims=nifti_dims[::-1], coords=coords, attrs=attrs, name=nifti_name
+        dask_arr, dims=data_dims, coords=coords, attrs=attrs, name=nifti_name
     )
+
+    if physical_geometry is not None:
+        (
+            voxel_to_physical,
+            voxel_dims,
+            physical_coord_names,
+            physical_coord_attrs,
+        ) = physical_geometry
+        data_array = add_physical_coords_from_voxel_affine(
+            data_array,
+            voxel_to_physical,
+            voxel_dims=voxel_dims,
+            physical_coord_names=physical_coord_names,
+            physical_coord_attrs=physical_coord_attrs,
+        )
 
     return data_array
 

--- a/src/confusius/io/scan.py
+++ b/src/confusius/io/scan.py
@@ -13,6 +13,7 @@ import numpy as np
 import numpy.typing as npt
 import xarray as xr
 
+from confusius._utils.geometry import add_physical_coords_from_voxel_affine
 from confusius.io.utils import check_path
 
 PHYSICAL_TO_PROBE_PERMUTATION: npt.NDArray[np.float64] = np.array(
@@ -186,6 +187,102 @@ def _build_physical_to_lab(
     return physical_to_lab
 
 
+def _build_voxel_to_confusius_physical(
+    voxels_to_probe: npt.NDArray[np.float64],
+) -> npt.NDArray[np.float64]:
+    """Convert `voxelsToProbe` into a zero-based ConfUSIus voxel-to-physical affine.
+
+    Parameters
+    ----------
+    voxels_to_probe : (4, 4) numpy.ndarray
+        SCAN `voxelsToProbe` affine mapping one-based probe voxel coordinates to probe
+        physical coordinates in metres.
+
+    Returns
+    -------
+    (4, 4) numpy.ndarray
+        Affine mapping zero-based ConfUSIus voxel coordinates `(k, j, i)` to
+        ConfUSIus physical coordinates `(z, y, x)` in millimetres.
+    """
+    conf_voxel_to_probe_voxel = np.array(
+        [
+            [0.0, 0.0, 1.0, 1.0],
+            [1.0, 0.0, 0.0, 1.0],
+            [0.0, 1.0, 0.0, 1.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ],
+        dtype=np.float64,
+    )
+    metres_to_mm = np.diag([1e3, 1e3, 1e3, 1.0])
+    return (
+        metres_to_mm
+        @ PHYSICAL_TO_PROBE_PERMUTATION.T
+        @ np.asarray(voxels_to_probe, dtype=np.float64)
+        @ conf_voxel_to_probe_voxel
+    )
+
+
+def _make_scan_voxel_coords(
+    size_x: int,
+    size_y: int,
+    size_z: int,
+) -> dict[str, xr.DataArray]:
+    """Return 1D voxel-space coordinates for ConfUSIus scan dimensions.
+
+    Parameters
+    ----------
+    size_x : int
+        Number of lateral voxels.
+    size_y : int
+        Number of elevation voxels.
+    size_z : int
+        Number of depth voxels.
+
+    Returns
+    -------
+    dict[str, xarray.DataArray]
+        One-dimensional voxel-space coordinates keyed by `k`, `j`, and `i`.
+    """
+    return {
+        "k": xr.DataArray(np.arange(size_y, dtype=np.float64), dims=["k"]),
+        "j": xr.DataArray(np.arange(size_z, dtype=np.float64), dims=["j"]),
+        "i": xr.DataArray(np.arange(size_x, dtype=np.float64), dims=["i"]),
+    }
+
+
+def _attach_scan_voxel_affine_geometry(
+    data: xr.DataArray,
+    voxel_to_physical: npt.NDArray[np.float64],
+) -> xr.DataArray:
+    """Attach lazy physical `(z, y, x)` coordinates derived from scan voxel space.
+
+    Parameters
+    ----------
+    data : xarray.DataArray
+        Scan data carrying 1D voxel-space coordinates `k`, `j`, `i`.
+    voxel_to_physical : (4, 4) numpy.ndarray
+        Affine mapping zero-based ConfUSIus voxel coordinates to physical probe space.
+
+    Returns
+    -------
+    xarray.DataArray
+        DataArray with lazy physical coordinates attached and the affine stored in
+        `attrs["voxel_to_physical"]`.
+    """
+    data.attrs["voxel_to_physical"] = np.asarray(voxel_to_physical, dtype=np.float64)
+    return add_physical_coords_from_voxel_affine(
+        data,
+        voxel_to_physical,
+        voxel_dims=("k", "j", "i"),
+        physical_coord_names=("z", "y", "x"),
+        physical_coord_attrs={
+            "z": {"units": "mm"},
+            "y": {"units": "mm"},
+            "x": {"units": "mm"},
+        },
+    )
+
+
 def load_bps(bps_path: str | Path) -> npt.NDArray[np.float64]:
     """Load a BPS file and return an affine from Iconeus' brain space to ConfUSIus lab space.
 
@@ -244,6 +341,7 @@ def load_scan(
     path: str | Path,
     bps_path: str | Path | None = None,
     chunks: int | tuple[int, ...] | str | None = "auto",
+    coordinate_model: str = "legacy",
 ) -> xr.DataArray:
     """Load an Iconeus SCAN file as a lazy Xarray DataArray.
 
@@ -271,17 +369,32 @@ def load_scan(
         - A size in bytes like `"100 MiB"`.
         - `"auto"` to let Dask choose based on heuristics.
         - `-1` or `None` for the full dimension size (no chunking).
+    coordinate_model : {"legacy", "voxel_affine"}, default: "legacy"
+        Spatial coordinate representation to construct.
+
+        - `"legacy"` keeps the current 1D physical coordinates `z`, `y`, `x`.
+        - `"voxel_affine"` creates 1D voxel-space coordinates `k`, `j`, `i` plus
+          lazy physical coordinates `z`, `y`, `x` derived from a single
+          `attrs["voxel_to_physical"]` affine.
 
     Returns
     -------
     xarray.DataArray
         Lazy DataArray with dimensions and coordinates:
 
-        - `2Dscan` → `(time, z, y, x)`.
-        - `3Dscan` → `(pose, z, y, x)`.
-        - `4Dscan` → `(time, pose, z, y, x)`.
+        - `coordinate_model="legacy"`:
 
-        All spatial coordinates are in millimeters. The `time` coordinate is in
+          - `2Dscan` → `(time, z, y, x)`.
+          - `3Dscan` → `(pose, z, y, x)`.
+          - `4Dscan` → `(time, pose, z, y, x)`.
+
+        - `coordinate_model="voxel_affine"`:
+
+          - `2Dscan` → `(time, k, j, i)`.
+          - `3Dscan` → `(pose, k, j, i)`.
+          - `4Dscan` → `(time, pose, k, j, i)`.
+
+        All physical coordinates are in millimeters. The `time` coordinate is in
         seconds. For `4Dscan`, a `pose_time` non-dimension coordinate of shape
         `(time, pose)` stores the actual per-pose acquisition timestamps.
 
@@ -332,6 +445,8 @@ def load_scan(
         spatial_coords = _coords_from_voxels_to_probe(
             voxels_to_probe, size_x, size_y, size_z
         )
+        voxel_coords = _make_scan_voxel_coords(size_x, size_y, size_z)
+        voxel_to_physical = _build_voxel_to_confusius_physical(voxels_to_probe)
         physical_to_lab = _build_physical_to_lab(probe_to_lab)
 
         attrs: dict[str, Any] = {
@@ -348,18 +463,48 @@ def load_scan(
 
         raw_lazy = da.from_array(h5["/Data"], chunks=chunks, asarray=False)
 
-        if mode == "2Dscan":
-            data_array = _load_2dscan(h5, raw_lazy, spatial_coords, attrs)
-        elif mode == "3Dscan":
-            data_array = _load_3dscan(raw_lazy, spatial_coords, attrs, npose)
-        elif mode == "4Dscan":
-            data_array = _load_4dscan(
-                h5, raw_lazy, spatial_coords, attrs, npose, nblock_repeat
-            )
+        if coordinate_model == "legacy":
+            if mode == "2Dscan":
+                data_array = _load_2dscan(h5, raw_lazy, spatial_coords, attrs)
+            elif mode == "3Dscan":
+                data_array = _load_3dscan(raw_lazy, spatial_coords, attrs, npose)
+            elif mode == "4Dscan":
+                data_array = _load_4dscan(
+                    h5, raw_lazy, spatial_coords, attrs, npose, nblock_repeat
+                )
+            else:
+                raise ValueError(
+                    f"Unknown acquisitionMode: {mode!r}. Expected one of '2Dscan',"
+                    " '3Dscan', '4Dscan'."
+                )
+        elif coordinate_model == "voxel_affine":
+            if mode == "2Dscan":
+                data_array = _load_2dscan_voxel_affine(
+                    h5, raw_lazy, voxel_coords, attrs, voxel_to_physical
+                )
+            elif mode == "3Dscan":
+                data_array = _load_3dscan_voxel_affine(
+                    raw_lazy, voxel_coords, attrs, npose, voxel_to_physical
+                )
+            elif mode == "4Dscan":
+                data_array = _load_4dscan_voxel_affine(
+                    h5,
+                    raw_lazy,
+                    voxel_coords,
+                    attrs,
+                    npose,
+                    nblock_repeat,
+                    voxel_to_physical,
+                )
+            else:
+                raise ValueError(
+                    f"Unknown acquisitionMode: {mode!r}. Expected one of '2Dscan',"
+                    " '3Dscan', '4Dscan'."
+                )
         else:
             raise ValueError(
-                f"Unknown acquisitionMode: {mode!r}. Expected one of '2Dscan',"
-                " '3Dscan', '4Dscan'."
+                f"Unknown coordinate_model {coordinate_model!r}. Expected 'legacy' or "
+                "'voxel_affine'."
             )
 
         data_array.name = attrs["iconeus_scan"] or path.stem
@@ -585,3 +730,102 @@ def _load_4dscan(
     return xr.DataArray(
         data_lazy, dims=["time", "pose", "z", "y", "x"], coords=coords, attrs=attrs
     )
+
+
+def _load_2dscan_voxel_affine(
+    h5: h5py.File,
+    raw_lazy: da.Array,
+    voxel_coords: dict[str, xr.DataArray],
+    attrs: dict[str, Any],
+    voxel_to_physical: npt.NDArray[np.float64],
+) -> xr.DataArray:
+    """Build a voxel-affine DataArray for `2Dscan` mode."""
+    data_lazy = da.transpose(raw_lazy, [0, 2, 1, 3])
+    time: npt.NDArray[np.float64] = np.array(
+        h5["/acqMetaData/time"][()], dtype=np.float64
+    ).squeeze()
+    time_attrs: dict[str, Any] = {
+        "units": "s",
+        "volume_acquisition_reference": "end",
+        "volume_acquisition_duration": time.min(),
+    }
+    coords: dict[str, Any] = {
+        "time": xr.DataArray(time, dims=["time"], attrs=time_attrs),
+        **voxel_coords,
+    }
+    result = xr.DataArray(
+        data_lazy,
+        dims=["time", "k", "j", "i"],
+        coords=coords,
+        attrs=attrs,
+    )
+    return _attach_scan_voxel_affine_geometry(result, voxel_to_physical)
+
+
+def _load_3dscan_voxel_affine(
+    raw_lazy: da.Array,
+    voxel_coords: dict[str, xr.DataArray],
+    attrs: dict[str, Any],
+    npose: int,
+    voxel_to_physical: npt.NDArray[np.float64],
+) -> xr.DataArray:
+    """Build a voxel-affine DataArray for `3Dscan` mode."""
+    sq = da.squeeze(raw_lazy, axis=1)
+    data_lazy = da.transpose(sq, [0, 2, 1, 3])
+    coords: dict[str, Any] = {
+        "pose": xr.DataArray(np.arange(npose), dims=["pose"]),
+        **voxel_coords,
+    }
+    result = xr.DataArray(
+        data_lazy,
+        dims=["pose", "k", "j", "i"],
+        coords=coords,
+        attrs=attrs,
+    )
+    return _attach_scan_voxel_affine_geometry(result, voxel_to_physical)
+
+
+def _load_4dscan_voxel_affine(
+    h5: h5py.File,
+    raw_lazy: da.Array,
+    voxel_coords: dict[str, xr.DataArray],
+    attrs: dict[str, Any],
+    npose: int,
+    nblock_repeat: int,
+    voxel_to_physical: npt.NDArray[np.float64],
+) -> xr.DataArray:
+    """Build a voxel-affine DataArray for `4Dscan` mode."""
+    nscan_repeat = raw_lazy.shape[0]
+    n_time = nscan_repeat * nblock_repeat
+
+    if nblock_repeat == 1:
+        sq = da.squeeze(raw_lazy, axis=2)
+    else:
+        transposed = da.transpose(raw_lazy, [0, 2, 1, 3, 4, 5])
+        sq = transposed.reshape(n_time, npose, *raw_lazy.shape[3:])
+
+    data_lazy = da.transpose(sq, [0, 1, 3, 2, 4])
+    time_raw: npt.NDArray[np.float64] = (
+        np.array(h5["/acqMetaData/time"][()], dtype=np.float64)
+        .squeeze()
+        .reshape(n_time, npose)
+    )
+    block_time = time_raw.max(axis=1)
+    time_attrs: dict[str, Any] = {
+        "units": "s",
+        "volume_acquisition_reference": "end",
+        "volume_acquisition_duration": time_raw.min(),
+    }
+    coords: dict[str, Any] = {
+        "time": xr.DataArray(block_time, dims=["time"], attrs=time_attrs),
+        "pose": xr.DataArray(np.arange(npose), dims=["pose"]),
+        "pose_time": xr.DataArray(time_raw, dims=["time", "pose"], attrs=time_attrs),
+        **voxel_coords,
+    }
+    result = xr.DataArray(
+        data_lazy,
+        dims=["time", "pose", "k", "j", "i"],
+        coords=coords,
+        attrs=attrs,
+    )
+    return _attach_scan_voxel_affine_geometry(result, voxel_to_physical)

--- a/src/confusius/plotting/image.py
+++ b/src/confusius/plotting/image.py
@@ -108,15 +108,128 @@ def _centers_to_edges(centers: np.ndarray) -> np.ndarray:
     return np.concatenate([[left], interior, [right]])
 
 
+def _has_voxel_affine_geometry(data: xr.DataArray) -> bool:
+    """Return whether `data` carries voxel-affine geometry metadata."""
+    return "voxel_to_physical" in data.attrs and all(
+        str(dim) in {"k", "j", "i"} for dim in data.dims
+    )
+
+
+def _voxel_affine_dim_order(slice_da: xr.DataArray) -> tuple[str, ...]:
+    """Return voxel-space dimension order implied by the stored affine."""
+    ndim = np.asarray(slice_da.attrs["voxel_to_physical"]).shape[0] - 1
+    dims = tuple(
+        dim for dim in ("k", "j", "i") if dim in slice_da.dims or dim in slice_da.coords
+    )
+    if len(dims) != ndim:
+        raise ValueError(
+            "Voxel-affine plotting could not infer voxel dimension order from "
+            f"dims/coords {dims!r} and affine shape {slice_da.attrs['voxel_to_physical'].shape}."
+        )
+    return dims
+
+
+def _project_voxel_affine_plane(
+    slice_da: xr.DataArray,
+    dim_row: str,
+    dim_col: str,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Project a voxel-affine 2D slice into an in-plane orthonormal basis.
+
+    Parameters
+    ----------
+    slice_da : xarray.DataArray
+        Two-dimensional slice whose dimensions are voxel-space dims.
+    dim_row : str
+        Voxel-space dimension displayed on rows.
+    dim_col : str
+        Voxel-space dimension displayed on columns.
+
+    Returns
+    -------
+    x_edges : (H+1, W+1) numpy.ndarray
+        In-plane x coordinates of cell corners.
+    y_edges : (H+1, W+1) numpy.ndarray
+        In-plane y coordinates of cell corners.
+    x_centers : (H, W) numpy.ndarray
+        In-plane x coordinates of cell centers.
+    y_centers : (H, W) numpy.ndarray
+        In-plane y coordinates of cell centers.
+    """
+    affine = np.asarray(slice_da.attrs["voxel_to_physical"], dtype=np.float64)
+    dim_order = _voxel_affine_dim_order(slice_da)
+    linear = affine[:-1, :-1]
+
+    row_vals = (
+        slice_da.coords[dim_row].values.astype(float)
+        if dim_row in slice_da.coords
+        else np.arange(slice_da.sizes[dim_row], dtype=float)
+    )
+    col_vals = (
+        slice_da.coords[dim_col].values.astype(float)
+        if dim_col in slice_da.coords
+        else np.arange(slice_da.sizes[dim_col], dtype=float)
+    )
+    row_edges = _centers_to_edges(row_vals)
+    col_edges = _centers_to_edges(col_vals)
+
+    col_vec = linear[:, dim_order.index(dim_col)]
+    row_vec = linear[:, dim_order.index(dim_row)]
+    e1 = col_vec / np.linalg.norm(col_vec)
+    row_perp = row_vec - np.dot(row_vec, e1) * e1
+    row_perp_norm = np.linalg.norm(row_perp)
+    if np.isclose(row_perp_norm, 0.0):
+        raise ValueError(
+            f"Voxel-affine plotting requires non-collinear plane axes, got {dim_row!r} "
+            f"and {dim_col!r}."
+        )
+    e2 = row_perp / row_perp_norm
+
+    def _project(
+        row_axis: np.ndarray, col_axis: np.ndarray
+    ) -> tuple[np.ndarray, np.ndarray]:
+        col_grid, row_grid = np.meshgrid(col_axis, row_axis, indexing="xy")
+        voxel_components: list[np.ndarray] = []
+        for dim in dim_order:
+            if dim == dim_row:
+                voxel_components.append(row_grid)
+            elif dim == dim_col:
+                voxel_components.append(col_grid)
+            else:
+                voxel_components.append(
+                    np.full_like(
+                        row_grid, float(slice_da.coords[dim].item()), dtype=float
+                    )
+                )
+        homogeneous = np.stack(
+            [*voxel_components, np.ones_like(row_grid, dtype=float)], axis=0
+        ).reshape(len(dim_order) + 1, -1)
+        physical = (affine @ homogeneous).reshape((affine.shape[0], *row_grid.shape))[
+            :-1
+        ]
+        origin = physical[:, 0, 0][:, np.newaxis, np.newaxis]
+        rel = physical - origin
+        x = np.tensordot(e1, rel, axes=(0, 0))
+        y = np.tensordot(e2, rel, axes=(0, 0))
+        return x, y
+
+    x_edges, y_edges = _project(row_edges, col_edges)
+    x_centers, y_centers = _project(row_vals, col_vals)
+    return x_edges, y_edges, x_centers, y_centers
+
+
 def _slice_edges_and_centers(
     slice_da: xr.DataArray, dim_row: str, dim_col: str
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
-    """Return `(x_edges, y_edges, x_centers, y_centers)` for a 2D slice.
+    """Return plotting geometry for a 2D slice.
 
-    Centers fall back to integer indices when the slice lacks coordinates along the
-    requested dimension; edges are derived from the centers via
-    [`_centers_to_edges`][confusius.plotting.image._centers_to_edges].
+    For standard axis-aligned data, returns 1D edge/center coordinates for the plotted
+    row/column dimensions. For voxel-affine data, returns 2D corner and center meshes
+    obtained by projecting the physical slice into an orthonormal in-plane basis.
     """
+    if _has_voxel_affine_geometry(slice_da):
+        return _project_voxel_affine_plane(slice_da, dim_row, dim_col)
+
     if dim_col in slice_da.coords:
         x_centers = slice_da.coords[dim_col].values.astype(float)
         x_edges = _centers_to_edges(x_centers)
@@ -279,6 +392,9 @@ def _resolve_cmap(
 
 def _build_axis_label(da: xr.DataArray, dim: str) -> str:
     """Return axis label for `dim`, including units when available."""
+    if _has_voxel_affine_geometry(da):
+        return f"{dim} in-plane (mm)"
+
     label = dim
     if dim in da.coords:
         units = da.coords[dim].attrs.get("units")
@@ -899,16 +1015,17 @@ class VolumePlotter:
                 norm=norm,
                 alpha=alpha,
             )
-            self._attach_or_update_hover_manager(resolved_roi_labels)
-            self._hover_manager.register_data_to_axis(
-                ax,
-                hover_x,
-                hover_y,
-                slice_da.values,
-                role="labels" if resolved_roi_labels else "volume",
-                name=str(data.name) if data.name is not None else "value",
-                units=data.attrs.get("units"),
-            )
+            if hover_x.ndim == 1 and hover_y.ndim == 1:
+                self._attach_or_update_hover_manager(resolved_roi_labels)
+                self._hover_manager.register_data_to_axis(
+                    ax,
+                    hover_x,
+                    hover_y,
+                    slice_da.values,
+                    role="labels" if resolved_roi_labels else "volume",
+                    name=str(data.name) if data.name is not None else "value",
+                    units=data.attrs.get("units"),
+                )
 
             self._style_slice_axis(
                 ax,
@@ -1198,19 +1315,22 @@ class VolumePlotter:
             )
 
             ax.pcolormesh(x_edges, y_edges, rgb, alpha=alpha)
-            self._attach_or_update_hover_manager({})
-            for i, (data, input_slices) in enumerate(
-                zip((data1, data2), (input_slices1, input_slices2))
-            ):
-                self._hover_manager.register_data_to_axis(
-                    ax,
-                    hover_x,
-                    hover_y,
-                    input_slices[slice_idx].values,
-                    role="volume",
-                    name=str(data.name) if data.name is not None else f"data{i + 1}",
-                    units=data.attrs.get("units"),
-                )
+            if hover_x.ndim == 1 and hover_y.ndim == 1:
+                self._attach_or_update_hover_manager({})
+                for i, (data, input_slices) in enumerate(
+                    zip((data1, data2), (input_slices1, input_slices2))
+                ):
+                    self._hover_manager.register_data_to_axis(
+                        ax,
+                        hover_x,
+                        hover_y,
+                        input_slices[slice_idx].values,
+                        role="volume",
+                        name=str(data.name)
+                        if data.name is not None
+                        else f"data{i + 1}",
+                        units=data.attrs.get("units"),
+                    )
 
             self._style_slice_axis(
                 ax,

--- a/src/confusius/plotting/image.py
+++ b/src/confusius/plotting/image.py
@@ -115,6 +115,34 @@ def _has_voxel_affine_geometry(data: xr.DataArray) -> bool:
     )
 
 
+def _validate_voxel_affine_slice_mode(data: xr.DataArray, slice_mode: str) -> None:
+    """Validate slice selection semantics for voxel-affine data.
+
+    Parameters
+    ----------
+    data : xarray.DataArray
+        Data being sliced for plotting.
+    slice_mode : str
+        Requested slice dimension.
+
+    Raises
+    ------
+    ValueError
+        If voxel-affine data is sliced along anything other than its native voxel-space
+        dimensions.
+    """
+    if not _has_voxel_affine_geometry(data):
+        return
+
+    valid_slice_modes = tuple(dim for dim in ("k", "j", "i") if dim in data.dims)
+    if slice_mode not in valid_slice_modes:
+        raise ValueError(
+            "Voxel-affine plotting currently supports only native voxel-plane slicing "
+            f"along {valid_slice_modes!r}, got slice_mode={slice_mode!r}. Physical-"
+            "plane slicing is not implemented yet."
+        )
+
+
 def _voxel_affine_dim_order(slice_da: xr.DataArray) -> tuple[str, ...]:
     """Return voxel-space dimension order implied by the stored affine."""
     ndim = np.asarray(slice_da.attrs["voxel_to_physical"]).shape[0] - 1
@@ -698,6 +726,7 @@ class VolumePlotter:
     def _prepare_slice_inputs(self, data: xr.DataArray, *, caller: str) -> xr.DataArray:
         """Coerce complex, squeeze, validate `slice_mode`/3D, and sort coords."""
         data = coerce_complex_to_magnitude(data, caller=caller)
+        _validate_voxel_affine_slice_mode(data, self.slice_mode)
         squeeze_dims = [
             d for d in data.dims if d != self.slice_mode and data.sizes[d] == 1
         ]
@@ -1489,6 +1518,8 @@ class VolumePlotter:
         ]
         if squeeze_dims:
             mask = mask.squeeze(dim=squeeze_dims)
+
+        _validate_voxel_affine_slice_mode(mask, self.slice_mode)
 
         if self.slice_mode not in mask.dims:
             raise ValueError(f"slice_mode '{self.slice_mode}' not in mask dimensions")

--- a/src/confusius/validation/fusi.py
+++ b/src/confusius/validation/fusi.py
@@ -10,6 +10,11 @@ import xarray as xr
 
 from confusius._dims import CORE_DIMS, POSE_DIM, SPATIAL_DIMS, TIME_DIM
 from confusius._utils.coordinates import get_coordinate_spacing_info
+from confusius._utils.geometry import (
+    get_voxel_affine_physical_coord_names,
+    get_voxel_affine_spatial_dims,
+    has_voxel_affine_geometry,
+)
 
 RegularSpacingDims = Literal["space", "core", "all"] | str | Sequence[str]
 """Selector for dimensions that must satisfy regular-spacing checks."""
@@ -17,9 +22,93 @@ RegularSpacingDims = Literal["space", "core", "all"] | str | Sequence[str]
 _ALLOWED_CORE_DIMS = CORE_DIMS
 """Core dimension names recognized by ConfUSIus fUSI validators."""
 
+_VOXEL_SPATIAL_DIMS = ("k", "j", "i")
+"""Voxel-space spatial dimension names used by voxel-affine geometry."""
+
+
+def _get_allowed_core_dims(da: xr.DataArray) -> tuple[str, ...]:
+    """Return the core dimension names valid for a DataArray.
+
+    Parameters
+    ----------
+    da : xarray.DataArray
+        DataArray to inspect.
+
+    Returns
+    -------
+    tuple[str, ...]
+        Allowed core dimensions for `da`.
+    """
+    if has_voxel_affine_geometry(da):
+        return (TIME_DIM, POSE_DIM, *_VOXEL_SPATIAL_DIMS)
+    return _ALLOWED_CORE_DIMS
+
+
+def _get_spatial_dims(da: xr.DataArray) -> tuple[str, ...]:
+    """Return the spatial dimensions to validate for a DataArray.
+
+    Parameters
+    ----------
+    da : xarray.DataArray
+        DataArray to inspect.
+
+    Returns
+    -------
+    tuple[str, ...]
+        Spatial dimensions for `da`, using `k/j/i` for voxel-affine geometry and
+        `z/y/x` otherwise.
+    """
+    if has_voxel_affine_geometry(da):
+        return get_voxel_affine_spatial_dims(da)
+    return tuple(dim for dim in SPATIAL_DIMS if dim in da.dims)
+
+
+def _validate_voxel_affine_geometry(da: xr.DataArray) -> None:
+    """Validate voxel-affine metadata when present.
+
+    Parameters
+    ----------
+    da : xarray.DataArray
+        DataArray to validate.
+
+    Raises
+    ------
+    ValueError
+        If stored voxel-affine metadata is incomplete or inconsistent with the DataArray
+        shape.
+    """
+    if not has_voxel_affine_geometry(da):
+        return
+
+    voxel_dims = get_voxel_affine_spatial_dims(da)
+    expected_shape = (len(voxel_dims) + 1, len(voxel_dims) + 1)
+    affine = np.asarray(da.attrs["voxel_to_physical"])
+    if affine.shape != expected_shape:
+        raise ValueError(
+            "voxel_to_physical must have shape "
+            f"{expected_shape} for voxel-affine dimensions {voxel_dims!r}, got "
+            f"{affine.shape}."
+        )
+
+    for name in get_voxel_affine_physical_coord_names(da):
+        if name not in da.coords:
+            raise ValueError(
+                f"Voxel-affine data is missing physical coordinate {name!r}."
+            )
+        coord = da.coords[name]
+        if coord.dims != voxel_dims:
+            raise ValueError(
+                f"Voxel-affine coordinate {name!r} must have dims {voxel_dims!r}, "
+                f"got {coord.dims!r}."
+            )
+
 
 def _validate_dimension_coordinate(
-    da: xr.DataArray, dim: Hashable, *, require_numeric: bool
+    da: xr.DataArray,
+    dim: Hashable,
+    *,
+    require_numeric: bool,
+    allowed_core_dims: tuple[str, ...],
 ) -> None:
     """Validate a single dimension coordinate.
 
@@ -31,6 +120,8 @@ def _validate_dimension_coordinate(
         Dimension name whose matching coordinate is required.
     require_numeric : bool
         Whether the coordinate must be numeric, finite, and strictly increasing.
+    allowed_core_dims : tuple[str, ...]
+        Core dimensions whose matching coordinates are required.
 
     Raises
     ------
@@ -40,7 +131,7 @@ def _validate_dimension_coordinate(
         increasing.
     """
     if dim not in da.coords:
-        if dim in _ALLOWED_CORE_DIMS:
+        if dim in allowed_core_dims:
             raise ValueError(f"Missing required coordinate for dimension {dim!r}.")
         return
 
@@ -64,7 +155,11 @@ def _validate_dimension_coordinate(
             )
 
 
-def _validate_core_dimension_names(da: xr.DataArray, allow_extra_dims: bool) -> None:
+def _validate_core_dimension_names(
+    da: xr.DataArray,
+    allow_extra_dims: bool,
+    allowed_core_dims: tuple[str, ...],
+) -> None:
     """Validate that core ConfUSIus dimensions are named consistently.
 
     Parameters
@@ -73,6 +168,8 @@ def _validate_core_dimension_names(da: xr.DataArray, allow_extra_dims: bool) -> 
         DataArray whose dimensions should be checked.
     allow_extra_dims : bool
         Whether dimensions outside the ConfUSIus core set are allowed.
+    allowed_core_dims : tuple[str, ...]
+        Core dimensions valid for the current geometry model.
 
     Raises
     ------
@@ -87,15 +184,17 @@ def _validate_core_dimension_names(da: xr.DataArray, allow_extra_dims: bool) -> 
         )
 
     if not allow_extra_dims:
-        unexpected_dims = [dim for dim in da.dims if dim not in _ALLOWED_CORE_DIMS]
+        unexpected_dims = [dim for dim in da.dims if dim not in allowed_core_dims]
         if unexpected_dims:
             raise ValueError(
                 f"Unexpected dimensions {unexpected_dims!r}. ConfUSIus fUSI DataArrays "
-                f"may only use dimensions {_ALLOWED_CORE_DIMS!r}."
+                f"may only use dimensions {allowed_core_dims!r}."
             )
 
 
-def _validate_canonical_core_dim_order(da: xr.DataArray) -> None:
+def _validate_canonical_core_dim_order(
+    da: xr.DataArray, allowed_core_dims: tuple[str, ...]
+) -> None:
     """Validate the relative order of ConfUSIus core dimensions.
 
     Extra dimensions are ignored. Only the subsequence formed by the ConfUSIus core
@@ -105,6 +204,8 @@ def _validate_canonical_core_dim_order(da: xr.DataArray) -> None:
     ----------
     da : xarray.DataArray
         DataArray whose dimension order should be checked.
+    allowed_core_dims : tuple[str, ...]
+        Core dimensions valid for the current geometry model.
 
     Raises
     ------
@@ -112,8 +213,8 @@ def _validate_canonical_core_dim_order(da: xr.DataArray) -> None:
         If the relative order of the present core dimensions differs from the canonical
         ConfUSIus order.
     """
-    present_core_dims = tuple(dim for dim in da.dims if dim in _ALLOWED_CORE_DIMS)
-    expected_order = tuple(dim for dim in _ALLOWED_CORE_DIMS if dim in da.dims)
+    present_core_dims = tuple(dim for dim in da.dims if dim in allowed_core_dims)
+    expected_order = tuple(dim for dim in allowed_core_dims if dim in da.dims)
     if present_core_dims != expected_order:
         raise ValueError(
             f"Core dimensions {present_core_dims!r} are not in canonical ConfUSIus "
@@ -153,6 +254,7 @@ def _validate_regular_spacing(
     da: xr.DataArray,
     regular_spacing_tolerance: float,
     regular_spacing_dims: RegularSpacingDims,
+    spatial_dims: tuple[str, ...],
 ) -> None:
     """Validate that selected numeric coordinates have regular spacing.
 
@@ -164,10 +266,11 @@ def _validate_regular_spacing(
         Relative tolerance used to assess regularity.
     regular_spacing_dims : {"space", "core", "all"} or str or sequence[str]
         Dimensions to validate. `"space"` checks present spatial dimensions, `"core"`
-        checks present core dimensions (`time`, `pose`, `z`, `y`, `x`), and `"all"`
-        checks all present dimensions. Any other string is treated as a single
-        dimension name. A sequence checks only listed dimensions. Non-numeric
-        dimensions are ignored.
+        checks present core dimensions, and `"all"` checks all present dimensions. Any
+        other string is treated as a single dimension name. A sequence checks only
+        listed dimensions. Non-numeric dimensions are ignored.
+    spatial_dims : tuple[str, ...]
+        Spatial dimensions for the current geometry model.
 
     Raises
     ------
@@ -176,9 +279,9 @@ def _validate_regular_spacing(
         selected numeric coordinate has non-uniform or undefined spacing.
     """
     if regular_spacing_dims == "space":
-        dims_to_check = [dim for dim in SPATIAL_DIMS if dim in da.dims]
+        dims_to_check = list(spatial_dims)
     elif regular_spacing_dims == "core":
-        dims_to_check = [dim for dim in _ALLOWED_CORE_DIMS if dim in da.dims]
+        dims_to_check = [dim for dim in _get_allowed_core_dims(da) if dim in da.dims]
     elif regular_spacing_dims == "all":
         dims_to_check = [str(dim) for dim in da.dims]
     elif isinstance(regular_spacing_dims, str):
@@ -229,13 +332,13 @@ def validate_fusi_dataarray(
 
     A valid fUSI DataArray must:
 
-    - Have dimension names from the set `(time, pose, z, y, x)`, with optional extra
+    - Have dimension names from the regular ConfUSIus set `(time, pose, z, y, x)` or,
+      for voxel-affine geometry, from `(time, pose, k, j, i)`, with optional extra
       dimensions if `allow_extra_dims` is `True` (e.g., `region`, `component`, `mask`,
       etc.).
-    - Have matching 1D coordinates for all core dimensions (`time`, `pose`, `z`, `y`,
-      `x`). Extra-dimension coordinates are optional.
-    - Have numeric, finite, and strictly increasing core dimension coordinates (`time`,
-      `pose`, `z`, `y`, `x`).
+    - Have matching 1D coordinates for all core dimensions. Extra-dimension
+      coordinates are optional.
+    - Have numeric, finite, and strictly increasing core dimension coordinates.
 
     Additional requirements can be enforced using the function parameters.
 
@@ -251,8 +354,8 @@ def validate_fusi_dataarray(
         Whether dimensions outside the ConfUSIus core set (`time`, `pose`, `z`, `y`,
         `x`) are allowed.
     minimum_spatial_dims : int, default: 2
-        Minimum number of spatial dimensions from `("z", "y", "x")` required in the
-        DataArray.
+        Minimum number of spatial dimensions required in the DataArray. This counts
+        `z/y/x` for regular geometry and `k/j/i` for voxel-affine geometry.
     require_regular_spacing : bool, default: False
         Whether numeric dimension coordinates must have regular spacing.
     regular_spacing_tolerance : float, default: 1e-2
@@ -292,7 +395,16 @@ def validate_fusi_dataarray(
             f"{minimum_spatial_dims}."
         )
 
-    _validate_core_dimension_names(data, allow_extra_dims=allow_extra_dims)
+    _validate_voxel_affine_geometry(data)
+
+    allowed_core_dims = _get_allowed_core_dims(data)
+    spatial_dims = _get_spatial_dims(data)
+
+    _validate_core_dimension_names(
+        data,
+        allow_extra_dims=allow_extra_dims,
+        allowed_core_dims=allowed_core_dims,
+    )
 
     if require_time and TIME_DIM not in data.dims:
         raise ValueError("DataArray must have a 'time' dimension.")
@@ -300,7 +412,7 @@ def validate_fusi_dataarray(
     if not allow_pose and POSE_DIM in data.dims:
         raise ValueError("DataArray must not have a 'pose' dimension.")
 
-    spatial_dims_present = [dim for dim in SPATIAL_DIMS if dim in data.dims]
+    spatial_dims_present = list(spatial_dims)
     if len(spatial_dims_present) < minimum_spatial_dims:
         raise ValueError(
             f"DataArray must have at least {minimum_spatial_dims} spatial dimensions "
@@ -309,20 +421,33 @@ def validate_fusi_dataarray(
 
     for dim in data.dims:
         _validate_dimension_coordinate(
-            data, dim, require_numeric=dim in _ALLOWED_CORE_DIMS
+            data,
+            dim,
+            require_numeric=dim in allowed_core_dims,
+            allowed_core_dims=allowed_core_dims,
         )
 
     if require_regular_spacing:
-        _validate_regular_spacing(data, regular_spacing_tolerance, regular_spacing_dims)
+        _validate_regular_spacing(
+            data,
+            regular_spacing_tolerance,
+            regular_spacing_dims,
+            spatial_dims,
+        )
 
     if require_canonical_dim_order:
-        _validate_canonical_core_dim_order(data)
+        _validate_canonical_core_dim_order(data, allowed_core_dims)
 
     if require_spatial_voxdim:
-        _validate_required_coordinate_attrs(data, SPATIAL_DIMS, "voxdim")
+        _validate_required_coordinate_attrs(data, spatial_dims, "voxdim")
 
     if require_spatial_units:
-        _validate_required_coordinate_attrs(data, SPATIAL_DIMS, "units")
+        spatial_unit_coords = (
+            get_voxel_affine_physical_coord_names(data)
+            if has_voxel_affine_geometry(data)
+            else SPATIAL_DIMS
+        )
+        _validate_required_coordinate_attrs(data, spatial_unit_coords, "units")
 
     if require_time_units and TIME_DIM in data.dims:
         _validate_required_coordinate_attrs(data, (TIME_DIM,), "units")

--- a/src/confusius/validation/fusi.py
+++ b/src/confusius/validation/fusi.py
@@ -90,16 +90,17 @@ def _validate_voxel_affine_geometry(da: xr.DataArray) -> None:
             f"{affine.shape}."
         )
 
-    for name in get_voxel_affine_physical_coord_names(da):
+    physical_coord_names = get_voxel_affine_physical_coord_names(da)
+    for name, dim in zip(physical_coord_names, voxel_dims, strict=True):
         if name not in da.coords:
             raise ValueError(
                 f"Voxel-affine data is missing physical coordinate {name!r}."
             )
         coord = da.coords[name]
-        if coord.dims != voxel_dims:
+        if coord.dims not in {voxel_dims, (dim,)}:
             raise ValueError(
-                f"Voxel-affine coordinate {name!r} must have dims {voxel_dims!r}, "
-                f"got {coord.dims!r}."
+                f"Voxel-affine coordinate {name!r} must have dims {voxel_dims!r} "
+                f"or {(dim,)!r}, got {coord.dims!r}."
             )
 
 

--- a/src/confusius/xarray/accessors.py
+++ b/src/confusius/xarray/accessors.py
@@ -170,15 +170,21 @@ class FUSIAccessor:
     def spacing(self) -> dict[str, float | None]:
         """Coordinate spacing for all dimensions.
 
-        Spacing is computed as the median of consecutive coordinate differences.
-        A coordinate is considered uniform if every interval is within 1% of the
-        median interval (per-interval `|diff - median| <= 0.01 * |median|`).
+        For regular axis-aligned data, spacing is computed as the median of
+        consecutive coordinate differences. A coordinate is considered uniform if every
+        interval is within 1% of the median interval (per-interval
+        `|diff - median| <= 0.01 * |median|`).
+
+        For voxel-affine data (`k/j/i` plus `attrs["voxel_to_physical"]`), spacing is
+        reported in DataArray dimension order, but each voxel-space dimension receives
+        its physical step length derived from the affine column norm and the 1D
+        voxel-coordinate step.
 
         Returns
         -------
         dict[str, float | None]
-            Spacing per dimension, in DataArray dimension order. Returns `None` for
-            dimensions with non-uniform or undefined spacing, with a warning.
+            Spacing per dimension. Returns `None` for dimensions with non-uniform or
+            undefined spacing, with a warning.
 
         Examples
         --------
@@ -194,20 +200,41 @@ class FUSIAccessor:
         {'y': 0.2, 'x': 0.1}
         """
         from confusius._utils.coordinates import get_coordinate_spacings
+        from confusius._utils.geometry import (
+            get_voxel_affine_spacing,
+            has_voxel_affine_geometry,
+        )
 
-        return get_coordinate_spacings(self._obj)
+        if not has_voxel_affine_geometry(self._obj):
+            return get_coordinate_spacings(self._obj)
+
+        voxel_spacing = get_voxel_affine_spacing(self._obj)
+        regular_spacing = get_coordinate_spacings(self._obj)
+        return {
+            dim_str: (
+                voxel_spacing[dim_str]
+                if dim_str in voxel_spacing
+                else regular_spacing[dim_str]
+            )
+            for dim_str in (str(dim) for dim in self._obj.dims)
+        }
 
     @property
     def origin(self) -> dict[str, float]:
-        """Physical origin (first coordinate value) for all dimensions.
+        """Physical origin metadata for the DataArray.
 
-        For each dimension, returns the first coordinate value. If a coordinate is
-        missing, warns and falls back to `0.0`.
+        For regular axis-aligned data, this returns the first coordinate value for each
+        dimension. If a coordinate is missing, warns and falls back to `0.0`.
+
+        For voxel-affine data, non-spatial dimensions still use their first coordinate
+        value, while spatial origin is returned in physical coordinate order as the
+        physical location of the first sampled voxel under the stored
+        `voxel_to_physical` affine.
 
         Returns
         -------
         dict[str, float]
-            Origin per dimension, in DataArray dimension order.
+            Origin metadata for the DataArray.
 
         Examples
         --------
@@ -223,8 +250,48 @@ class FUSIAccessor:
         {'y': 0.0, 'x': 0.0}
         """
         from confusius._utils.coordinates import get_coordinate_origins
+        from confusius._utils.geometry import (
+            get_voxel_affine_origin,
+            get_voxel_affine_spatial_dims,
+            has_voxel_affine_geometry,
+        )
 
-        return get_coordinate_origins(self._obj)
+        if not has_voxel_affine_geometry(self._obj):
+            return get_coordinate_origins(self._obj)
+
+        voxel_dims = set(get_voxel_affine_spatial_dims(self._obj))
+        regular_origin = get_coordinate_origins(self._obj)
+        return {
+            **{
+                dim_str: regular_origin[dim_str]
+                for dim_str in (str(dim) for dim in self._obj.dims)
+                if dim_str not in voxel_dims
+            },
+            **get_voxel_affine_origin(self._obj),
+        }
+
+    @property
+    def direction(self):
+        """Physical-space direction matrix for the present spatial geometry.
+
+        Returns
+        -------
+        numpy.ndarray
+            Identity for axis-aligned data. For voxel-affine data, the columns are the
+            unit physical-space directions of the voxel axes.
+        """
+        import numpy as np
+
+        from confusius._utils.geometry import (
+            get_voxel_affine_direction_matrix,
+            has_voxel_affine_geometry,
+        )
+
+        if has_voxel_affine_geometry(self._obj):
+            return get_voxel_affine_direction_matrix(self._obj)
+
+        ndim = len([dim for dim in self._obj.dims if dim in {"z", "y", "x"}])
+        return np.eye(ndim, dtype=np.float64)
 
     @property
     def affine(self) -> FUSIAffineAccessor:

--- a/tests/unit/test_io/test_loadsave.py
+++ b/tests/unit/test_io/test_loadsave.py
@@ -1,11 +1,12 @@
 """Unit tests for confusius.io.loadsave module."""
 
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
 import xarray as xr
 
+from confusius._utils.geometry import add_physical_coords_from_voxel_affine
 from confusius.io.loadsave import load, save
 
 
@@ -18,7 +19,7 @@ class TestLoadDispatch:
         mock_da = MagicMock(spec=xr.DataArray)
         with patch("confusius.io.nifti.load_nifti", return_value=mock_da) as mock:
             result = load(path)
-        mock.assert_called_once_with(path.resolve())
+        mock.assert_called_once_with(path.resolve(), coordinate_model="legacy")
         assert result is mock_da
 
     def test_compound_nii_gz_extension(self, tmp_path):
@@ -27,7 +28,7 @@ class TestLoadDispatch:
         mock_da = MagicMock(spec=xr.DataArray)
         with patch("confusius.io.nifti.load_nifti", return_value=mock_da) as mock:
             result = load(path)
-        mock.assert_called_once_with(path.resolve())
+        mock.assert_called_once_with(path.resolve(), coordinate_model="legacy")
         assert result is mock_da
 
     def test_nii_dispatches_to_load_nifti(self, tmp_path):
@@ -36,7 +37,7 @@ class TestLoadDispatch:
         mock_da = MagicMock(spec=xr.DataArray)
         with patch("confusius.io.nifti.load_nifti", return_value=mock_da) as mock:
             result = load(path)
-        mock.assert_called_once_with(path.resolve())
+        mock.assert_called_once_with(path.resolve(), coordinate_model="legacy")
         assert result is mock_da
 
     def test_scan_dispatches_to_load_scan(self, tmp_path):
@@ -45,7 +46,7 @@ class TestLoadDispatch:
         mock_da = MagicMock(spec=xr.DataArray)
         with patch("confusius.io.scan.load_scan", return_value=mock_da) as mock:
             result = load(path)
-        mock.assert_called_once_with(path.resolve())
+        mock.assert_called_once_with(path.resolve(), coordinate_model="legacy")
         assert result is mock_da
 
     def test_compound_scan_extension(self, tmp_path):
@@ -54,7 +55,7 @@ class TestLoadDispatch:
         mock_da = MagicMock(spec=xr.DataArray)
         with patch("confusius.io.scan.load_scan", return_value=mock_da) as mock:
             result = load(path)
-        mock.assert_called_once_with(path.resolve())
+        mock.assert_called_once_with(path.resolve(), coordinate_model="legacy")
         assert result is mock_da
 
     def test_kwargs_forwarded_to_loader(self, tmp_path):
@@ -63,7 +64,9 @@ class TestLoadDispatch:
         mock_da = MagicMock(spec=xr.DataArray)
         with patch("confusius.io.nifti.load_nifti", return_value=mock_da) as mock:
             load(path, chunks=None)
-        mock.assert_called_once_with(path.resolve(), chunks=None)
+        mock.assert_called_once_with(
+            path.resolve(), coordinate_model="legacy", chunks=None
+        )
 
     def test_unsupported_extension_raises(self, tmp_path):
         """Unsupported extension raises ValueError."""
@@ -103,7 +106,7 @@ class TestSaveDispatch:
         """.zarr extension calls DataArray.to_zarr."""
         path = tmp_path / "data.zarr"
         da = MagicMock(spec=xr.DataArray)
-        with patch("confusius.io.nifti.save_nifti") as mock:
+        with patch("confusius.io.nifti.save_nifti"):
             save(da, path)
         da.to_zarr.assert_called_once_with(path.resolve())
 
@@ -111,7 +114,7 @@ class TestSaveDispatch:
         """.source.zarr compound extension calls DataArray.to_zarr."""
         path = tmp_path / "data.source.zarr"
         da = MagicMock(spec=xr.DataArray)
-        with patch("confusius.io.nifti.save_nifti") as mock:
+        with patch("confusius.io.nifti.save_nifti"):
             save(da, path)
         da.to_zarr.assert_called_once_with(path.resolve())
 
@@ -165,3 +168,47 @@ class TestLoadZarr:
         result = load(multi_var_zarr, variable="iq")
         assert isinstance(result, xr.DataArray)
         assert result.name == "iq"
+
+    def test_zarr_voxel_affine_rebuilds_coordinate_transform_index(self, tmp_path):
+        """coordinate_model='voxel_affine' rebuilds CTI-backed physical coords."""
+        base = xr.DataArray(
+            np.arange(24, dtype=float).reshape(2, 3, 4),
+            dims=["k", "j", "i"],
+            coords={
+                "k": [0.0, 1.0],
+                "j": [0.0, 1.0, 2.0],
+                "i": [0.0, 1.0, 2.0, 3.0],
+            },
+            name="power",
+        )
+        voxel_affine = add_physical_coords_from_voxel_affine(
+            base,
+            np.array(
+                [
+                    [0.4, 0.0, 0.1, 10.0],
+                    [0.1, 0.3, 0.0, 20.0],
+                    [0.0, 0.05, 0.25, 30.0],
+                    [0.0, 0.0, 0.0, 1.0],
+                ]
+            ),
+            voxel_dims=("k", "j", "i"),
+            physical_coord_names=("z", "y", "x"),
+            physical_coord_attrs={
+                "z": {"units": "mm"},
+                "y": {"units": "mm"},
+                "x": {"units": "mm"},
+            },
+        )
+        path = tmp_path / "voxel_affine.zarr"
+        voxel_affine.to_dataset().to_zarr(path, zarr_format=2)
+
+        loaded = load(path, variable="power", coordinate_model="voxel_affine")
+
+        assert loaded.dims == ("k", "j", "i")
+        assert loaded.coords["x"].dims == ("k", "j", "i")
+        assert loaded.coords["y"].dims == ("k", "j", "i")
+        assert loaded.coords["z"].dims == ("k", "j", "i")
+        assert type(loaded.xindexes["x"]).__name__ == "CoordinateTransformIndex"
+        np.testing.assert_allclose(
+            loaded.attrs["voxel_to_physical"], voxel_affine.attrs["voxel_to_physical"]
+        )

--- a/tests/unit/test_io/test_nifti.py
+++ b/tests/unit/test_io/test_nifti.py
@@ -115,6 +115,54 @@ class TestLoadNifti:
         assert da.shape == (6, 5, 4, 3, 2)
         np.testing.assert_array_equal(da.values, data.transpose(4, 3, 2, 1, 0))
 
+    def test_load_3d_nifti_voxel_affine_model(
+        self, nifti_3d_path: tuple[Path, np.ndarray]
+    ) -> None:
+        """Voxel-affine loading exposes voxel dims plus lazy physical coords."""
+        nifti_path, expected_data = nifti_3d_path
+        da = load_nifti(nifti_path, coordinate_model="voxel_affine")
+
+        assert da.dims == ("k", "j", "i")
+        assert da.shape == (6, 8, 10)
+        assert da.coords["k"].dims == ("k",)
+        assert da.coords["j"].dims == ("j",)
+        assert da.coords["i"].dims == ("i",)
+        assert da.coords["z"].dims == ("k", "j", "i")
+        assert da.coords["y"].dims == ("k", "j", "i")
+        assert da.coords["x"].dims == ("k", "j", "i")
+        assert da.attrs["voxel_to_physical"].shape == (4, 4)
+        np.testing.assert_array_equal(da.values, expected_data.transpose(2, 1, 0))
+        np.testing.assert_array_equal(da.coords["z"].values[:, 0, 0], np.arange(6))
+        np.testing.assert_array_equal(da.coords["y"].values[0, :, 0], np.arange(8))
+        np.testing.assert_array_equal(da.coords["x"].values[0, 0, :], np.arange(10))
+
+    def test_load_nifti_voxel_affine_model_uses_full_primary_affine(
+        self, tmp_path: Path
+    ) -> None:
+        """Voxel-affine loading keeps the full voxel-to-world geometry in coords."""
+        data = np.random.default_rng(0).random((5, 4, 3)).astype(np.float32)
+        affine = np.array(
+            [
+                [0.0, -3.0, 0.0, 10.0],
+                [2.0, 0.0, 0.0, 20.0],
+                [0.0, 0.0, 4.0, 30.0],
+                [0.0, 0.0, 0.0, 1.0],
+            ]
+        )
+        nifti_path = tmp_path / "rotated_voxel_affine.nii.gz"
+        nib.Nifti1Image(data, affine).to_filename(nifti_path)
+
+        da = load_nifti(nifti_path, coordinate_model="voxel_affine")
+
+        expected_xyz = affine @ np.array([2.0, 1.0, 0.0, 1.0])
+        assert da.dims == ("k", "j", "i")
+        assert da.attrs["voxel_to_physical"].shape == (4, 4)
+        assert da.attrs["affines"]["physical_to_sform"].shape == (4, 4)
+        assert np.allclose(da.attrs["affines"]["physical_to_sform"], np.eye(4))
+        assert da.coords["z"].values[0, 1, 2] == pytest.approx(expected_xyz[2])
+        assert da.coords["y"].values[0, 1, 2] == pytest.approx(expected_xyz[1])
+        assert da.coords["x"].values[0, 1, 2] == pytest.approx(expected_xyz[0])
+
     def test_load_nifti_units_from_header(self, tmp_path: Path) -> None:
         """Units on coordinate attrs come from the NIfTI header, not hardcoded."""
         data = np.random.default_rng(0).random((4, 3, 2)).astype(np.float32)

--- a/tests/unit/test_io/test_nifti.py
+++ b/tests/unit/test_io/test_nifti.py
@@ -118,7 +118,7 @@ class TestLoadNifti:
     def test_load_3d_nifti_voxel_affine_model(
         self, nifti_3d_path: tuple[Path, np.ndarray]
     ) -> None:
-        """Voxel-affine loading exposes voxel dims plus lazy physical coords."""
+        """Axis-aligned voxel-affine loading exposes voxel dims plus 1D physical coords."""
         nifti_path, expected_data = nifti_3d_path
         da = load_nifti(nifti_path, coordinate_model="voxel_affine")
 
@@ -127,14 +127,14 @@ class TestLoadNifti:
         assert da.coords["k"].dims == ("k",)
         assert da.coords["j"].dims == ("j",)
         assert da.coords["i"].dims == ("i",)
-        assert da.coords["z"].dims == ("k", "j", "i")
-        assert da.coords["y"].dims == ("k", "j", "i")
-        assert da.coords["x"].dims == ("k", "j", "i")
+        assert da.coords["z"].dims == ("k",)
+        assert da.coords["y"].dims == ("j",)
+        assert da.coords["x"].dims == ("i",)
         assert da.attrs["voxel_to_physical"].shape == (4, 4)
         np.testing.assert_array_equal(da.values, expected_data.transpose(2, 1, 0))
-        np.testing.assert_array_equal(da.coords["z"].values[:, 0, 0], np.arange(6))
-        np.testing.assert_array_equal(da.coords["y"].values[0, :, 0], np.arange(8))
-        np.testing.assert_array_equal(da.coords["x"].values[0, 0, :], np.arange(10))
+        np.testing.assert_array_equal(da.coords["z"].values, np.arange(6))
+        np.testing.assert_array_equal(da.coords["y"].values, np.arange(8))
+        np.testing.assert_array_equal(da.coords["x"].values, np.arange(10))
 
     def test_load_nifti_voxel_affine_model_uses_full_primary_affine(
         self, tmp_path: Path

--- a/tests/unit/test_io/test_scan.py
+++ b/tests/unit/test_io/test_scan.py
@@ -137,6 +137,52 @@ class TestLoadScan2D:
         """2Dscan produces DataArray with dims (time, z, y, x)."""
         assert scan_2d.dims == ("time", "z", "y", "x")
 
+    def test_voxel_affine_model_uses_voxel_dims_and_lazy_physical_coords(
+        self, scan_2d_path: Path
+    ) -> None:
+        """Voxel-affine loading exposes `k/j/i` plus derived physical coords."""
+        da = load_scan(scan_2d_path, coordinate_model="voxel_affine")
+
+        assert da.dims == ("time", "k", "j", "i")
+        assert da.shape == (_T, _SIZE_Y, _SIZE_Z, _SIZE_X)
+        assert da.coords["k"].dims == ("k",)
+        assert da.coords["j"].dims == ("j",)
+        assert da.coords["i"].dims == ("i",)
+        assert da.coords["z"].dims == ("k", "j", "i")
+        assert da.coords["y"].dims == ("k", "j", "i")
+        assert da.coords["x"].dims == ("k", "j", "i")
+        assert da.attrs["voxel_to_physical"].shape == (4, 4)
+        np.testing.assert_allclose(
+            da.coords["x"].values[0, 0, :],
+            1e3
+            * (
+                _VOXELS_TO_PROBE[0, 0] * (np.arange(_SIZE_X) + 1)
+                + _VOXELS_TO_PROBE[0, 3]
+            ),
+            rtol=1e-10,
+        )
+        np.testing.assert_allclose(
+            da.coords["y"].values[0, :, 0],
+            1e3
+            * (
+                -(
+                    _VOXELS_TO_PROBE[2, 2] * (np.arange(_SIZE_Z) + 1)
+                    + _VOXELS_TO_PROBE[2, 3]
+                )
+            ),
+            rtol=1e-10,
+        )
+        np.testing.assert_allclose(
+            da.coords["z"].values[:, 0, 0],
+            1e3
+            * (
+                _VOXELS_TO_PROBE[1, 1] * (np.arange(_SIZE_Y) + 1)
+                + _VOXELS_TO_PROBE[1, 3]
+            ),
+            rtol=1e-10,
+        )
+        assert da.attrs["affines"]["physical_to_lab"].shape == (4, 4)
+
     def test_shape(self, scan_2d: xr.DataArray) -> None:
         """2Dscan shape matches (T, sizeY, sizeZ, sizeX)."""
         assert scan_2d.shape == (_T, _SIZE_Y, _SIZE_Z, _SIZE_X)
@@ -608,7 +654,9 @@ class TestLoadScanWithBPS:
         brain_to_confusius_lab = cls._expected_brain_to_confusius_lab(brain_to_lab)
         return np.linalg.inv(brain_to_confusius_lab) @ physical_to_lab
 
-    def test_load_bps_reexpresses_lab_side(self, bps_path: Path, brain_to_lab: np.ndarray) -> None:
+    def test_load_bps_reexpresses_lab_side(
+        self, bps_path: Path, brain_to_lab: np.ndarray
+    ) -> None:
         """load_bps converts BrainToLab to ConfUSIus-ordered lab coordinates."""
         expected = self._expected_brain_to_confusius_lab(brain_to_lab)
         result = load_bps(bps_path)

--- a/tests/unit/test_io/test_scan.py
+++ b/tests/unit/test_io/test_scan.py
@@ -137,10 +137,10 @@ class TestLoadScan2D:
         """2Dscan produces DataArray with dims (time, z, y, x)."""
         assert scan_2d.dims == ("time", "z", "y", "x")
 
-    def test_voxel_affine_model_uses_voxel_dims_and_lazy_physical_coords(
+    def test_voxel_affine_model_uses_voxel_dims_and_1d_physical_coords(
         self, scan_2d_path: Path
     ) -> None:
-        """Voxel-affine loading exposes `k/j/i` plus derived physical coords."""
+        """Axis-aligned voxel-affine loading exposes `k/j/i` plus 1D physical coords."""
         da = load_scan(scan_2d_path, coordinate_model="voxel_affine")
 
         assert da.dims == ("time", "k", "j", "i")
@@ -148,12 +148,12 @@ class TestLoadScan2D:
         assert da.coords["k"].dims == ("k",)
         assert da.coords["j"].dims == ("j",)
         assert da.coords["i"].dims == ("i",)
-        assert da.coords["z"].dims == ("k", "j", "i")
-        assert da.coords["y"].dims == ("k", "j", "i")
-        assert da.coords["x"].dims == ("k", "j", "i")
+        assert da.coords["z"].dims == ("k",)
+        assert da.coords["y"].dims == ("j",)
+        assert da.coords["x"].dims == ("i",)
         assert da.attrs["voxel_to_physical"].shape == (4, 4)
         np.testing.assert_allclose(
-            da.coords["x"].values[0, 0, :],
+            da.coords["x"].values,
             1e3
             * (
                 _VOXELS_TO_PROBE[0, 0] * (np.arange(_SIZE_X) + 1)
@@ -162,7 +162,7 @@ class TestLoadScan2D:
             rtol=1e-10,
         )
         np.testing.assert_allclose(
-            da.coords["y"].values[0, :, 0],
+            da.coords["y"].values,
             1e3
             * (
                 -(
@@ -173,7 +173,7 @@ class TestLoadScan2D:
             rtol=1e-10,
         )
         np.testing.assert_allclose(
-            da.coords["z"].values[:, 0, 0],
+            da.coords["z"].values,
             1e3
             * (
                 _VOXELS_TO_PROBE[1, 1] * (np.arange(_SIZE_Y) + 1)

--- a/tests/unit/test_plotting/test_image.py
+++ b/tests/unit/test_plotting/test_image.py
@@ -8,12 +8,45 @@ import numpy as np
 import pytest
 import xarray as xr
 
+from confusius._utils.geometry import add_physical_coords_from_voxel_affine
 from confusius.plotting import (
     VolumePlotter,
     plot_carpet,
     plot_contours,
     plot_volume,
 )
+
+
+def _make_voxel_affine_volume() -> xr.DataArray:
+    """Create a small voxel-affine test volume with an oblique slice geometry."""
+    data = xr.DataArray(
+        np.arange(2 * 3 * 4, dtype=float).reshape(2, 3, 4),
+        dims=["k", "j", "i"],
+        coords={
+            "k": [0.0, 1.0],
+            "j": [0.0, 1.0, 2.0],
+            "i": [0.0, 1.0, 2.0, 3.0],
+        },
+    )
+    voxel_to_physical = np.array(
+        [
+            [0.4, 0.0, 0.1, 10.0],
+            [0.1, 0.3, 0.0, 20.0],
+            [0.0, 0.05, 0.25, 30.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ]
+    )
+    return add_physical_coords_from_voxel_affine(
+        data,
+        voxel_to_physical,
+        voxel_dims=("k", "j", "i"),
+        physical_coord_names=("z", "y", "x"),
+        physical_coord_attrs={
+            "z": {"units": "mm"},
+            "y": {"units": "mm"},
+            "x": {"units": "mm"},
+        },
+    )
 
 
 class TestPlotVolume:
@@ -385,6 +418,42 @@ class TestPlotVolume:
         assert ax.get_ylim() == pytest.approx(
             (y_sorted[-1] + dy / 2, y_sorted[0] - dy / 2)
         )
+
+    def test_voxel_affine_slice_geometry_returns_2d_meshes(self):
+        """Voxel-affine slice geometry is projected to 2D corner meshes."""
+        from confusius.plotting.image import _slice_edges_and_centers
+
+        data = _make_voxel_affine_volume().isel(k=0)
+        x_edges, y_edges, x_centers, y_centers = _slice_edges_and_centers(
+            data, "j", "i"
+        )
+
+        assert x_edges.shape == (data.sizes["j"] + 1, data.sizes["i"] + 1)
+        assert y_edges.shape == (data.sizes["j"] + 1, data.sizes["i"] + 1)
+        assert x_centers.shape == (data.sizes["j"], data.sizes["i"])
+        assert y_centers.shape == (data.sizes["j"], data.sizes["i"])
+
+    def test_voxel_affine_volume_uses_projected_plane_coordinates(
+        self, matplotlib_pyplot
+    ):
+        """Voxel-affine volumes plot native planes in projected in-plane coords."""
+        data = _make_voxel_affine_volume()
+        plotter = plot_volume(
+            data,
+            slice_mode="k",
+            slice_coords=[0.0],
+            show_colorbar=False,
+        )
+
+        ax = plotter.axes[0, 0]
+        quadmesh = ax.collections[0]
+        assert quadmesh.get_coordinates().shape == (
+            data.sizes["j"] + 1,
+            data.sizes["i"] + 1,
+            2,
+        )
+        assert ax.get_xlabel() == "i in-plane (mm)"
+        assert ax.get_ylabel() == "j in-plane (mm)"
 
 
 class TestCentersToEdges:

--- a/tests/unit/test_plotting/test_image.py
+++ b/tests/unit/test_plotting/test_image.py
@@ -455,6 +455,13 @@ class TestPlotVolume:
         assert ax.get_xlabel() == "i in-plane (mm)"
         assert ax.get_ylabel() == "j in-plane (mm)"
 
+    def test_voxel_affine_volume_rejects_physical_slice_mode(self, matplotlib_pyplot):
+        """Voxel-affine plotting accepts only native voxel-space slice modes."""
+        data = _make_voxel_affine_volume()
+
+        with pytest.raises(ValueError, match="native voxel-plane slicing"):
+            plot_volume(data, slice_mode="z", slice_coords=[0.0], show_colorbar=False)
+
 
 class TestCentersToEdges:
     """Tests for _centers_to_edges helper function."""

--- a/tests/unit/test_utils/test_geometry.py
+++ b/tests/unit/test_utils/test_geometry.py
@@ -1,0 +1,148 @@
+"""Tests for voxel-space geometry helpers."""
+
+import numpy as np
+import xarray as xr
+from numpy.testing import assert_allclose, assert_array_equal
+
+from confusius._utils.geometry import (
+    add_physical_coords_from_voxel_affine,
+    get_affine_axis_scalings,
+    get_affine_axis_vectors,
+    get_affine_orientation_matrix,
+    get_affine_origin,
+    get_physical_spacings,
+)
+
+
+def test_add_physical_coords_from_voxel_affine_uses_irregular_voxel_coords() -> None:
+    """Physical coords follow voxel-space lookup arrays, not dense positions."""
+    data = xr.DataArray(
+        np.arange(24).reshape(2, 3, 4),
+        dims=("k", "j", "i"),
+        coords={
+            "k": [0.0, 2.0],
+            "j": [0.0, 1.0, 3.0],
+            "i": [0.0, 2.0, 3.0, 7.0],
+        },
+    )
+    voxel_to_physical = np.array(
+        [
+            [10.0, 0.0, 0.0, 100.0],
+            [0.0, 2.0, 0.0, 200.0],
+            [0.0, 0.0, 3.0, 300.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ]
+    )
+
+    result = add_physical_coords_from_voxel_affine(
+        data,
+        voxel_to_physical,
+        voxel_dims=("k", "j", "i"),
+        physical_coord_names=("z", "y", "x"),
+    )
+
+    assert result.coords["z"].dims == ("k", "j", "i")
+    assert result.coords["y"].dims == ("k", "j", "i")
+    assert result.coords["x"].dims == ("k", "j", "i")
+    assert_array_equal(result.coords["z"].values[:, 0, 0], [100.0, 120.0])
+    assert_array_equal(result.coords["y"].values[0, :, 0], [200.0, 202.0, 206.0])
+    assert_array_equal(result.coords["x"].values[0, 0, :], [300.0, 306.0, 309.0, 321.0])
+
+
+def test_coordinate_transform_index_selection_uses_physical_coords() -> None:
+    """Nearest selection in physical space returns the correct dense voxel."""
+    data = xr.DataArray(
+        np.arange(24).reshape(2, 3, 4),
+        dims=("k", "j", "i"),
+        coords={
+            "k": [0.0, 2.0],
+            "j": [0.0, 1.0, 3.0],
+            "i": [0.0, 2.0, 3.0, 7.0],
+        },
+    )
+    voxel_to_physical = np.array(
+        [
+            [1.0, 0.0, 0.0, 10.0],
+            [0.0, 2.0, 0.0, 20.0],
+            [0.0, 0.0, 3.0, 30.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ]
+    )
+    result = add_physical_coords_from_voxel_affine(
+        data,
+        voxel_to_physical,
+        voxel_dims=("k", "j", "i"),
+        physical_coord_names=("z", "y", "x"),
+    )
+
+    selected = result.sel(
+        z=xr.Variable("point", [12.1]),
+        y=xr.Variable("point", [26.2]),
+        x=xr.Variable("point", [39.4]),
+        method="nearest",
+    )
+
+    assert selected.item() == data.sel(k=2.0, j=3.0, i=3.0).item()
+    assert_allclose(selected.coords["z"].values, [12.0])
+    assert_allclose(selected.coords["y"].values, [26.0])
+    assert_allclose(selected.coords["x"].values, [39.0])
+
+
+def test_affine_geometry_helpers_extract_origin_vectors_scalings_and_orientation() -> (
+    None
+):
+    """Affine geometry helpers expose the linear part in physical-space form."""
+    voxel_to_physical = np.array(
+        [
+            [2.0, 1.0, 0.0, 10.0],
+            [0.0, 3.0, 0.0, 20.0],
+            [0.0, 0.0, 4.0, 30.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ]
+    )
+
+    assert_allclose(get_affine_origin(voxel_to_physical), [10.0, 20.0, 30.0])
+    assert_allclose(
+        get_affine_axis_vectors(voxel_to_physical, ("k", "j", "i"))["k"],
+        [2.0, 0.0, 0.0],
+    )
+    assert_allclose(
+        get_affine_axis_vectors(voxel_to_physical, ("k", "j", "i"))["j"],
+        [1.0, 3.0, 0.0],
+    )
+    scalings = get_affine_axis_scalings(voxel_to_physical, ("k", "j", "i"))
+    assert scalings.keys() == {"k", "j", "i"}
+    assert_allclose(scalings["k"], 2.0)
+    assert_allclose(scalings["j"], np.sqrt(10.0))
+    assert_allclose(scalings["i"], 4.0)
+    expected_orientation = np.array(
+        [
+            [1.0, 1.0 / np.sqrt(10.0), 0.0],
+            [0.0, 3.0 / np.sqrt(10.0), 0.0],
+            [0.0, 0.0, 1.0],
+        ]
+    )
+    assert_allclose(
+        get_affine_orientation_matrix(voxel_to_physical), expected_orientation
+    )
+
+
+def test_get_physical_spacings_returns_none_for_irregular_voxel_axes() -> None:
+    """Physical spacing is undefined when voxel-space sampling is irregular."""
+    voxel_coords = {
+        "k": [0.0, 1.0, 2.0],
+        "j": [0.0, 2.0, 4.0],
+        "i": [0.0, 1.0, 3.0, 4.0],
+    }
+    voxel_to_physical = np.array(
+        [
+            [2.0, 0.0, 0.0, 0.0],
+            [0.0, 3.0, 0.0, 0.0],
+            [0.0, 0.0, 5.0, 0.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ]
+    )
+
+    spacing = get_physical_spacings(voxel_coords, voxel_to_physical)
+
+    assert spacing == {"k": 2.0, "j": 6.0, "i": None}

--- a/tests/unit/test_utils/test_geometry.py
+++ b/tests/unit/test_utils/test_geometry.py
@@ -15,8 +15,8 @@ from confusius._utils.geometry import (
 )
 
 
-def test_add_physical_coords_from_voxel_affine_uses_irregular_voxel_coords() -> None:
-    """Physical coords follow voxel-space lookup arrays, not dense positions."""
+def test_axis_aligned_voxel_affine_uses_1d_physical_coords() -> None:
+    """Axis-aligned voxel-affine geometry exposes 1D physical coords and indexes."""
     data = xr.DataArray(
         np.arange(24).reshape(2, 3, 4),
         dims=("k", "j", "i"),
@@ -42,16 +42,18 @@ def test_add_physical_coords_from_voxel_affine_uses_irregular_voxel_coords() -> 
         physical_coord_names=("z", "y", "x"),
     )
 
-    assert result.coords["z"].dims == ("k", "j", "i")
-    assert result.coords["y"].dims == ("k", "j", "i")
-    assert result.coords["x"].dims == ("k", "j", "i")
-    assert_array_equal(result.coords["z"].values[:, 0, 0], [100.0, 120.0])
-    assert_array_equal(result.coords["y"].values[0, :, 0], [200.0, 202.0, 206.0])
-    assert_array_equal(result.coords["x"].values[0, 0, :], [300.0, 306.0, 309.0, 321.0])
+    assert result.coords["z"].dims == ("k",)
+    assert result.coords["y"].dims == ("j",)
+    assert result.coords["x"].dims == ("i",)
+    assert_array_equal(result.coords["z"].values, [100.0, 120.0])
+    assert_array_equal(result.coords["y"].values, [200.0, 202.0, 206.0])
+    assert_array_equal(result.coords["x"].values, [300.0, 306.0, 309.0, 321.0])
+    assert type(result.xindexes["x"]).__name__ == "PandasIndex"
 
 
-def test_coordinate_transform_index_selection_uses_physical_coords() -> None:
-    """Nearest selection in physical space returns the correct dense voxel."""
+
+def test_axis_aligned_voxel_affine_sel_supports_scalars_and_slices() -> None:
+    """Axis-aligned voxel-affine geometry supports ordinary `.sel(...)` queries."""
     data = xr.DataArray(
         np.arange(24).reshape(2, 3, 4),
         dims=("k", "j", "i"),
@@ -76,6 +78,43 @@ def test_coordinate_transform_index_selection_uses_physical_coords() -> None:
         physical_coord_names=("z", "y", "x"),
     )
 
+    selected = result.sel(z=12.1, y=26.2, x=39.4, method="nearest")
+    sliced = result.sel(z=slice(10.0, 12.0), y=slice(20.0, 22.0))
+
+    assert selected.item() == data.sel(k=2.0, j=3.0, i=3.0).item()
+    assert float(selected.coords["z"]) == 12.0
+    assert float(selected.coords["y"]) == 26.0
+    assert float(selected.coords["x"]) == 39.0
+    assert sliced.sizes == {"k": 2, "j": 2, "i": 4}
+
+
+
+def test_oblique_coordinate_transform_index_selection_uses_physical_coords() -> None:
+    """Oblique voxel-affine geometry still uses CTI pointwise physical selection."""
+    data = xr.DataArray(
+        np.arange(24).reshape(2, 3, 4),
+        dims=("k", "j", "i"),
+        coords={
+            "k": [0.0, 2.0],
+            "j": [0.0, 1.0, 3.0],
+            "i": [0.0, 2.0, 3.0, 7.0],
+        },
+    )
+    voxel_to_physical = np.array(
+        [
+            [1.0, 0.1, 0.0, 10.0],
+            [0.0, 2.0, 0.0, 20.0],
+            [0.0, 0.0, 3.0, 30.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ]
+    )
+    result = add_physical_coords_from_voxel_affine(
+        data,
+        voxel_to_physical,
+        voxel_dims=("k", "j", "i"),
+        physical_coord_names=("z", "y", "x"),
+    )
+
     selected = result.sel(
         z=xr.Variable("point", [12.1]),
         y=xr.Variable("point", [26.2]),
@@ -83,10 +122,9 @@ def test_coordinate_transform_index_selection_uses_physical_coords() -> None:
         method="nearest",
     )
 
+    assert type(result.xindexes["x"]).__name__ == "CoordinateTransformIndex"
+    assert result.coords["x"].dims == ("k", "j", "i")
     assert selected.item() == data.sel(k=2.0, j=3.0, i=3.0).item()
-    assert_allclose(selected.coords["z"].values, [12.0])
-    assert_allclose(selected.coords["y"].values, [26.0])
-    assert_allclose(selected.coords["x"].values, [39.0])
 
 
 def test_affine_geometry_helpers_extract_origin_vectors_scalings_and_orientation() -> (

--- a/tests/unit/test_utils/test_geometry.py
+++ b/tests/unit/test_utils/test_geometry.py
@@ -11,6 +11,7 @@ from confusius._utils.geometry import (
     get_affine_orientation_matrix,
     get_affine_origin,
     get_physical_spacings,
+    get_voxel_affine_origin,
 )
 
 
@@ -146,3 +147,28 @@ def test_get_physical_spacings_returns_none_for_irregular_voxel_axes() -> None:
     spacing = get_physical_spacings(voxel_coords, voxel_to_physical)
 
     assert spacing == {"k": 2.0, "j": 6.0, "i": None}
+
+
+def test_get_voxel_affine_origin_uses_first_sampled_voxel() -> None:
+    """Voxel-affine origin is the physical location of array index zero."""
+    data = xr.DataArray(
+        np.zeros((2, 3, 4)),
+        dims=("k", "j", "i"),
+        coords={
+            "k": [10.0, 11.0],
+            "j": [5.0, 7.0, 9.0],
+            "i": [100.0, 101.0, 102.0, 103.0],
+        },
+        attrs={
+            "voxel_to_physical": np.array(
+                [
+                    [2.0, 0.0, 0.0, 10.0],
+                    [0.0, 3.0, 0.0, 20.0],
+                    [0.0, 0.0, 4.0, 30.0],
+                    [0.0, 0.0, 0.0, 1.0],
+                ]
+            )
+        },
+    )
+
+    assert get_voxel_affine_origin(data) == {"z": 30.0, "y": 35.0, "x": 430.0}

--- a/tests/unit/test_validation/test_fusi.py
+++ b/tests/unit/test_validation/test_fusi.py
@@ -4,7 +4,39 @@ import numpy as np
 import pytest
 import xarray as xr
 
+from confusius._utils.geometry import add_physical_coords_from_voxel_affine
 from confusius.validation import validate_fusi_dataarray
+
+
+def _make_voxel_affine_volume() -> xr.DataArray:
+    """Create a small voxel-affine volume for validation tests."""
+    base = xr.DataArray(
+        np.zeros((2, 3, 4), dtype=np.float32),
+        dims=("k", "j", "i"),
+        coords={
+            "k": [0.0, 1.0],
+            "j": [0.0, 2.0, 4.0],
+            "i": [0.0, 1.0, 2.0, 3.0],
+        },
+    )
+    return add_physical_coords_from_voxel_affine(
+        base,
+        np.array(
+            [
+                [2.0, 0.0, 0.0, 10.0],
+                [0.0, 3.0, 0.0, 20.0],
+                [0.0, 0.0, 4.0, 30.0],
+                [0.0, 0.0, 0.0, 1.0],
+            ]
+        ),
+        voxel_dims=("k", "j", "i"),
+        physical_coord_names=("z", "y", "x"),
+        physical_coord_attrs={
+            "z": {"units": "mm"},
+            "y": {"units": "mm"},
+            "x": {"units": "mm"},
+        },
+    )
 
 
 def test_validate_fusi_dataarray_accepts_valid_3d(
@@ -33,6 +65,35 @@ def test_validate_fusi_dataarray_rejects_non_dataarray() -> None:
     """Non-DataArray inputs raise `TypeError`."""
     with pytest.raises(TypeError, match="xarray.DataArray"):
         validate_fusi_dataarray(np.zeros((2, 2)))  # type: ignore
+
+
+def test_validate_fusi_dataarray_accepts_voxel_affine_geometry() -> None:
+    """Voxel-affine spatial geometry is accepted as valid ConfUSIus data."""
+    validate_fusi_dataarray(_make_voxel_affine_volume())
+
+
+def test_validate_fusi_dataarray_accepts_voxel_affine_with_regular_spacing() -> None:
+    """Regular-spacing checks operate on voxel-space dimensions for CTI geometry."""
+    validate_fusi_dataarray(
+        _make_voxel_affine_volume(),
+        require_regular_spacing=True,
+        regular_spacing_dims="space",
+        allow_extra_dims=False,
+    )
+
+
+def test_validate_fusi_dataarray_rejects_voxel_affine_missing_physical_coord() -> None:
+    """Voxel-affine validation requires CTI-derived physical coordinates."""
+    good = _make_voxel_affine_volume()
+    bad = xr.DataArray(
+        good.values,
+        dims=good.dims,
+        coords={dim: good.coords[dim] for dim in ("k", "j", "i")},
+        attrs={"voxel_to_physical": good.attrs["voxel_to_physical"]},
+    )
+
+    with pytest.raises(ValueError, match="missing physical coordinate 'z'"):
+        validate_fusi_dataarray(bad)
 
 
 def test_validate_fusi_dataarray_allows_extra_dims_by_default(

--- a/tests/unit/test_xarray/test_accessors.py
+++ b/tests/unit/test_xarray/test_accessors.py
@@ -7,6 +7,38 @@ import pytest
 import xarray as xr
 
 import confusius  # noqa: F401  # Import to register accessor.
+from confusius._utils.geometry import add_physical_coords_from_voxel_affine
+
+
+def _make_voxel_affine_volume() -> xr.DataArray:
+    """Create a small voxel-affine volume for accessor tests."""
+    base = xr.DataArray(
+        np.zeros((2, 3, 4)),
+        dims=["k", "j", "i"],
+        coords={
+            "k": [0.0, 1.0],
+            "j": [0.0, 2.0, 4.0],
+            "i": [0.0, 1.0, 2.0, 3.0],
+        },
+    )
+    return add_physical_coords_from_voxel_affine(
+        base,
+        np.array(
+            [
+                [2.0, 1.0, 0.0, 10.0],
+                [0.0, 3.0, 0.0, 20.0],
+                [0.0, 0.0, 4.0, 30.0],
+                [0.0, 0.0, 0.0, 1.0],
+            ]
+        ),
+        voxel_dims=("k", "j", "i"),
+        physical_coord_names=("z", "y", "x"),
+        physical_coord_attrs={
+            "z": {"units": "mm"},
+            "y": {"units": "mm"},
+            "x": {"units": "mm"},
+        },
+    )
 
 
 class TestFUSIAccessor:
@@ -209,6 +241,48 @@ class TestOrigin:
         )
         assert data.fusi.origin["z"] == pytest.approx(3.5)
 
+    def test_voxel_affine_origin_uses_first_sampled_voxel(self):
+        """Voxel-affine origin is the physical location of array index zero."""
+        data = _make_voxel_affine_volume().expand_dims(time=[0.0, 0.5])
+
+        assert data.fusi.origin == {
+            "time": pytest.approx(0.0),
+            "z": pytest.approx(10.0),
+            "y": pytest.approx(20.0),
+            "x": pytest.approx(30.0),
+        }
+
+    def test_voxel_affine_origin_respects_nonzero_voxel_coords(self):
+        """Voxel-affine origin uses the first sampled voxel coords, not affine translation."""
+        base = xr.DataArray(
+            np.zeros((2, 3, 4)),
+            dims=["k", "j", "i"],
+            coords={
+                "k": [10.0, 11.0],
+                "j": [5.0, 7.0, 9.0],
+                "i": [100.0, 101.0, 102.0, 103.0],
+            },
+        )
+        data = add_physical_coords_from_voxel_affine(
+            base,
+            np.array(
+                [
+                    [2.0, 0.0, 0.0, 10.0],
+                    [0.0, 3.0, 0.0, 20.0],
+                    [0.0, 0.0, 4.0, 30.0],
+                    [0.0, 0.0, 0.0, 1.0],
+                ]
+            ),
+            voxel_dims=("k", "j", "i"),
+            physical_coord_names=("z", "y", "x"),
+        )
+
+        assert data.fusi.origin == {
+            "z": pytest.approx(30.0),
+            "y": pytest.approx(35.0),
+            "x": pytest.approx(430.0),
+        }
+
     """Tests for fusi.spacing."""
 
     @pytest.fixture
@@ -283,6 +357,32 @@ class TestOrigin:
             },
         )
         assert list(data.fusi.spacing.keys()) == ["z", "y", "x"]
+
+    def test_voxel_affine_spacing_uses_physical_step_lengths(self):
+        """Voxel-affine spacing comes from voxel steps and affine column norms."""
+        data = _make_voxel_affine_volume().expand_dims(time=[0.0, 0.5])
+
+        assert data.fusi.spacing == {
+            "time": pytest.approx(0.5),
+            "k": pytest.approx(2.0),
+            "j": pytest.approx(2.0 * np.sqrt(10.0)),
+            "i": pytest.approx(4.0),
+        }
+
+    def test_voxel_affine_direction_returns_orientation_matrix(self):
+        """Voxel-affine direction is the normalized affine linear part."""
+        data = _make_voxel_affine_volume()
+
+        np.testing.assert_allclose(
+            data.fusi.direction,
+            np.array(
+                [
+                    [1.0, 1.0 / np.sqrt(10.0), 0.0],
+                    [0.0, 3.0 / np.sqrt(10.0), 0.0],
+                    [0.0, 0.0, 1.0],
+                ]
+            ),
+        )
 
 
 class TestAffineToMethod:


### PR DESCRIPTION
## Summary

This draft PR opens discussion around a `CoordinateTransformIndex`-backed
geometry model for ConfUSIus.

Current prototype features:

- `coordinate_model="voxel_affine"` for `cf.load`, `load_nifti`, and `load_scan`.
- Canonical `attrs["voxel_to_physical"]` affine.
- Lazy CTI-derived physical coordinates from voxel-space coords.
- Exact matplotlib plotting of native voxel planes for CTI-backed data.
- Small iPython demo script for manual exploration.

## Motivation

The goal is to explore whether CTI can improve on the current split between:

- axis-aligned physical coordinates in `z/y/x`, and
- residual orientation/shear stored in `attrs["affines"]`.

A voxel-affine model may let us preserve the full geometry more naturally,
while also supporting irregular voxel-space sampling.

## Important caveats

- This is intentionally experimental / discussion-oriented.
- CTI itself is still experimental in xarray.
- This PR does **not** implement physical-plane slicing yet.
  Current CTI-backed plotting only supports native voxel-plane slicing along
  `k/j/i`.
- Hover sampling for oblique projected matplotlib slices is currently disabled.
- Napari integration is not addressed yet.

## Suggested review focus

- Does the voxel-space + `voxel_to_physical` model make sense for ConfUSIus?
- Is `coordinate_model="voxel_affine"` a reasonable migration path?
- Which downstream subsystems should be adapted next if we continue?

Closes #198
