### PR TITLE
feat(cli): support opening multiple files in a single invocation

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,10 @@ Current development version for the next ConfUSIus release.
 
 ### :sparkles: Enhancements
 
+- The `confusius` CLI now accepts multiple fUSI data files in a single
+  invocation (e.g. `confusius fixed.nii moving.nii`). Each file is added as its
+  own image layer, named after the file's basename
+  ([#205](https://github.com/confusius-tools/confusius/issues/205)).
 - `data.fusi.affine.apply` now accepts affines with rotation and shear. The
   axis-aligned part updates the 1D `z`/`y`/`x` coordinates and the method returns
   the residual orientation as a 4x4 affine (the identity for diagonal affines)

--- a/docs/gui/overview.md
+++ b/docs/gui/overview.md
@@ -62,10 +62,10 @@ itself, click **Take a Tour** in the upper-right corner of the sidebar header.
 ### Recommended: Data Panel and CLI
 
 The recommended way to open files is through the [Data Panel](plugin.md#data-io-panel) or
-by passing a path to the `confusius` command on launch:
+by passing one or multiple paths to the `confusius` command on launch:
 
 ```bash
-confusius path/to/data.zarr
+confusius path/to/data.zarr path/to/other/data.zarr
 ```
 
 Both routes use [`confusius.load()`][confusius.load] under the hood, which produces a

--- a/src/confusius/_cli.py
+++ b/src/confusius/_cli.py
@@ -1,31 +1,46 @@
 """ConfUSIus command-line interface."""
 
+from __future__ import annotations
 
-def main() -> None:
-    """Launch napari with the ConfUSIus plugin open."""
-    import argparse
-    from pathlib import Path
+import argparse
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
 
+if TYPE_CHECKING:
     import napari
+    import napari.layers
 
-    from confusius._napari import ConfUSIusWidget
 
+def build_parser() -> argparse.ArgumentParser:
+    """Build the ``confusius`` command-line argument parser.
+
+    Returns
+    -------
+    argparse.ArgumentParser
+        The parser configured with the CLI's positional path argument and
+        ``--lazy`` / ``--video`` options.
+    """
     parser = argparse.ArgumentParser(
         prog="confusius",
         description="Launch the ConfUSIus napari plugin.",
     )
     parser.add_argument(
         "path",
-        nargs="?",
+        nargs="*",
         type=Path,
-        help="Path to a fUSI data file (.nii, .nii.gz, .scan, .zarr) to open on launch.",
+        metavar="PATH",
+        help=(
+            "Path to a fUSI data file (.nii, .nii.gz, .scan, .zarr) to open on "
+            "launch. May be passed multiple times to open several layers at "
+            "once, e.g. `confusius fixed.nii moving.nii`."
+        ),
     )
     parser.add_argument(
         "--lazy",
         action="store_true",
         help=(
-            "Load the file as a Dask-backed array without computing. "
-            "By default the full array is loaded into memory."
+            "Load the files as Dask-backed arrays without computing. "
+            "By default the full arrays are loaded into memory."
         ),
     )
     parser.add_argument(
@@ -33,29 +48,96 @@ def main() -> None:
         type=Path,
         help=(
             "Path to a video file (.mp4, .mov, .avi) to display side-by-side "
-            "with the fUSI data. Requires a data file to be specified as well."
+            "with the first fUSI data file. Requires at least one data file."
         ),
     )
-    args = parser.parse_args()
+    return parser
 
-    viewer = napari.Viewer()
+
+def run(args: argparse.Namespace, viewer: napari.Viewer | None = None) -> napari.Viewer:
+    """Open the requested files in a napari viewer and attach the ConfUSIus widget.
+
+    Parameters
+    ----------
+    args : argparse.Namespace
+        Parsed CLI arguments, as produced by [`build_parser`][confusius._cli.build_parser].
+    viewer : napari.Viewer, optional
+        Existing viewer to populate. If not provided, a new viewer is created.
+        Tests pass a headless viewer to avoid opening a Qt window.
+
+    Returns
+    -------
+    napari.Viewer
+        The viewer with the ConfUSIus widget docked and the requested data
+        files added as image layers (one layer per file, in the same order as
+        ``args.path``). The first loaded layer is paired with ``args.video``
+        if it is also set.
+    """
+    import napari
+
+    from confusius._napari import ConfUSIusWidget
+
+    if viewer is None:
+        viewer = napari.Viewer()
     widget = ConfUSIusWidget(viewer)
     viewer.window.add_dock_widget(widget, name="ConfUSIus")
 
-    if args.path is not None:
-        from confusius.io import load
-        from confusius.plotting.napari import plot_napari
+    layers = _open_paths(viewer, args.path, lazy=args.lazy) if args.path else []
 
-        da = load(args.path)
-        if not args.lazy:
-            da = da.compute()
-        _viewer, layer = plot_napari(da, viewer=viewer)
+    if args.video is not None:
+        if not layers:
+            build_parser().error(
+                "--video requires a data file to be specified as well."
+            )
+        video_panel = widget._accordion_panels["Video"]
+        video_panel._add_video(args.video, layers[0])
 
-        if args.video is not None:
-            video_panel = widget._accordion_panels["Video"]
-            video_panel._add_video(args.video, layer)
+    return viewer
 
-    elif args.video is not None:
-        parser.error("--video requires a data file to be specified as well.")
+
+def main() -> None:
+    """Parse CLI arguments, run the plugin, and start the napari event loop."""
+    args = build_parser().parse_args()
+    run(args)
+    import napari
 
     napari.run()
+
+
+def _open_paths(
+    viewer: napari.Viewer,
+    paths: list[Path],
+    *,
+    lazy: bool,
+) -> list[napari.layers.Image]:
+    """Load each path and add it to the viewer as a ConfUSIus image layer.
+
+    Parameters
+    ----------
+    viewer : napari.Viewer
+        Active napari viewer to add the loaded layers to.
+    paths : list of pathlib.Path
+        One path per fUSI data file. Each becomes its own image layer named
+        after the file's basename.
+    lazy : bool
+        Whether to keep the data Dask-backed (`True`) or materialise it into
+        memory before plotting (`False`).
+
+    Returns
+    -------
+    list of napari.layers.Image
+        The layers added to the viewer, in the same order as `paths`.
+    """
+    from confusius.io import load
+    from confusius.plotting.napari import plot_napari
+
+    layers: list[napari.layers.Image] = []
+    for path in paths:
+        da = load(path)
+        if not lazy:
+            da = da.compute()
+        _, layer = plot_napari(da, viewer=viewer, name=path.name)
+        # `plot_napari` returns Image | Labels; the CLI only loads image
+        # data files, so the resulting layer is always an Image.
+        layers.append(cast("napari.layers.Image", layer))
+    return layers

--- a/src/confusius/_cli.py
+++ b/src/confusius/_cli.py
@@ -12,13 +12,13 @@ if TYPE_CHECKING:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    """Build the ``confusius`` command-line argument parser.
+    """Build the `confusius` command-line argument parser.
 
     Returns
     -------
     argparse.ArgumentParser
         The parser configured with the CLI's positional path argument and
-        ``--lazy`` / ``--video`` options.
+        `--lazy` / `--video` options.
     """
     parser = argparse.ArgumentParser(
         prog="confusius",
@@ -70,7 +70,7 @@ def run(args: argparse.Namespace, viewer: napari.Viewer | None = None) -> napari
     napari.Viewer
         The viewer with the ConfUSIus widget docked and the requested data
         files added as image layers (one layer per file, in the same order as
-        ``args.path``). The first loaded layer is paired with ``args.video``
+        `args.path`). The first loaded layer is paired with `args.video`
         if it is also set.
     """
     import napari

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,96 @@
+"""Unit tests for the ConfUSIus CLI entry point."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+class TestBuildParser:
+    """The CLI parser accepts zero, one, or many positional paths."""
+
+    def test_no_path(self) -> None:
+        from confusius._cli import build_parser
+
+        ns = build_parser().parse_args([])
+        assert ns.path == []
+        assert ns.lazy is False
+        assert ns.video is None
+
+    def test_one_path(self) -> None:
+        from confusius._cli import build_parser
+
+        ns = build_parser().parse_args(["fixed.nii"])
+        assert ns.path == [Path("fixed.nii")]
+
+    def test_two_paths(self) -> None:
+        from confusius._cli import build_parser
+
+        ns = build_parser().parse_args(["fixed.nii", "moving.nii"])
+        assert ns.path == [Path("fixed.nii"), Path("moving.nii")]
+
+    def test_three_paths_with_various_extensions(self) -> None:
+        from confusius._cli import build_parser
+
+        ns = build_parser().parse_args(["a.nii", "b.nii.gz", "c.scan"])
+        assert ns.path == [Path("a.nii"), Path("b.nii.gz"), Path("c.scan")]
+
+    def test_lazy_and_video(self) -> None:
+        from confusius._cli import build_parser
+
+        ns = build_parser().parse_args(["fixed.nii", "--lazy", "--video", "v.mp4"])
+        assert ns.lazy is True
+        assert ns.video == Path("v.mp4")
+
+
+class TestRun:
+    """`run` opens each requested file as a layer named after the file."""
+
+    def test_no_path_adds_nothing(self, make_napari_viewer) -> None:
+        from confusius._cli import build_parser, run
+
+        args = build_parser().parse_args([])
+        viewer = make_napari_viewer()
+        run(args, viewer=viewer)
+        assert len(viewer.layers) == 0
+
+    def test_one_path_adds_one_layer(
+        self, make_napari_viewer, scan_2d_path: Path
+    ) -> None:
+        from confusius._cli import build_parser, run
+
+        args = build_parser().parse_args([str(scan_2d_path)])
+        viewer = make_napari_viewer()
+        run(args, viewer=viewer)
+
+        assert len(viewer.layers) == 1
+        assert viewer.layers[scan_2d_path.name].name == scan_2d_path.name
+
+    def test_two_paths_adds_two_layers_in_order(
+        self, make_napari_viewer, tmp_path: Path, scan_2d_path: Path
+    ) -> None:
+        from confusius._cli import build_parser, run
+
+        # Make a second file via copy so the two paths have distinct basenames.
+        second = tmp_path / "second.scan"
+        second.write_bytes(scan_2d_path.read_bytes())
+
+        args = build_parser().parse_args([str(scan_2d_path), str(second)])
+        viewer = make_napari_viewer()
+        run(args, viewer=viewer)
+
+        assert len(viewer.layers) == 2
+        names = {layer.name for layer in viewer.layers}
+        assert names == {scan_2d_path.name, second.name}
+        # Returned order matches the input order.
+        layer_names = [layer.name for layer in viewer.layers]
+        assert layer_names.index(scan_2d_path.name) < layer_names.index(second.name)
+
+    def test_video_without_data_file_errors(self, make_napari_viewer) -> None:
+        import pytest
+
+        from confusius._cli import build_parser, run
+
+        args = build_parser().parse_args(["--video", "v.mp4"])
+        viewer = make_napari_viewer()
+        with pytest.raises(SystemExit):
+            run(args, viewer=viewer)


### PR DESCRIPTION
## Summary

- Allow `confusius` CLI to accept multiple positional file paths so users can open batches (e.g. fixed/moving pairs for registration) in one call.
- Each path becomes its own napari image layer, named after the file's basename.
- Split the parser out into a public `build_parser()` and the side-effecting work into a public `run()` so the CLI is testable against a headless napari viewer.

## Usage

```bash
confusius fixed.nii moving.nii
confusius data/*.nii --lazy
confusius scan.scan --video cam.mp4
```

## Test plan

- [x] `uv run pytest tests/unit/test_cli.py` — 9 new tests, all green
- [x] `just pre-commit` — ruff check/format, ty, codespell, numpydoc all pass
- [x] CI

## Related

Closes #205