### PR TITLE
feat: add `smoothing_fwhm` to `FirstLevelModel` for spatial smoothing.

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,10 @@ Current development version for the next ConfUSIus release.
   the residual orientation as a 4x4 affine (the identity for diagonal affines)
   for the caller to use as they wish
   ([#188](https://github.com/confusius-tools/confusius/pull/188)).
+- Add `smoothing_fwhm` parameter to [`FirstLevelModel`][confusius.glm.FirstLevelModel].
+  Spatial smoothing is applied to each run before model fitting
+  ([#201](https://github.com/confusius-tools/confusius/pull/201)).
+
 ### :zap: Performance
 
 - [`process_iq_blocks`][confusius.iq.process.process_iq_blocks] now uses

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,7 +18,7 @@ Current development version for the next ConfUSIus release.
   for the caller to use as they wish
   ([#188](https://github.com/confusius-tools/confusius/pull/188)).
 - Add `smoothing_fwhm` parameter to [`FirstLevelModel`][confusius.glm.FirstLevelModel].
-  Spatial smoothing is applied to each run before model fitting
+  Smoothing is applied to each run before model fitting
   ([#201](https://github.com/confusius-tools/confusius/pull/201)).
 
 ### :zap: Performance

--- a/src/confusius/glm/first_level.py
+++ b/src/confusius/glm/first_level.py
@@ -118,13 +118,13 @@ class FirstLevelModel(BaseEstimator):
         Smoothing is delegated to [`smooth_volume`][confusius.spatial.smooth_volume],
         which requires each smoothed dimension to have uniform coordinate spacing.
 
-        .. attention::
+        !!! warning
             If the data has any other dimension besides `time`, a scalar
             `smoothing_fwhm` will smooth these dimensions as well.
 
-        .. attention::
-          The dict may also include the `"time"` key to smooth along the
-          time axis as well (this is intended behavior).
+        !!! attention
+            The dict may also include the `"time"` key to smooth along the
+            time axis as well (this is intended behavior).
 
         If not provided, no smoothing is applied.
     mask : xarray.DataArray, optional

--- a/src/confusius/glm/first_level.py
+++ b/src/confusius/glm/first_level.py
@@ -31,6 +31,7 @@ from confusius.glm._utils import (
     select_contrast_map,
     to_spatial_dataarray,
 )
+from confusius.spatial import smooth_volume
 from confusius.validation.coordinates import validate_matching_coordinates
 from confusius.validation.mask import validate_mask
 from confusius.validation.time_series import validate_time_series
@@ -109,6 +110,14 @@ class FirstLevelModel(BaseEstimator):
         interval in the run `time` coordinate (see
         [`get_representative_step`][confusius._utils.get_representative_step]).
         Increase this value to tolerate slight timestamp jitter.
+    smoothing_fwhm : float or dict[str, float], optional
+        Full width at half maximum of the Gaussian smoothing kernel, in the physical
+        units of the spatial coordinates, applied to each run before model fitting. A
+        scalar smooths all non-`time` dimensions (caution if data `pose` dimension); a
+        dict maps dimension names to per-dimension FWHM. Smoothing is delegated to
+        [`smooth_volume`][confusius.spatial.smooth_volume], which requires each smoothed
+        dimension to have uniform coordinate spacing. If not provided, no smoothing is
+        applied.
     mask : xarray.DataArray, optional
         Boolean spatial mask selecting voxels to include in model fitting. Must match
         the spatial dimensions and coordinates of each run.
@@ -153,6 +162,7 @@ class FirstLevelModel(BaseEstimator):
         oversampling: int = 50,
         min_onset: float = -24.0,
         uniformity_tolerance: float = 1e-2,
+        smoothing_fwhm: float | dict[str, float] | None = None,
         mask: xr.DataArray | None = None,
     ) -> None:
         self.hrf_model = hrf_model
@@ -165,6 +175,7 @@ class FirstLevelModel(BaseEstimator):
         self.oversampling = oversampling
         self.min_onset = min_onset
         self.uniformity_tolerance = uniformity_tolerance
+        self.smoothing_fwhm = smoothing_fwhm
         self.mask = mask
 
     def fit(
@@ -285,17 +296,16 @@ class FirstLevelModel(BaseEstimator):
         self._input_attrs: dict[str, object] = consensus_attrs(run_data)
 
         for run_index in range(n_runs):
-            data_2d, s_dims, s_shape = _flatten_spatial(run_data[run_index])
+            run = run_data[run_index]
+            if self.smoothing_fwhm is not None:
+                run = smooth_volume(run, self.smoothing_fwhm)
+            data_2d, s_dims, s_shape = _flatten_spatial(run)
             if self.mask is not None:
-                masked = extract_with_mask(run_data[run_index], self.mask)
+                masked = extract_with_mask(run, self.mask)
                 data_2d = masked.transpose("time", "space").values
             self._spatial_shapes.append(s_shape)
             self._run_coords.append(
-                {
-                    str(d): run_data[run_index].coords[d]
-                    for d in s_dims
-                    if d in run_data[run_index].coords
-                }
+                {str(d): run.coords[d] for d in s_dims if d in run.coords}
             )
 
             dm = design_matrices_list[run_index]

--- a/src/confusius/glm/first_level.py
+++ b/src/confusius/glm/first_level.py
@@ -111,11 +111,11 @@ class FirstLevelModel(BaseEstimator):
         [`get_representative_step`][confusius._utils.get_representative_step]).
         Increase this value to tolerate slight timestamp jitter.
     smoothing_fwhm : float or dict[str, float], optional
-        Full width at half maximum of the Gaussian smoothing kernel, in the physical
         units of the spatial coordinates, applied to each run before model fitting. A
-        scalar smooths all non-`time` dimensions (caution if data `pose` dimension); a
-        dict maps dimension names to per-dimension FWHM. Smoothing is delegated to
-        [`smooth_volume`][confusius.spatial.smooth_volume], which requires each smoothed
+        scalar smooths all non-`time` dimensions (caution if the data has a `pose`
+        dimension); a dict maps non-`time` dimension names to per-dimension FWHM.
+        Smoothing is delegated to [`smooth_volume`][confusius.spatial.smooth_volume],
+        which requires each smoothed dimension to have uniform coordinate spacing.
         dimension to have uniform coordinate spacing. If not provided, no smoothing is
         applied.
     mask : xarray.DataArray, optional

--- a/src/confusius/glm/first_level.py
+++ b/src/confusius/glm/first_level.py
@@ -111,13 +111,22 @@ class FirstLevelModel(BaseEstimator):
         [`get_representative_step`][confusius._utils.get_representative_step]).
         Increase this value to tolerate slight timestamp jitter.
     smoothing_fwhm : float or dict[str, float], optional
+        Full width at half maximum of the Gaussian smoothing kernel, in the physical
         units of the spatial coordinates, applied to each run before model fitting. A
         scalar smooths all non-`time` dimensions (caution if the data has a `pose`
-        dimension); a dict maps non-`time` dimension names to per-dimension FWHM.
+        dimension); a dict maps dimension names to per-dimension FWHM.
         Smoothing is delegated to [`smooth_volume`][confusius.spatial.smooth_volume],
         which requires each smoothed dimension to have uniform coordinate spacing.
-        dimension to have uniform coordinate spacing. If not provided, no smoothing is
-        applied.
+
+        .. attention::
+            If the data has any other dimension besides `time`, a scalar
+            `smoothing_fwhm` will smooth these dimensions as well.
+
+        .. attention::
+          The dict may also include the `"time"` key to smooth along the
+          time axis as well (this is intended behavior).
+
+        If not provided, no smoothing is applied.
     mask : xarray.DataArray, optional
         Boolean spatial mask selecting voxels to include in model fitting. Must match
         the spatial dimensions and coordinates of each run.

--- a/tests/unit/test_glm/test_first_level.py
+++ b/tests/unit/test_glm/test_first_level.py
@@ -9,6 +9,7 @@ from numpy.testing import assert_allclose
 from confusius.glm import FirstLevelModel, make_first_level_design_matrix
 from confusius.glm._models import OLSModel
 from confusius.glm.first_level import _flatten_spatial
+from confusius.spatial import smooth_volume
 
 
 # -----------------------------------------------------------------------------
@@ -176,6 +177,23 @@ class TestFirstLevelModelFit:
         assert z_map.attrs["long_name"] == "zscore"
         assert z_map.attrs["cmap"] == "coolwarm"
 
+    def test_smoothing_fwhm_matches_presmoothed_input(self, fusi_data, events):
+        """smoothing_fwhm=f equals fitting on smooth_volume(data, f) and changes
+        the result relative to no smoothing."""
+        smoothed = FirstLevelModel(noise_model="ols", smoothing_fwhm=0.2)
+        smoothed.fit(fusi_data, events=events)
+        reference = FirstLevelModel(noise_model="ols")
+        reference.fit(smooth_volume(fusi_data, 0.2), events=events)
+        unsmoothed = FirstLevelModel(noise_model="ols")
+        unsmoothed.fit(fusi_data, events=events)
+
+        smoothed_map = smoothed.compute_contrast("A - B").values
+        assert_allclose(smoothed_map, reference.compute_contrast("A - B").values)
+        # Guard against a silent no-op: smoothing must change the contrast map.
+        assert not np.allclose(
+            smoothed_map, unsmoothed.compute_contrast("A - B").values
+        )
+
 
 # -----------------------------------------------------------------------------
 # FirstLevelModel: contrasts
@@ -264,9 +282,7 @@ class TestFirstLevelModelContrastMultiRun:
         # scale (mean of two unbiased estimates).
         assert np.median(np.abs(e_multi)) < 1.5 * np.median(np.abs(e_single))
 
-    def test_multi_run_per_run_confounds_pass_through(
-        self, rng, frame_times, events
-    ):
+    def test_multi_run_per_run_confounds_pass_through(self, rng, frame_times, events):
         """Per-run confounds passed as a list show up with their values in each
         run's design matrix."""
         data1 = xr.DataArray(


### PR DESCRIPTION
- Closes #193

## Description

Spatial smoothing is applied for each run during `fit`.
Small attention to data with `pose` dimension. If a single int value is passed as `fwhm`, smoothing will be applied to *all* non-temporal dimensions. I added a caution note to the docstring about this.

## Checklist

- [x] Tests pass locally (`just t`)
- [x] Pre-commit hooks pass (`just pc`)
- [x] New public API is documented (NumPy docstring, type hints)
- [x] Changelog updated if user-facing
