### PR TITLE
feat(decomposition): add NMF wrapper

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,15 @@ icon: lucide/history
 
 Current development version for the next ConfUSIus release.
 
+### :sparkles: Enhancements
+
+- Add [`NMF`][confusius.decomposition.NMF] for non-negative matrix factorization
+  of fUSI time series, wrapping `sklearn.decomposition.NMF` with the same
+  xarray-aware `fit`/`transform`/`inverse_transform` interface as
+  [`PCA`][confusius.decomposition.PCA] and [`FastICA`][confusius.decomposition.FastICA].
+  Both `mode='temporal'` and `mode='spatial'` are supported
+  ([#117](https://github.com/confusius-tools/confusius/issues/117)).
+
 ## 0.4.0
 
 *Released 2026-06-25.*

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,6 +19,12 @@ Current development version for the next ConfUSIus release.
   Both `mode='temporal'` and `mode='spatial'` are supported
   ([#117](https://github.com/confusius-tools/confusius/issues/117)).
 
+### :books: Documentation
+
+- Add an [NMF example](examples/_built/decomposition/nmf_single_recording.md) to the
+  gallery, demonstrating the z-score + absolute-value standardization that makes
+  signed fUSI signals NMF-compatible.
+
 ### :boom: Breaking changes
 
 - Registration now takes a single `initialization` parameter in place of

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,7 +12,7 @@ Current development version for the next ConfUSIus release.
 
 ### :sparkles: Enhancements
 
-- Add [`NMF`][confusius.decomposition.NMF] for non-negative matrix factorization
+- Added [`NMF`][confusius.decomposition.NMF] for non-negative matrix factorization
   of fUSI time series, wrapping `sklearn.decomposition.NMF` with the same
   xarray-aware `fit`/`transform`/`inverse_transform` interface as
   [`PCA`][confusius.decomposition.PCA] and [`FastICA`][confusius.decomposition.FastICA].

--- a/docs/examples/03_decomposition/01_pca_single_recording.py
+++ b/docs/examples/03_decomposition/01_pca_single_recording.py
@@ -39,9 +39,6 @@ import numpy as np
 import xarray as xr
 
 import confusius as cf
-from confusius.datasets import fetch_nunez_elizalde_2022
-from confusius.decomposition import PCA
-from confusius.signal import standardize
 
 # Adapt background color to the current Matplotlib style.
 bg_color = mpl.colors.to_hex(mpl.rcParams["figure.facecolor"])
@@ -49,7 +46,7 @@ bg_color = mpl.colors.to_hex(mpl.rcParams["figure.facecolor"])
 # Keep notebook output compact for large DataArray displays.
 xr.set_options(display_expand_data=False)
 
-bids_root = fetch_nunez_elizalde_2022(
+bids_root = cf.datasets.fetch_nunez_elizalde_2022(
     subjects="CR022",
     sessions="20201011",
     tasks="spontaneous",
@@ -70,7 +67,7 @@ data
 # ## Correct for brain motion
 #
 # This recording contains some brain motion, which we can mitigate by performing a rigid
-# translation correction with
+# transform correction with
 # [`register_volumewise`][confusius.registration.register_volumewise]. This is a common
 # preprocessing step for fUSI data, and it can help avoid spurious components driven by
 # brain motion.
@@ -92,7 +89,7 @@ data = cf.registration.register_volumewise(data, learning_rate=1e-2)
 # near large blood vessels, which may not be of primary interest.
 
 # %%
-data_std = standardize(data)
+data_std = cf.signal.standardize(data)
 
 # %% [markdown]
 # In ConfUSIus, the [`PCA`][confusius.decomposition.PCA] model wraps the familiar
@@ -110,7 +107,7 @@ data_std = standardize(data)
 # Here, we fit a PCA model with all available components.
 
 # %%
-pca_t = PCA(random_state=0, mode="temporal")
+pca_t = cf.decomposition.PCA(random_state=0, mode="temporal")
 signals_t = pca_t.fit_transform(data_std)
 signals_t
 
@@ -205,7 +202,7 @@ _ = fig.suptitle("Temporal PCA maps and time courses (first 6 components)", font
 # spatial maps as principal components.
 
 # %%
-pca_s = PCA(random_state=0, mode="spatial")
+pca_s = cf.decomposition.PCA(random_state=0, mode="spatial")
 signals_s = pca_s.fit_transform(data_std)
 signals_s
 

--- a/docs/examples/03_decomposition/02_fastica_single_recording.py
+++ b/docs/examples/03_decomposition/02_fastica_single_recording.py
@@ -46,9 +46,6 @@ import numpy as np
 import xarray as xr
 
 import confusius as cf
-from confusius.datasets import fetch_nunez_elizalde_2022
-from confusius.decomposition import FastICA
-from confusius.signal import standardize
 
 # Adapt background color to the current Matplotlib style.
 bg_color = mpl.colors.to_hex(mpl.rcParams["figure.facecolor"])
@@ -56,7 +53,7 @@ bg_color = mpl.colors.to_hex(mpl.rcParams["figure.facecolor"])
 # Keep notebook output compact for large DataArray displays.
 xr.set_options(display_expand_data=False)
 
-bids_root = fetch_nunez_elizalde_2022(
+bids_root = cf.datasets.fetch_nunez_elizalde_2022(
     subjects="CR022",
     sessions="20201011",
     tasks="spontaneous",
@@ -74,14 +71,14 @@ data = cf.load(pwd_path).compute()
 data
 
 # %% [markdown]
-# ## Correct for brain motion
+## Correct for brain motion
 #
 # This recording contains some brain motion, which we can mitigate by performing a rigid
-# translation correction with
+# transform correction with
 # [`register_volumewise`][confusius.registration.register_volumewise]. This is the same
 # preprocessing step used in the [PCA
-# example](pca_single_recording.md#correct-for-brain-motion), and it helps
-# avoid components dominated by motion artefacts.
+# example](pca_single_recording.md#correct-for-brain-motion), and it helps avoid
+# components dominated by motion artefacts.
 
 # %%
 data = cf.registration.register_volumewise(data, learning_rate=1e-2)
@@ -99,7 +96,7 @@ data = cf.registration.register_volumewise(data, learning_rate=1e-2)
 # [PCA example](pca_single_recording.md#temporal-pca-modetemporal).
 
 # %%
-data_std = standardize(data)
+data_std = cf.signal.standardize(data)
 
 # %% [markdown]
 # With `mode="temporal"`, [FastICA][confusius.decomposition.FastICA] operates on the
@@ -110,7 +107,7 @@ data_std = standardize(data)
 # which each independent time course has its strongest influence).
 
 # %%
-ica_t = FastICA(
+ica_t = cf.decomposition.FastICA(
     n_components=10,
     mode="temporal",
     random_state=42,
@@ -173,7 +170,7 @@ _ = fig.suptitle(
 # reducing whole-brain motion-related structure.
 
 # %%
-ica_s = FastICA(
+ica_s = cf.decomposition.FastICA(
     n_components=10, mode="spatial", random_state=42, fun="cube", max_iter=500
 )
 signals_s = ica_s.fit_transform(data_std)

--- a/docs/examples/03_decomposition/02_fastica_single_recording.py
+++ b/docs/examples/03_decomposition/02_fastica_single_recording.py
@@ -222,7 +222,9 @@ for i, comp in enumerate(range(n_show)):
 for ax in axes_tc[:-1]:
     ax.tick_params(labelbottom=False)
 axes_tc[-1].set_xlabel("Time (s)")
-_ = fig.suptitle("Spatial ICA: maps and time courses (first 10 components)", fontsize=21)
+_ = fig.suptitle(
+    "Spatial ICA: maps and time courses (first 10 components)", fontsize=21
+)
 
 # %% [markdown]
 # [^1]: Hyvärinen, A., and Oja, E. (2000). "Independent component analysis:

--- a/docs/examples/03_decomposition/03_nmf_single_recording.py
+++ b/docs/examples/03_decomposition/03_nmf_single_recording.py
@@ -1,0 +1,192 @@
+# %% [markdown]
+# # NMF on a single fUSI recording
+#
+# This example shows how to use non-negative matrix factorization (NMF) to decompose a
+# fUSI recording into non-negative spatial maps and their associated non-negative time
+# courses. It complements the [PCA](pca_single_recording.md) and
+# [FastICA](fastica_single_recording.md) examples in the same gallery.
+#
+# NMF is unique among the decomposers in ConfUSIus because it requires strictly
+# non-negative inputs[^1]. Power Doppler fUSI signals are non-negative by construction,
+# so they pass the constraint directly. Other modalities (e.g. contrast-based signals,
+# B-mode, or demeaned timeseries) contain negative values; the wrapper raises a clear
+# `ValueError` in that case, since the underlying optimization has no real solution.
+#
+# A practical way to make signed signals NMF-compatible is to **z-score each voxel and
+# take the absolute value**. The z-score rescales every voxel to a comparable dynamic
+# range so that high-variance voxels (e.g. near large vessels) do not dominate the
+# decomposition, and the absolute value restores the non-negativity constraint at the
+# cost of losing the sign. NMF then factorizes the resulting *magnitude* signal, which
+# empirically highlights the same local spatiotemporal patterns as correlation-based
+# methods (PCA, ICA) but with strictly non-negative parts.
+
+# %% [markdown]
+# ## Load a fUSI recording
+#
+# We use the same spontaneous activity recording from the [Nunez-Elizalde 2022
+# dataset](https://doi.org/10.1016/j.neuron.2022.02.012) as in the [PCA](pca_single_recording.md)
+# and [FastICA](fastica_single_recording.md) examples. See the
+# [Datasets](../../../user-guide/datasets.md) user guide for more details on how to
+# download this dataset using ConfUSIus.
+
+# %%
+from pathlib import Path
+
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+import numpy as np
+import xarray as xr
+
+import confusius as cf
+from confusius.datasets import fetch_nunez_elizalde_2022
+from confusius.decomposition import NMF
+from confusius.signal import standardize
+
+# Adapt background color to the current Matplotlib style.
+bg_color = mpl.colors.to_hex(mpl.rcParams["figure.facecolor"])
+
+# Keep notebook output compact for large DataArray displays.
+xr.set_options(display_expand_data=False)
+
+bids_root = fetch_nunez_elizalde_2022(
+    subjects="CR022",
+    sessions="20201011",
+    tasks="spontaneous",
+    acqs="slice03",
+)
+
+pwd_path = (
+    Path(bids_root)
+    / "sub-CR022"
+    / "ses-20201011"
+    / "fusi"
+    / "sub-CR022_ses-20201011_task-spontaneous_acq-slice03_pwd.nii.gz"
+)
+data = cf.load(pwd_path).compute()
+data
+
+# %% [markdown]
+# ## Correct for brain motion
+#
+# As in the [PCA](pca_single_recording.md#correct-for-brain-motion) and
+# [FastICA](fastica_single_recording.md#correct-for-brain-motion) examples, we first
+# perform a rigid translation correction with
+# [`register_volumewise`][confusius.registration.register_volumewise] to mitigate brain
+# motion.
+
+# %%
+data = cf.registration.register_volumewise(data, learning_rate=1e-2)
+
+# %% [markdown]
+# ## Standardize for NMF
+#
+# NMF requires non-negative inputs but a raw Power Doppler timeseries is dominated by
+# each voxel's own mean intensity, which is unrelated to the fluctuations we want to
+# capture. We therefore:
+#
+# 1. Z-score each voxel's time series with
+#    [`standardize`][confusius.signal.standardize] to put every voxel on a common
+#    scale and remove its mean.
+# 2. Take the absolute value to satisfy NMF's non-negativity constraint.
+#
+# The result is a non-negative *magnitude* signal that NMF can decompose additively.
+
+# %%
+data_nmf = np.abs(standardize(data))
+
+# %% [markdown]
+# ## Fit temporal NMF
+#
+# [`NMF`][confusius.decomposition.NMF] wraps the familiar scikit-learn
+# [`NMF`][sklearn.decomposition.NMF] estimator while preserving fUSI DataArray metadata
+# and coordinates. With `mode="temporal"` (the default), it fits on `(time, voxels)`
+# and returns:
+#
+# - [`maps_`][confusius.decomposition.NMF]: non-negative spatial maps of shape
+#   `(component, z, y, x)`.
+# - [`fit_transform`][confusius.decomposition.NMF.fit_transform]: non-negative time
+#   courses of shape `(time, component)`.
+
+# %%
+nmf = NMF(n_components=10, random_state=0, max_iter=500)
+signals = nmf.fit_transform(data_nmf)
+signals
+
+# %% [markdown]
+# ## Reconstruction error
+#
+# [`reconstruction_err_`][confusius.decomposition.NMF] is the Frobenius norm of
+# `X - WH`, where `W` are the spatial maps and `H` the time courses. It gives a sense
+# of how well the chosen number of components explains the standardized data. A
+# quantitative model-selection procedure is out of scope here, but the trace is useful
+# when sweeping `n_components` and looking for diminishing returns.
+
+# %%
+print(f"reconstruction_err_: {nmf.reconstruction_err_:.3f}")
+print(f"n_iter_: {nmf.n_iter_}")
+
+# %% [markdown]
+# ## Spatial maps and time courses
+#
+# Looking at the spatial maps and the associated time courses side by side is a useful
+# first sanity check. Maps with localized, anatomically plausible structure paired with
+# a single dominant transient in the time course tend to reflect a coherent
+# spatiotemporal pattern, while diffuse maps paired with noisy or drift-like
+# fluctuations often indicate residual motion or physiological artefacts.
+
+# %% tags=["thumbnail"]
+n_show = 10
+fig = plt.figure(figsize=(10.5, 12.0), constrained_layout=True)
+fig.patch.set_facecolor(bg_color)
+gs = fig.add_gridspec(n_show, 2, width_ratios=[1, 3])
+
+axes_tc = [fig.add_subplot(gs[i, 1]) for i in range(n_show)]
+for ax in axes_tc[1:]:
+    ax.sharex(axes_tc[0])
+
+for i, comp in enumerate(range(n_show)):
+    component_map = nmf.maps_.isel(component=[comp])
+    vmax = float(component_map.max())
+    cf.plotting.plot_volume(
+        component_map,
+        axes=fig.add_subplot(gs[i, 0]),
+        slice_mode="component",
+        cmap="viridis",
+        vmin=0,
+        vmax=vmax,
+        show_axes=False,
+        show_colorbar=False,
+        show_titles=False,
+        bg_color=bg_color,
+    )
+
+    signals.sel(component=comp).plot(ax=axes_tc[i], lw=1.1)
+    axes_tc[i].set_title(f"Component {comp + 1}")
+    axes_tc[i].set_ylabel("Signal")
+    axes_tc[i].set_xlabel("")
+
+for ax in axes_tc[:-1]:
+    ax.tick_params(labelbottom=False)
+axes_tc[-1].set_xlabel("Time (s)")
+_ = fig.suptitle(
+    "Temporal NMF: spatial maps and time courses (first 10 components)", fontsize=21
+)
+
+# %% [markdown]
+# ## Spatial NMF
+#
+# [`NMF`][confusius.decomposition.NMF] also accepts `mode="spatial"`, which transposes
+# the data to `(voxels, time)` before fitting. In this orientation, the dictionaries
+# are non-negative time courses and the projected signals are non-negative spatial
+# maps. The rest of the API is identical and the choice between the two modes mirrors
+# the temporal/spatial choice offered by [PCA](pca_single_recording.md) and
+# [FastICA](fastica_single_recording.md).
+
+# %%
+nmf_spatial = NMF(n_components=10, mode="spatial", random_state=0, max_iter=500)
+spatial_maps = nmf_spatial.fit_transform(data_nmf)
+spatial_maps
+
+# %% [markdown]
+# [^1]: Lee, D. D., and Seung, H. S. (1999). "Learning the parts of objects by
+# non-negative matrix factorization". *Nature*, 401(6755), 788-791.

--- a/docs/examples/03_decomposition/03_nmf_single_recording.py
+++ b/docs/examples/03_decomposition/03_nmf_single_recording.py
@@ -1,5 +1,4 @@
-# %% [markdown]
-# # NMF on a single fUSI recording
+# %% [markdown] # NMF on a single fUSI recording
 #
 # This example shows how to use non-negative matrix factorization (NMF) to decompose a
 # fUSI recording into non-negative spatial maps and their associated non-negative time
@@ -8,17 +7,13 @@
 #
 # NMF is unique among the decomposers in ConfUSIus because it requires strictly
 # non-negative inputs[^1]. Power Doppler fUSI signals are non-negative by construction,
-# so they pass the constraint directly. Other modalities (e.g. contrast-based signals,
-# B-mode, or demeaned timeseries) contain negative values; the wrapper raises a clear
-# `ValueError` in that case, since the underlying optimization has no real solution.
+# so they pass the constraint directly. However, raw power is dominated by each voxel's
+# baseline intensity, which can make bright vessels dominate the factorization.
 #
-# A practical way to make signed signals NMF-compatible is to **z-score each voxel and
-# take the absolute value**. The z-score rescales every voxel to a comparable dynamic
-# range so that high-variance voxels (e.g. near large vessels) do not dominate the
-# decomposition, and the absolute value restores the non-negativity constraint at the
-# cost of losing the sign. NMF then factorizes the resulting *magnitude* signal, which
-# empirically highlights the same local spatiotemporal patterns as correlation-based
-# methods (PCA, ICA) but with strictly non-negative parts.
+# A practical workaround is to center and scale each voxel across time, then split the
+# standardized signal into separate positive and negative channels, preserving NMF's
+# non-negativity constraint. NMF can then discover additive components in above-baseline
+# and below-baseline fluctuations separately.
 
 # %% [markdown]
 # ## Load a fUSI recording
@@ -34,13 +29,9 @@ from pathlib import Path
 
 import matplotlib as mpl
 import matplotlib.pyplot as plt
-import numpy as np
 import xarray as xr
 
 import confusius as cf
-from confusius.datasets import fetch_nunez_elizalde_2022
-from confusius.decomposition import NMF
-from confusius.signal import standardize
 
 # Adapt background color to the current Matplotlib style.
 bg_color = mpl.colors.to_hex(mpl.rcParams["figure.facecolor"])
@@ -48,7 +39,7 @@ bg_color = mpl.colors.to_hex(mpl.rcParams["figure.facecolor"])
 # Keep notebook output compact for large DataArray displays.
 xr.set_options(display_expand_data=False)
 
-bids_root = fetch_nunez_elizalde_2022(
+bids_root = cf.datasets.fetch_nunez_elizalde_2022(
     subjects="CR022",
     sessions="20201011",
     tasks="spontaneous",
@@ -66,11 +57,11 @@ data = cf.load(pwd_path).compute()
 data
 
 # %% [markdown]
-# ## Correct for brain motion
+## Correct for brain motion
 #
 # As in the [PCA](pca_single_recording.md#correct-for-brain-motion) and
 # [FastICA](fastica_single_recording.md#correct-for-brain-motion) examples, we first
-# perform a rigid translation correction with
+# perform a rigid transformation correction with
 # [`register_volumewise`][confusius.registration.register_volumewise] to mitigate brain
 # motion.
 
@@ -80,19 +71,23 @@ data = cf.registration.register_volumewise(data, learning_rate=1e-2)
 # %% [markdown]
 # ## Standardize for NMF
 #
-# NMF requires non-negative inputs but a raw Power Doppler timeseries is dominated by
-# each voxel's own mean intensity, which is unrelated to the fluctuations we want to
-# capture. We therefore:
+# NMF requires non-negative inputs, but raw Power Doppler is dominated by each voxel's
+# baseline intensity rather than the temporal fluctuations we want to group. We
+# therefore:
 #
-# 1. Z-score each voxel's time series with
-#    [`standardize`][confusius.signal.standardize] to put every voxel on a common
-#    scale and remove its mean.
-# 2. Take the absolute value to satisfy NMF's non-negativity constraint.
+# 1. Z-score each voxel's time series with [`standardize`][confusius.signal.standardize]
+#    to remove its mean and put voxels on a comparable scale.
+# 2. Split the standardized signal into separate positive and negative parts.
 #
-# The result is a non-negative *magnitude* signal that NMF can decompose additively.
+# This keeps the sign information— above-baseline versus below-baseline
+# fluctuations—while still presenting a non-negative matrix to NMF.
 
 # %%
-data_nmf = np.abs(standardize(data))
+z = cf.signal.standardize(data)
+data_nmf = xr.concat(
+    [z.clip(min=0), (-z).clip(min=0)],
+    dim=xr.IndexVariable("sign", ["pos", "neg"]),
+)
 
 # %% [markdown]
 # ## Fit temporal NMF
@@ -102,13 +97,14 @@ data_nmf = np.abs(standardize(data))
 # and coordinates. With `mode="temporal"` (the default), it fits on `(time, voxels)`
 # and returns:
 #
-# - [`maps_`][confusius.decomposition.NMF]: non-negative spatial maps of shape
-#   `(component, z, y, x)`.
+# - [`maps_`][confusius.decomposition.NMF]: non-negative spatial maps. Because we split
+#   the input into positive and negative channels, the maps here have shape
+#   `(component, sign, z, y, x)`.
 # - [`fit_transform`][confusius.decomposition.NMF.fit_transform]: non-negative time
 #   courses of shape `(time, component)`.
 
 # %%
-nmf = NMF(n_components=10, random_state=0, max_iter=500)
+nmf = cf.decomposition.NMF(n_components=10, random_state=0, max_iter=500)
 signals = nmf.fit_transform(data_nmf)
 signals
 
@@ -129,36 +125,41 @@ print(f"n_iter_: {nmf.n_iter_}")
 # ## Spatial maps and time courses
 #
 # Looking at the spatial maps and the associated time courses side by side is a useful
-# first sanity check. Maps with localized, anatomically plausible structure paired with
-# a single dominant transient in the time course tend to reflect a coherent
-# spatiotemporal pattern, while diffuse maps paired with noisy or drift-like
-# fluctuations often indicate residual motion or physiological artefacts.
+# first sanity check. Here each component has two map panels: one for above-baseline
+# fluctuations (`pos`) and one for below-baseline fluctuations (`neg`). Localized,
+# anatomically plausible structure paired with a clear transient in the time course
+# tends to reflect a coherent spatiotemporal pattern, while diffuse maps paired with
+# noisy or drift-like fluctuations often indicate residual motion or physiological
+# artefacts.
 
 # %% tags=["thumbnail"]
 n_show = 10
-fig = plt.figure(figsize=(10.5, 12.0), constrained_layout=True)
+fig = plt.figure(figsize=(11.5, 12.0), constrained_layout=True)
 fig.patch.set_facecolor(bg_color)
-gs = fig.add_gridspec(n_show, 2, width_ratios=[1, 3])
+gs = fig.add_gridspec(n_show, 2, width_ratios=[1.4, 3])
 
 axes_tc = [fig.add_subplot(gs[i, 1]) for i in range(n_show)]
 for ax in axes_tc[1:]:
     ax.sharex(axes_tc[0])
 
 for i, comp in enumerate(range(n_show)):
-    component_map = nmf.maps_.isel(component=[comp])
+    component_map = nmf.maps_.isel(component=comp, drop=True)
     vmax = float(component_map.max())
-    cf.plotting.plot_volume(
-        component_map,
-        axes=fig.add_subplot(gs[i, 0]),
-        slice_mode="component",
-        cmap="viridis",
-        vmin=0,
-        vmax=vmax,
-        show_axes=False,
-        show_colorbar=False,
-        show_titles=False,
-        bg_color=bg_color,
-    )
+    map_gs = gs[i, 0].subgridspec(1, 2, wspace=0.02)
+
+    for j, sign in enumerate(["pos", "neg"]):
+        cf.plotting.plot_volume(
+            component_map.sel(sign=sign, drop=True),
+            axes=fig.add_subplot(map_gs[0, j]),
+            slice_mode="z",
+            cmap="viridis",
+            vmin=0,
+            vmax=vmax,
+            show_axes=False,
+            show_colorbar=False,
+            show_titles=False,
+            bg_color=bg_color,
+        )
 
     signals.sel(component=comp).plot(ax=axes_tc[i], lw=1.1)
     axes_tc[i].set_title(f"Component {comp + 1}")
@@ -169,7 +170,8 @@ for ax in axes_tc[:-1]:
     ax.tick_params(labelbottom=False)
 axes_tc[-1].set_xlabel("Time (s)")
 _ = fig.suptitle(
-    "Temporal NMF: spatial maps and time courses (first 10 components)", fontsize=21
+    "Temporal NMF: positive/negative maps and time courses (first 10 components)",
+    fontsize=21,
 )
 
 # %% [markdown]
@@ -177,48 +179,54 @@ _ = fig.suptitle(
 #
 # [`NMF`][confusius.decomposition.NMF] also accepts `mode="spatial"`, which transposes
 # the data to `(voxels, time)` before fitting. The output convention is identical to
-# temporal mode — [`maps_`][confusius.decomposition.NMF] holds the non-negative spatial
-# maps and [`fit_transform`][confusius.decomposition.NMF.fit_transform] returns their
+# temporal mode — [`maps_`][confusius.decomposition.NMF] still holds the non-negative
+# spatial maps (here with `pos`/`neg` channels) and
+# [`fit_transform`][confusius.decomposition.NMF.fit_transform] returns their
 # non-negative time courses — so the choice between the two modes mirrors the
 # temporal/spatial choice offered by [PCA](pca_single_recording.md) and
 # [FastICA](fastica_single_recording.md).
 
 # %%
-nmf_spatial = NMF(n_components=10, mode="spatial", random_state=0, max_iter=500)
+nmf_spatial = cf.decomposition.NMF(
+    n_components=10, mode="spatial", random_state=0, max_iter=500
+)
 signals_s = nmf_spatial.fit_transform(data_nmf)
 signals_s
 
 # %% [markdown]
 # ### Spatial maps and time courses
 #
-# As in temporal mode, we inspect the spatial maps and their corresponding time courses
-# side by side.
+# As in temporal mode, we inspect the positive and negative spatial maps and their
+# corresponding time courses side by side.
 
 # %%
 n_show = 10
-fig = plt.figure(figsize=(10.5, 12.0), constrained_layout=True)
+fig = plt.figure(figsize=(11.5, 12.0), constrained_layout=True)
 fig.patch.set_facecolor(bg_color)
-gs = fig.add_gridspec(n_show, 2, width_ratios=[1, 3])
+gs = fig.add_gridspec(n_show, 2, width_ratios=[1.4, 3])
 
 axes_tc = [fig.add_subplot(gs[i, 1]) for i in range(n_show)]
 for ax in axes_tc[1:]:
     ax.sharex(axes_tc[0])
 
 for i, comp in enumerate(range(n_show)):
-    component_map = nmf_spatial.maps_.isel(component=[comp])
+    component_map = nmf_spatial.maps_.isel(component=comp, drop=True)
     vmax = float(component_map.max())
-    cf.plotting.plot_volume(
-        component_map,
-        axes=fig.add_subplot(gs[i, 0]),
-        slice_mode="component",
-        cmap="viridis",
-        vmin=0,
-        vmax=vmax,
-        show_axes=False,
-        show_colorbar=False,
-        show_titles=False,
-        bg_color=bg_color,
-    )
+    map_gs = gs[i, 0].subgridspec(1, 2, wspace=0.02)
+
+    for j, sign in enumerate(["pos", "neg"]):
+        cf.plotting.plot_volume(
+            component_map.sel(sign=sign, drop=True),
+            axes=fig.add_subplot(map_gs[0, j]),
+            slice_mode="z",
+            cmap="viridis",
+            vmin=0,
+            vmax=vmax,
+            show_axes=False,
+            show_colorbar=False,
+            show_titles=False,
+            bg_color=bg_color,
+        )
 
     signals_s.sel(component=comp).plot(ax=axes_tc[i], lw=1.1)
     axes_tc[i].set_title(f"Component {comp + 1}")
@@ -229,7 +237,8 @@ for ax in axes_tc[:-1]:
     ax.tick_params(labelbottom=False)
 axes_tc[-1].set_xlabel("Time (s)")
 _ = fig.suptitle(
-    "Spatial NMF: spatial maps and time courses (first 10 components)", fontsize=21
+    "Spatial NMF: positive/negative maps and time courses (first 10 components)",
+    fontsize=21,
 )
 
 # %% [markdown]

--- a/docs/examples/03_decomposition/03_nmf_single_recording.py
+++ b/docs/examples/03_decomposition/03_nmf_single_recording.py
@@ -176,16 +176,61 @@ _ = fig.suptitle(
 # ## Spatial NMF
 #
 # [`NMF`][confusius.decomposition.NMF] also accepts `mode="spatial"`, which transposes
-# the data to `(voxels, time)` before fitting. In this orientation, the dictionaries
-# are non-negative time courses and the projected signals are non-negative spatial
-# maps. The rest of the API is identical and the choice between the two modes mirrors
-# the temporal/spatial choice offered by [PCA](pca_single_recording.md) and
+# the data to `(voxels, time)` before fitting. The output convention is identical to
+# temporal mode — [`maps_`][confusius.decomposition.NMF] holds the non-negative spatial
+# maps and [`fit_transform`][confusius.decomposition.NMF.fit_transform] returns their
+# non-negative time courses — so the choice between the two modes mirrors the
+# temporal/spatial choice offered by [PCA](pca_single_recording.md) and
 # [FastICA](fastica_single_recording.md).
 
 # %%
 nmf_spatial = NMF(n_components=10, mode="spatial", random_state=0, max_iter=500)
-spatial_maps = nmf_spatial.fit_transform(data_nmf)
-spatial_maps
+signals_s = nmf_spatial.fit_transform(data_nmf)
+signals_s
+
+# %% [markdown]
+# ### Spatial maps and time courses
+#
+# As in temporal mode, we inspect the spatial maps and their corresponding time courses
+# side by side.
+
+# %%
+n_show = 10
+fig = plt.figure(figsize=(10.5, 12.0), constrained_layout=True)
+fig.patch.set_facecolor(bg_color)
+gs = fig.add_gridspec(n_show, 2, width_ratios=[1, 3])
+
+axes_tc = [fig.add_subplot(gs[i, 1]) for i in range(n_show)]
+for ax in axes_tc[1:]:
+    ax.sharex(axes_tc[0])
+
+for i, comp in enumerate(range(n_show)):
+    component_map = nmf_spatial.maps_.isel(component=[comp])
+    vmax = float(component_map.max())
+    cf.plotting.plot_volume(
+        component_map,
+        axes=fig.add_subplot(gs[i, 0]),
+        slice_mode="component",
+        cmap="viridis",
+        vmin=0,
+        vmax=vmax,
+        show_axes=False,
+        show_colorbar=False,
+        show_titles=False,
+        bg_color=bg_color,
+    )
+
+    signals_s.sel(component=comp).plot(ax=axes_tc[i], lw=1.1)
+    axes_tc[i].set_title(f"Component {comp + 1}")
+    axes_tc[i].set_ylabel("Signal")
+    axes_tc[i].set_xlabel("")
+
+for ax in axes_tc[:-1]:
+    ax.tick_params(labelbottom=False)
+axes_tc[-1].set_xlabel("Time (s)")
+_ = fig.suptitle(
+    "Spatial NMF: spatial maps and time courses (first 10 components)", fontsize=21
+)
 
 # %% [markdown]
 # [^1]: Lee, D. D., and Seung, H. S. (1999). "Learning the parts of objects by

--- a/docs/examples/03_decomposition/_section.md
+++ b/docs/examples/03_decomposition/_section.md
@@ -1,4 +1,4 @@
 # Decomposition
 
 Extracting spatiotemporal structure from fUSI recordings using dimensionality reduction
-techniques such as PCA and FastICA.
+techniques such as PCA, FastICA, and NMF.

--- a/docs/includes/abbreviations.md
+++ b/docs/includes/abbreviations.md
@@ -7,7 +7,9 @@
 *[SVD]: Singular Value Decomposition
 *[PCA]: Principal Component Analysis
 *[ICA]: Independent Component Analysis
+*[IC]: Independent Component
 *[NMF]: Non-negative Matrix Factorization
+*[NNDSVD]: Non-negative Double Singular Value Decomposition
 *[GLM]: General Linear Model
 *[GLMs]: General Linear Models
 *[OLS]: Ordinary Least Squares

--- a/docs/includes/abbreviations.md
+++ b/docs/includes/abbreviations.md
@@ -7,6 +7,7 @@
 *[SVD]: Singular Value Decomposition
 *[PCA]: Principal Component Analysis
 *[ICA]: Independent Component Analysis
+*[NMF]: Non-negative Matrix Factorization
 *[GLM]: General Linear Model
 *[GLMs]: General Linear Models
 *[OLS]: Ordinary Least Squares

--- a/src/confusius/decomposition/__init__.py
+++ b/src/confusius/decomposition/__init__.py
@@ -1,9 +1,11 @@
 """Decomposition techniques for fUSI data."""
 
 from confusius.decomposition.fastica import FastICA
+from confusius.decomposition.nmf import NMF
 from confusius.decomposition.pca import PCA
 
 __all__ = [
     "FastICA",
+    "NMF",
     "PCA",
 ]

--- a/src/confusius/decomposition/nmf.py
+++ b/src/confusius/decomposition/nmf.py
@@ -79,6 +79,8 @@ class NMF(_BaseFUSIDecomposer):
     mask : xarray.DataArray, optional
         Boolean spatial mask selecting voxels to include during fitting and projection.
         Must match the spatial dimensions and coordinates of the input data.
+    verbose : int, default: 0
+        Whether to be verbose.
 
     Attributes
     ----------
@@ -156,6 +158,7 @@ class NMF(_BaseFUSIDecomposer):
         l1_ratio: float = 0.0,
         mode: Literal["temporal", "spatial"] = "temporal",
         mask: xr.DataArray | None = None,
+        verbose: int = 0,
     ) -> None:
         self.n_components = n_components
         self.init = init
@@ -169,6 +172,7 @@ class NMF(_BaseFUSIDecomposer):
         self.l1_ratio = l1_ratio
         self.mode = mode
         self.mask = mask
+        self.verbose = verbose
 
     def fit(self, X: xr.DataArray, y: None = None) -> "NMF":
         """Fit NMF on `(time, ...)` fUSI data.
@@ -223,6 +227,7 @@ class NMF(_BaseFUSIDecomposer):
             alpha_W=self.alpha_W,
             alpha_H=self.alpha_H,
             l1_ratio=self.l1_ratio,
+            verbose=self.verbose,
         )
 
         self._store_fit_metadata(X, X_proc, spatial_dims, feature_mask)

--- a/src/confusius/decomposition/nmf.py
+++ b/src/confusius/decomposition/nmf.py
@@ -34,10 +34,10 @@ class NMF(_BaseFUSIDecomposer):
         Number of components to keep. If not set, `n_components == min(n_samples,
         n_features)`. Note that NMF does not support a fractional `n_components` or
         `"mle"`: it must be an integer or `"auto"`.
-    init : {"auto", "nndsvda", "nndsvdar", "random"}, default: "auto"
-        Method used to initialize the procedure. `"auto"` lets sklearn pick `"nndsvda"`
-        for non-negative sparse data and `"random"` otherwise. `"nndsvda"` (or its
-        randomized variant `"nndsvdar"`) is a good default for sparse fUSI Power
+    init : {"nndsvda", "nndsvdar", "random"}, optional
+        Method used to initialize the procedure. If not set, lets sklearn pick
+        `"nndsvda"` for non-negative sparse data and `"random"` otherwise. `"nndsvda"`
+        (or its randomized variant `"nndsvdar"`) is a good default for sparse fUSI Power
         Doppler data.
     solver : {"cd", "mu"}, default: "cd"
         Numerical solver to use: `"cd"` is a Coordinate Descent solver (only one
@@ -143,7 +143,7 @@ class NMF(_BaseFUSIDecomposer):
         self,
         *,
         n_components: int | Literal["auto"] = "auto",
-        init: Literal["auto", "nndsvda", "nndsvdar", "random"] = "auto",
+        init: Literal["nndsvda", "nndsvdar", "random"] | None = None,
         solver: Literal["cd", "mu"] = "cd",
         beta_loss: float | Literal["frobenius", "kullback-leibler", "itakura-saito"] = (
             "frobenius"

--- a/src/confusius/decomposition/nmf.py
+++ b/src/confusius/decomposition/nmf.py
@@ -36,9 +36,7 @@ class NMF(_BaseFUSIDecomposer):
         `"mle"`: it must be an integer or `"auto"`.
     init : {"nndsvda", "nndsvdar", "random"}, optional
         Method used to initialize the procedure. If not set, lets sklearn pick
-        `"nndsvda"` for non-negative sparse data and `"random"` otherwise. `"nndsvda"`
-        (or its randomized variant `"nndsvdar"`) is a good default for sparse fUSI Power
-        Doppler data.
+        `"nndsvda"` for non-negative sparse data and `"random"` otherwise.
     solver : {"cd", "mu"}, default: "cd"
         Numerical solver to use: `"cd"` is a Coordinate Descent solver (only one
         supporting beta-loss different from `"frobenius"`) while `"mu"` is a

--- a/src/confusius/decomposition/nmf.py
+++ b/src/confusius/decomposition/nmf.py
@@ -11,7 +11,7 @@ from confusius.decomposition._base import _BaseFUSIDecomposer
 
 
 class NMF(_BaseFUSIDecomposer):
-    """Non-negative matrix factorization (NMF) for fUSI data.
+    r"""Non-negative matrix factorization (NMF) for fUSI data.
 
     Find two non-negative matrices, i.e. matrices with all non-negative elements,
     (`W`, `H`) whose product approximates the non-negative matrix `X`. This
@@ -22,21 +22,21 @@ class NMF(_BaseFUSIDecomposer):
 
     $$
         \begin{aligned}
-        L(W, H) &= 0.5 * ||X - WH||_{loss}^2 \\
-                &+ alpha_W * l1_ratio * n_features * ||vec(W)||_1 \\
-                &+ alpha_H * l1_ratio * n_samples * ||vec(H)||_1 \\
-                &+ 0.5 * alpha_W * (1 - l1_ratio) * n_features * ||W||_{F}^2 \\
-                &+ 0.5 * alpha_H * (1 - l1_ratio) * n_samples * ||H||_{F}^2,
+        L(W, H) &= 0.5 * ||X - WH||_{\text{loss}}^2 \\
+                &+ \alpha_W \, l_{1,\text{ratio}} \, n_{\text{features}} \, ||\mathrm{vec}(W)||_1 \\
+                &+ \alpha_H \, l_{1,\text{ratio}} \, n_{\text{samples}} \, ||\mathrm{vec}(H)||_1 \\
+                &+ 0.5 \, \alpha_W \, (1 - l_{1,\text{ratio}}) \, n_{\text{features}} \, ||W||_{F}^2 \\
+                &+ 0.5 \, \alpha_H \, (1 - l_{1,\text{ratio}}) \, n_{\text{samples}} \, ||H||_{F}^2,
         \end{aligned}
     $$
 
-    where $||A||_{F}^2 = \sum_{i,j} A_{ij}^2$ is the Frobenius norm and
-    $||vec(A)||_1 = \sum_{i,j} abs(A_{ij})$ is the elementwise L1 norm.
+    where $||A||_{F}^2 = \sum_{i,j} A_{ij}^2$ is the Frobenius norm and $||vec(A)||_1 =
+    \sum_{i,j} abs(A_{ij})$ is the elementwise L1 norm.
 
-    The generic norm `||X - WH||_loss` may represent the Frobenius norm or
-    another supported beta-divergence loss. The regularization terms are scaled
-    by `n_features` for `W` and by `n_samples` for `H` to keep their impact
-    balanced with respect to one another and to the data fit term.
+    The generic norm `||X - WH||_{\text{loss}}` may represent the Frobenius norm or
+    another supported beta-divergence loss. The regularization terms are scaled by
+    `n_features` for `W` and by `n_samples` for `H` to keep their impact balanced with
+    respect to one another and to the data fit term.
 
     This estimator wraps [`sklearn.decomposition.NMF`][sklearn.decomposition.NMF]
     while keeping xarray metadata through

--- a/src/confusius/decomposition/nmf.py
+++ b/src/confusius/decomposition/nmf.py
@@ -156,6 +156,18 @@ class NMF(_BaseFUSIDecomposer):
     the fitted spatial maps, so that `transform` and `inverse_transform` keep the same
     public API in both modes.
 
+    References
+    ----------
+    [^1]:
+        Cichocki, A., and Anh-Huy, P. H. A. N. (2009). "Fast local algorithms
+        for large scale nonnegative matrix and tensor factorizations". IEICE
+        Transactions on Fundamentals of Electronics, Communications and Computer
+        Sciences, 92(3), 708-721.
+
+    [^2]:
+        Fevotte, C., and Idier, J. (2011). "Algorithms for nonnegative matrix
+        factorization with the beta-divergence". Neural Computation, 23(9).
+
     Examples
     --------
     >>> import numpy as np

--- a/src/confusius/decomposition/nmf.py
+++ b/src/confusius/decomposition/nmf.py
@@ -13,15 +13,35 @@ from confusius.decomposition._base import _BaseFUSIDecomposer
 class NMF(_BaseFUSIDecomposer):
     """Non-negative matrix factorization (NMF) for fUSI data.
 
-    Linear dimensionality reduction that factorizes a non-negative data matrix into two
-    non-negative factors: a dictionary of spatial maps (`maps_`) and their associated
-    non-negative temporal signals. The decomposition is computed by minimizing the
-    Frobenius norm (or a beta-divergence, depending on the `beta_loss` parameter)
-    between the input data and the reconstructed product of the two factors.
+    Find two non-negative matrices, i.e. matrices with all non-negative elements,
+    (`W`, `H`) whose product approximates the non-negative matrix `X`. This
+    factorization can be used for example for dimensionality reduction, source
+    separation, or topic extraction.
 
-    This estimator wraps [`sklearn.decomposition.NMF`][sklearn.decomposition.NMF] while
-    keeping xarray metadata through [`transform`][confusius.decomposition.NMF.transform]
-    and [`inverse_transform`][confusius.decomposition.NMF.inverse_transform]:
+    The objective function is:
+
+    $$
+        \begin{aligned}
+        L(W, H) &= 0.5 * ||X - WH||_{loss}^2 \\
+                &+ alpha_W * l1_ratio * n_features * ||vec(W)||_1 \\
+                &+ alpha_H * l1_ratio * n_samples * ||vec(H)||_1 \\
+                &+ 0.5 * alpha_W * (1 - l1_ratio) * n_features * ||W||_{F}^2 \\
+                &+ 0.5 * alpha_H * (1 - l1_ratio) * n_samples * ||H||_{F}^2,
+        \end{aligned}
+    $$
+
+    where $||A||_{F}^2 = \sum_{i,j} A_{ij}^2$ is the Frobenius norm and
+    $||vec(A)||_1 = \sum_{i,j} abs(A_{ij})$ is the elementwise L1 norm.
+
+    The generic norm `||X - WH||_loss` may represent the Frobenius norm or
+    another supported beta-divergence loss. The regularization terms are scaled
+    by `n_features` for `W` and by `n_samples` for `H` to keep their impact
+    balanced with respect to one another and to the data fit term.
+
+    This estimator wraps [`sklearn.decomposition.NMF`][sklearn.decomposition.NMF]
+    while keeping xarray metadata through
+    [`transform`][confusius.decomposition.NMF.transform] and
+    [`inverse_transform`][confusius.decomposition.NMF.inverse_transform]:
 
     - Input data are expected as `(time, ...)` where `...` are spatial dimensions.
     - `transform` returns a `(time, component)` DataArray.
@@ -30,87 +50,111 @@ class NMF(_BaseFUSIDecomposer):
 
     Parameters
     ----------
-    n_components : int, default: "auto"
-        Number of components to keep. If not set, `n_components == min(n_samples,
-        n_features)`. Note that NMF does not support a fractional `n_components` or
-        `"mle"`: it must be an integer or `"auto"`.
-    init : {"nndsvda", "nndsvdar", "random"}, optional
-        Method used to initialize the procedure. If not set, lets sklearn pick
-        `"nndsvda"` for non-negative sparse data and `"random"` otherwise.
+    n_components : int or {"auto"} or None, default: "auto"
+        Number of components. If `None`, all features are kept. If
+        `n_components="auto"`, the number of components is automatically inferred from
+        `W` or `H` shapes.
+    init : {"random", "nndsvd", "nndsvda", "nndsvdar"}, optional
+        Method used to initialize the procedure.
+
+        - `None`: `"nndsvda"` if `n_components <= min(n_samples, n_features)`,
+          otherwise `"random"`.
+        - `"random"`: non-negative random matrices, scaled with
+          `sqrt(X.mean() / n_components)`.
+        - `"nndsvd"`: non-negative double singular value decomposition (NNDSVD)
+          initialization, better for sparseness.
+        - `"nndsvda"`: NNDSVD with zeros filled with the average of `X`, better when
+          sparsity is not desired.
+        - `"nndsvdar"`: NNDSVD with zeros filled with small random values, generally
+          faster but less accurate than `"nndsvda"` when sparsity is not desired.
+
     solver : {"cd", "mu"}, default: "cd"
-        Numerical solver to use: `"cd"` is a Coordinate Descent solver (only one
-        supporting beta-loss different from `"frobenius"`) while `"mu"` is a
-        Multiplicative Update solver.
+        Numerical solver to use:
+
+        - `"cd"`: coordinate descent solver.
+        - `"mu"`: multiplicative update solver.
+
     beta_loss : float or {"frobenius", "kullback-leibler", "itakura-saito"}, \
             default: "frobenius"
-        Beta divergence to be minimized, measuring the distance between `X` and the
-        dot product `WH`. Note that values different from `"frobenius"` (or
-        `"kullback-leibler"`, `"itakura-saito"` with beta values equal to 1 or 2
-        respectively) are not strictly beta divergences and may lead to significantly
-        slower convergence. See details in the [`sklearn` user guide][sklearn-nmf].
+        Beta divergence to be minimized, measuring the distance between `X` and the dot
+        product `WH`. Note that values different from `"frobenius"` (or `2`) and
+        `"kullback-leibler"` (or `1`) lead to significantly slower fits. Note that for
+        `beta_loss <= 0` (or `"itakura-saito"`), the input matrix `X` cannot contain
+        zeros. Used only in the `"mu"` solver.
     tol : float, default: 1e-4
         Tolerance of the stopping condition.
     max_iter : int, default: 200
         Maximum number of iterations before timing out.
-    random_state : int, optional
-        Used for initialisation when `init == "random"` and for `"nndsvdar"`. Pass an
-        int for reproducible results across multiple function calls.
+    random_state : int or numpy.random.RandomState, optional
+        Used for initialisation (when `init == "nndsvdar"` or `"random"`) and in
+        coordinate descent. Pass an int for reproducible results across multiple
+        function calls.
     alpha_W : float, default: 0.0
-        Constant that multiplies the regularization terms of `W`. Set it to zero (the
-        default) to have no regularization on `W`.
+        Constant that multiplies the regularization terms of `W`. Set it to zero to have
+        no regularization on `W`.
     alpha_H : float or "same", default: "same"
-        Constant that multiplies the regularization terms of `H`. If `"same"` (the
-        default), the value depends on `alpha_W`: if `alpha_W == 0`, `alpha_H == 0`,
-        else `alpha_H == alpha_W`.
+        Constant that multiplies the regularization terms of `H`. Set it to zero to have
+        no regularization on `H`. If `"same"`, it takes the same value as `alpha_W`.
     l1_ratio : float, default: 0.0
-        The regularization mixing parameter, with `0 <= l1_ratio <= 1`. For `l1_ratio
-        == 0` the penalty is an elementwise L2 penalty (aka Frobenius Norm). For
-        `l1_ratio == 1` it is an elementwise L1 penalty. For `0 < l1_ratio < 1`, the
-        penalty is a combination of L1 and L2.
+        The regularization mixing parameter, with `0 <= l1_ratio <= 1`.
+
+        - For `l1_ratio = 0`, the penalty is an elementwise L2 penalty (aka
+          Frobenius Norm).
+        - For `l1_ratio = 1`, it is an elementwise L1 penalty.
+        - For `0 < l1_ratio < 1`, the penalty is a combination of L1 and L2.
+
+    verbose : int, default: 0
+        Whether to be verbose.
+    shuffle : bool, default: False
+        Whether to randomize the order of coordinates in the coordinate descent solver.
     mode : {"temporal", "spatial"}, default: "temporal"
         Whether to fit NMF along temporal or spatial orientation:
 
-        - `"temporal"`: fit on `(time, voxels)`. The dictionaries are spatial maps; the
-          component signals are non-negative temporal time courses.
-        - `"spatial"`: fit on `(voxels, time)`. The dictionaries are non-negative time
-          courses; the component signals are spatial maps.
+        - `"temporal"`: fit on `(time, voxels)`. The transformed data `W` are
+          non-negative temporal time courses and the components matrix `H` reshapes to
+          spatial maps.
+        - `"spatial"`: fit on `(voxels, time)`. In the underlying sklearn fit, `W` lives
+          on voxels and `H` lives on timepoints because the data matrix is transposed.
+          This wrapper still exposes `maps_` as spatial maps and `transform` as `(time,
+          component)` signals.
+
     mask : xarray.DataArray, optional
         Boolean spatial mask selecting voxels to include during fitting and projection.
         Must match the spatial dimensions and coordinates of the input data.
-    verbose : int, default: 0
-        Whether to be verbose.
 
     Attributes
     ----------
     maps_ : (n_components, ...) xarray.DataArray
-        Non-negative dictionary elements, sorted by decreasing reconstruction
-        contribution. In `"temporal"` mode these are spatial maps; in `"spatial"` mode
-        these are time courses. Reshaped to the fitted spatial geometry.
+        Non-negative component maps reshaped to the original spatial geometry.
+
+        - In `"temporal"` mode: the components matrix `H`, interpreted as spatial maps.
+        - In `"spatial"` mode: spatial projection maps derived from the fitted NMF model
+          on transposed data.
     n_components_ : int
-        The estimated number of components. When `n_components` is `"auto"`, this is
-        `min(n_samples, n_features)`.
-    n_iter_ : int
-        Actual number of iterations run by the solver.
+        The number of components. It is the same as the `n_components` parameter if it
+        was given. Otherwise, it is inferred from the fitted factorization.
     reconstruction_err_ : float
-        Frobenius norm of the matrix difference between the training data and the
-        reconstructed data from the fit, equal to `||X - WH||_F`.
+        Frobenius norm of the matrix difference, or beta-divergence, between the
+        training data `X` and the reconstructed data `WH` from the fitted model.
+    n_iter_ : int
+        Actual number of iterations.
     n_features_in_ : int
         Number of features seen during fit.
     feature_names_in_ : (n_features_in_,) numpy.ndarray
-        Feature names seen during fit. Defined only when flattened feature labels are
-        all strings.
+        Names of features seen during fit. Defined only when flattened feature
+        labels are all strings.
 
     Notes
     -----
-    NMF requires strictly non-negative input data. fUSI Power Doppler signals are
-    non-negative by construction. The wrapper raises a clear `ValueError` if the
-    (masked) input data contains negative values.
+    In sklearn's notation, the transformed data are named `W` and the components matrix
+    is named `H`. In much of the NMF literature the convention is often the opposite
+    because the data matrix is transposed.
 
-    The `"spatial"` mode fits NMF on the transposed data and exposes a manual
-    projection rather than relying on `sklearn.decomposition.NMF.transform`, because
-    `sklearn`'s NMF `transform` is only defined for `(n_samples, n_features)` input.
-    As a consequence, `transform` and `inverse_transform` do not call into
-    `sklearn.decomposition.NMF` in `"spatial"` mode.
+    In `"spatial"` mode, the estimator is still fitted with `sklearn.decomposition.NMF`,
+    but on the transposed data matrix `(voxels, time)`. The wrapper then computes
+    `(time, component)` signals by projecting the original `(time, voxel)` matrix onto
+    the fitted spatial maps, so that `transform` and `inverse_transform` keep the same
+    public API in both modes.
 
     Examples
     --------
@@ -142,21 +186,22 @@ class NMF(_BaseFUSIDecomposer):
     def __init__(
         self,
         *,
-        n_components: int | Literal["auto"] = "auto",
-        init: Literal["nndsvda", "nndsvdar", "random"] | None = None,
+        n_components: int | Literal["auto"] | None = "auto",
+        init: Literal["random", "nndsvd", "nndsvda", "nndsvdar"] | None = None,
         solver: Literal["cd", "mu"] = "cd",
         beta_loss: float | Literal["frobenius", "kullback-leibler", "itakura-saito"] = (
             "frobenius"
         ),
         tol: float = 1e-4,
         max_iter: int = 200,
-        random_state: int | None = None,
+        random_state: int | np.random.RandomState | None = None,
         alpha_W: float = 0.0,
         alpha_H: float | Literal["same"] = "same",
         l1_ratio: float = 0.0,
+        verbose: int = 0,
+        shuffle: bool = False,
         mode: Literal["temporal", "spatial"] = "temporal",
         mask: xr.DataArray | None = None,
-        verbose: int = 0,
     ) -> None:
         self.n_components = n_components
         self.init = init
@@ -168,9 +213,10 @@ class NMF(_BaseFUSIDecomposer):
         self.alpha_W = alpha_W
         self.alpha_H = alpha_H
         self.l1_ratio = l1_ratio
+        self.verbose = verbose
+        self.shuffle = shuffle
         self.mode = mode
         self.mask = mask
-        self.verbose = verbose
 
     def fit(self, X: xr.DataArray, y: None = None) -> "NMF":
         """Fit NMF on `(time, ...)` fUSI data.
@@ -226,6 +272,7 @@ class NMF(_BaseFUSIDecomposer):
             alpha_H=self.alpha_H,
             l1_ratio=self.l1_ratio,
             verbose=self.verbose,
+            shuffle=self.shuffle,
         )
 
         self._store_fit_metadata(X, X_proc, spatial_dims, feature_mask)

--- a/src/confusius/decomposition/nmf.py
+++ b/src/confusius/decomposition/nmf.py
@@ -1,0 +1,282 @@
+"""Non-negative matrix factorization for `(time, ...)` fUSI DataArrays."""
+
+from typing import Literal
+
+import numpy as np
+import numpy.typing as npt
+import xarray as xr
+from sklearn.decomposition import NMF as _SklearnNMF
+
+from confusius.decomposition._base import _BaseFUSIDecomposer
+
+
+class NMF(_BaseFUSIDecomposer):
+    """Non-negative matrix factorization (NMF) for fUSI data.
+
+    Linear dimensionality reduction that factorizes a non-negative data matrix into two
+    non-negative factors: a dictionary of spatial maps (`maps_`) and their associated
+    non-negative temporal signals. The decomposition is computed by minimizing the
+    Frobenius norm (or a beta-divergence, depending on the `beta_loss` parameter)
+    between the input data and the reconstructed product of the two factors.
+
+    This estimator wraps [`sklearn.decomposition.NMF`][sklearn.decomposition.NMF] while
+    keeping xarray metadata through [`transform`][confusius.decomposition.NMF.transform]
+    and [`inverse_transform`][confusius.decomposition.NMF.inverse_transform]:
+
+    - Input data are expected as `(time, ...)` where `...` are spatial dimensions.
+    - `transform` returns a `(time, component)` DataArray.
+    - `inverse_transform` reconstructs to `(time, ...)` using the fitted spatial
+      coordinates.
+
+    Parameters
+    ----------
+    n_components : int, default: "auto"
+        Number of components to keep. If not set, `n_components == min(n_samples,
+        n_features)`. Note that NMF does not support a fractional `n_components` or
+        `"mle"`: it must be an integer or `"auto"`.
+    init : {"auto", "nndsvda", "nndsvdar", "random"}, default: "auto"
+        Method used to initialize the procedure. `"auto"` lets sklearn pick `"nndsvda"`
+        for non-negative sparse data and `"random"` otherwise. `"nndsvda"` (or its
+        randomized variant `"nndsvdar"`) is a good default for sparse fUSI Power
+        Doppler data.
+    solver : {"cd", "mu"}, default: "cd"
+        Numerical solver to use: `"cd"` is a Coordinate Descent solver (only one
+        supporting beta-loss different from `"frobenius"`) while `"mu"` is a
+        Multiplicative Update solver.
+    beta_loss : float or {"frobenius", "kullback-leibler", "itakura-saito"}, \
+            default: "frobenius"
+        Beta divergence to be minimized, measuring the distance between `X` and the
+        dot product `WH`. Note that values different from `"frobenius"` (or
+        `"kullback-leibler"`, `"itakura-saito"` with beta values equal to 1 or 2
+        respectively) are not strictly beta divergences and may lead to significantly
+        slower convergence. See details in the [`sklearn` user guide][sklearn-nmf].
+    tol : float, default: 1e-4
+        Tolerance of the stopping condition.
+    max_iter : int, default: 200
+        Maximum number of iterations before timing out.
+    random_state : int, optional
+        Used for initialisation when `init == "random"` and for `"nndsvdar"`. Pass an
+        int for reproducible results across multiple function calls.
+    alpha_W : float, default: 0.0
+        Constant that multiplies the regularization terms of `W`. Set it to zero (the
+        default) to have no regularization on `W`.
+    alpha_H : float or "same", default: "same"
+        Constant that multiplies the regularization terms of `H`. If `"same"` (the
+        default), the value depends on `alpha_W`: if `alpha_W == 0`, `alpha_H == 0`,
+        else `alpha_H == alpha_W`.
+    l1_ratio : float, default: 0.0
+        The regularization mixing parameter, with `0 <= l1_ratio <= 1`. For `l1_ratio
+        == 0` the penalty is an elementwise L2 penalty (aka Frobenius Norm). For
+        `l1_ratio == 1` it is an elementwise L1 penalty. For `0 < l1_ratio < 1`, the
+        penalty is a combination of L1 and L2.
+    mode : {"temporal", "spatial"}, default: "temporal"
+        Whether to fit NMF along temporal or spatial orientation:
+
+        - `"temporal"`: fit on `(time, voxels)`. The dictionaries are spatial maps; the
+          component signals are non-negative temporal time courses.
+        - `"spatial"`: fit on `(voxels, time)`. The dictionaries are non-negative time
+          courses; the component signals are spatial maps.
+    mask : xarray.DataArray, optional
+        Boolean spatial mask selecting voxels to include during fitting and projection.
+        Must match the spatial dimensions and coordinates of the input data.
+
+    Attributes
+    ----------
+    maps_ : (n_components, ...) xarray.DataArray
+        Non-negative dictionary elements, sorted by decreasing reconstruction
+        contribution. In `"temporal"` mode these are spatial maps; in `"spatial"` mode
+        these are time courses. Reshaped to the fitted spatial geometry.
+    n_components_ : int
+        The estimated number of components. When `n_components` is `"auto"`, this is
+        `min(n_samples, n_features)`.
+    n_iter_ : int
+        Actual number of iterations run by the solver.
+    reconstruction_err_ : float
+        Frobenius norm of the matrix difference between the training data and the
+        reconstructed data from the fit, equal to `||X - WH||_F`.
+    n_features_in_ : int
+        Number of features seen during fit.
+    feature_names_in_ : (n_features_in_,) numpy.ndarray
+        Feature names seen during fit. Defined only when flattened feature labels are
+        all strings.
+
+    Notes
+    -----
+    NMF requires strictly non-negative input data. fUSI Power Doppler signals are
+    non-negative by construction. The wrapper raises a clear `ValueError` if the
+    (masked) input data contains negative values.
+
+    The `"spatial"` mode fits NMF on the transposed data and exposes a manual
+    projection rather than relying on `sklearn.decomposition.NMF.transform`, because
+    `sklearn`'s NMF `transform` is only defined for `(n_samples, n_features)` input.
+    As a consequence, `transform` and `inverse_transform` do not call into
+    `sklearn.decomposition.NMF` in `"spatial"` mode.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import xarray as xr
+    >>> from confusius.decomposition import NMF
+    >>>
+    >>> rng = np.random.default_rng(0)
+    >>> k = 5
+    >>> n_t, n_z, n_y, n_x = 200, 4, 6, 8
+    >>> temporal = rng.random((n_t, k))
+    >>> spatial = rng.random((k, n_z * n_y * n_x))
+    >>> data = xr.DataArray(
+    ...     (10.0 * (temporal @ spatial) + 1.0).reshape(n_t, n_z, n_y, n_x),
+    ...     dims=["time", "z", "y", "x"],
+    ... )
+    >>>
+    >>> nmf = NMF(n_components=k, init="nndsvda", random_state=0)
+    >>> signals = nmf.fit_transform(data)
+    >>> signals.dims
+    ('time', 'component')
+    >>> reconstructed = nmf.inverse_transform(signals)
+    >>> reconstructed.dims
+    ('time', 'z', 'y', 'x')
+    """
+
+    _signals_long_name = "NMF signals"
+
+    def __init__(
+        self,
+        *,
+        n_components: int | Literal["auto"] = "auto",
+        init: Literal["auto", "nndsvda", "nndsvdar", "random"] = "auto",
+        solver: Literal["cd", "mu"] = "cd",
+        beta_loss: float | Literal["frobenius", "kullback-leibler", "itakura-saito"] = (
+            "frobenius"
+        ),
+        tol: float = 1e-4,
+        max_iter: int = 200,
+        random_state: int | None = None,
+        alpha_W: float = 0.0,
+        alpha_H: float | Literal["same"] = "same",
+        l1_ratio: float = 0.0,
+        mode: Literal["temporal", "spatial"] = "temporal",
+        mask: xr.DataArray | None = None,
+    ) -> None:
+        self.n_components = n_components
+        self.init = init
+        self.solver = solver
+        self.beta_loss = beta_loss
+        self.tol = tol
+        self.max_iter = max_iter
+        self.random_state = random_state
+        self.alpha_W = alpha_W
+        self.alpha_H = alpha_H
+        self.l1_ratio = l1_ratio
+        self.mode = mode
+        self.mask = mask
+
+    def fit(self, X: xr.DataArray, y: None = None) -> "NMF":
+        """Fit NMF on `(time, ...)` fUSI data.
+
+        Parameters
+        ----------
+        X : (time, ...) xarray.DataArray
+            Input fUSI data. Must be non-negative.
+        y : None, optional
+            Ignored. Present for scikit-learn API compatibility.
+
+        Returns
+        -------
+        NMF
+            Fitted estimator.
+
+        Raises
+        ------
+        ValueError
+            If input has no `time` dimension, fewer than 2 timepoints, no spatial
+            dimensions, contains negative values, or `mode` is not `"temporal"` or
+            `"spatial"`.
+        """
+        del y
+
+        if self.mode not in {"temporal", "spatial"}:
+            raise ValueError(
+                f"mode must be 'temporal' or 'spatial', got '{self.mode}'."
+            )
+
+        X_proc, spatial_dims, feature_mask = self._prepare_data(
+            X,
+            check_layout=False,
+            operation_name="NMF.fit",
+        )
+
+        if np.any(X_proc < 0.0):
+            raise ValueError(
+                "NMF requires non-negative input data, but negative values were "
+                f"found along dimensions {spatial_dims}. NMF is typically applied "
+                "to Power Doppler or other non-negative fUSI signals."
+            )
+
+        nmf = _SklearnNMF(
+            n_components=self.n_components,
+            init=self.init,
+            solver=self.solver,
+            beta_loss=self.beta_loss,
+            tol=self.tol,
+            max_iter=self.max_iter,
+            random_state=self.random_state,
+            alpha_W=self.alpha_W,
+            alpha_H=self.alpha_H,
+            l1_ratio=self.l1_ratio,
+        )
+
+        self._store_fit_metadata(X, X_proc, spatial_dims, feature_mask)
+
+        if self.mode == "temporal":
+            self._fit_temporal(nmf, X_proc)
+        else:
+            self._fit_spatial(nmf, X_proc)
+
+        self._store_feature_names(X)
+        return self
+
+    def _fit_temporal(
+        self,
+        nmf: _SklearnNMF,
+        X_proc: npt.NDArray[np.floating],
+    ) -> None:
+        """Fit NMF in temporal orientation `(time, voxel)`."""
+        nmf.fit(X_proc)
+
+        component_coord = np.arange(nmf.components_.shape[0], dtype=np.intp)
+        self.maps_ = self._reshape_component_matrix(
+            nmf.components_,
+            component_coord,
+            long_name="NMF spatial maps",
+        )
+
+        self.n_components_ = int(nmf.n_components_)
+        self.n_iter_ = int(nmf.n_iter_)
+        self.reconstruction_err_ = float(nmf.reconstruction_err_)
+        self._estimator = nmf
+
+    def _fit_spatial(
+        self,
+        nmf: _SklearnNMF,
+        X_proc: npt.NDArray[np.floating],
+    ) -> None:
+        """Fit NMF in spatial orientation `(voxel, time)`."""
+        nmf.fit(X_proc.T)
+
+        spatial_maps_flat: npt.NDArray[np.floating] = nmf.transform(X_proc.T).T
+        voxel_mean: npt.NDArray[np.floating] = X_proc.mean(axis=0)
+
+        component_coord = np.arange(spatial_maps_flat.shape[0], dtype=np.intp)
+        self.maps_ = self._reshape_component_matrix(
+            spatial_maps_flat,
+            component_coord,
+            long_name="NMF spatial maps",
+        )
+        self.mean_ = self._reshape_mean(voxel_mean)
+
+        self.n_components_ = int(spatial_maps_flat.shape[0])
+        self.n_iter_ = int(nmf.n_iter_)
+        self.reconstruction_err_ = float(nmf.reconstruction_err_)
+        self._spatial_components_flat_ = spatial_maps_flat
+        self._spatial_feature_mean_ = voxel_mean
+        self._estimator = nmf

--- a/tests/unit/test_decomposition/test_nmf.py
+++ b/tests/unit/test_decomposition/test_nmf.py
@@ -61,7 +61,7 @@ def test_feature_names_in_for_string_feature_labels(nmf_3dt_volume):
         .assign_coords(region=["A", "B", "C", "D", "E", "F"])
     )
 
-    model = NMF(n_components=2, init="nndsvda", random_state=0).fit(data)
+    model = NMF(n_components=2, random_state=0).fit(data)
 
     np.testing.assert_array_equal(
         model.feature_names_in_,
@@ -72,10 +72,10 @@ def test_feature_names_in_for_string_feature_labels(nmf_3dt_volume):
 @pytest.mark.parametrize("mode", ["temporal", "spatial"])
 def test_fit_transform_matches_fit_then_transform(nmf_3dt_volume, mode):
     """fit_transform matches calling fit followed by transform."""
-    model_direct = NMF(n_components=3, init="nndsvda", random_state=0, mode=mode)
+    model_direct = NMF(n_components=3, random_state=0, mode=mode)
     direct = model_direct.fit_transform(nmf_3dt_volume)
 
-    model_two_step = NMF(n_components=3, init="nndsvda", random_state=0, mode=mode)
+    model_two_step = NMF(n_components=3, random_state=0, mode=mode)
     two_step = model_two_step.fit(nmf_3dt_volume).transform(nmf_3dt_volume)
 
     xr.testing.assert_identical(direct, two_step)
@@ -88,8 +88,8 @@ def test_wrapper_matches_sklearn_attributes(nmf_3dt_volume):
     )
     X = np.asarray(stacked.values, dtype=np.float64)
 
-    model = NMF(n_components=3, init="nndsvda", random_state=0).fit(nmf_3dt_volume)
-    sklearn_model = SklearnNMF(n_components=3, init="nndsvda", random_state=0).fit(X)
+    model = NMF(n_components=3, random_state=0).fit(nmf_3dt_volume)
+    sklearn_model = SklearnNMF(n_components=3, random_state=0).fit(X)
 
     np.testing.assert_allclose(
         model.transform(nmf_3dt_volume).values,
@@ -115,15 +115,7 @@ def test_fit_raises_for_negative_input():
     )
 
     with pytest.raises(ValueError, match="non-negative input data"):
-        NMF(n_components=3, init="nndsvda", random_state=0).fit(data)
-
-
-def test_fit_raises_for_negative_input_under_mask(nmf_3dt_volume):
-    """fit raises ValueError when masked voxels contain negative values."""
-    data = nmf_3dt_volume - 20.0
-
-    with pytest.raises(ValueError, match="non-negative input data"):
-        NMF(n_components=3, init="nndsvda", random_state=0).fit(data)
+        NMF(n_components=3, random_state=0).fit(data)
 
 
 def test_inverse_transform_matches_sklearn_temporal(nmf_3dt_volume):
@@ -133,15 +125,11 @@ def test_inverse_transform_matches_sklearn_temporal(nmf_3dt_volume):
     )
     X = np.asarray(stacked.values, dtype=np.float64)
 
-    model = NMF(n_components=3, init="nndsvda", random_state=0, mode="temporal")
+    model = NMF(n_components=3, random_state=0, mode="temporal")
     reconstructed = model.inverse_transform(model.fit_transform(nmf_3dt_volume))
 
-    sklearn_model = SklearnNMF(
-        n_components=3, init="nndsvda", random_state=0
-    ).fit(X)
-    sklearn_reconstructed = sklearn_model.inverse_transform(
-        sklearn_model.transform(X)
-    )
+    sklearn_model = SklearnNMF(n_components=3, random_state=0).fit(X)
+    sklearn_reconstructed = sklearn_model.inverse_transform(sklearn_model.transform(X))
 
     np.testing.assert_allclose(
         reconstructed.stack(feature=["z", "y", "x"]).values,
@@ -151,7 +139,7 @@ def test_inverse_transform_matches_sklearn_temporal(nmf_3dt_volume):
 
 def test_inverse_transform_runs_in_fitted_geometry(nmf_3dt_volume):
     """NMF inverse_transform reconstructs in fitted spatial geometry with metadata."""
-    model = NMF(n_components=3, init="nndsvda", random_state=0)
+    model = NMF(n_components=3, random_state=0)
 
     signals = model.fit_transform(nmf_3dt_volume)
     reconstructed = model.inverse_transform(signals)
@@ -166,7 +154,7 @@ def test_inverse_transform_runs_in_fitted_geometry(nmf_3dt_volume):
 
 def test_temporal_mode_signals_and_maps_are_non_negative(nmf_3dt_volume):
     """Temporal-mode signals and maps are non-negative — the defining NMF guarantee."""
-    model = NMF(n_components=3, init="nndsvda", random_state=0, mode="temporal")
+    model = NMF(n_components=3, random_state=0, mode="temporal")
     signals = model.fit_transform(nmf_3dt_volume)
 
     assert float(signals.min()) >= 0.0
@@ -175,7 +163,7 @@ def test_temporal_mode_signals_and_maps_are_non_negative(nmf_3dt_volume):
 
 def test_inverse_transform_from_numpy_returns_dataarray(nmf_3dt_volume):
     """inverse_transform accepts ndarray input and returns DataArray."""
-    model = NMF(n_components=3, init="nndsvda", random_state=0)
+    model = NMF(n_components=3, random_state=0)
     scores = model.fit_transform(nmf_3dt_volume).values
 
     reconstructed = model.inverse_transform(scores)
@@ -189,7 +177,7 @@ def test_inverse_transform_from_numpy_returns_dataarray(nmf_3dt_volume):
 
 def test_inverse_transform_raises_for_invalid_dataarray_dims(nmf_3dt_volume):
     """inverse_transform raises when DataArray dims are not time/component."""
-    model = NMF(n_components=3, init="nndsvda", random_state=0).fit(nmf_3dt_volume)
+    model = NMF(n_components=3, random_state=0).fit(nmf_3dt_volume)
     bad = xr.DataArray(
         np.zeros((nmf_3dt_volume.sizes["time"], 3)),
         dims=["time", "region"],
@@ -201,7 +189,7 @@ def test_inverse_transform_raises_for_invalid_dataarray_dims(nmf_3dt_volume):
 
 def test_inverse_transform_raises_for_component_count_mismatch(nmf_3dt_volume):
     """inverse_transform raises when component count differs from fitted NMF."""
-    model = NMF(n_components=3, init="nndsvda", random_state=0).fit(nmf_3dt_volume)
+    model = NMF(n_components=3, random_state=0).fit(nmf_3dt_volume)
     scores = model.transform(nmf_3dt_volume)
     bad = scores.isel(component=slice(0, 2))
 
@@ -211,7 +199,7 @@ def test_inverse_transform_raises_for_component_count_mismatch(nmf_3dt_volume):
 
 def test_inverse_transform_raises_for_invalid_numpy_shape(nmf_3dt_volume):
     """inverse_transform raises when ndarray input is not 2D."""
-    model = NMF(n_components=3, init="nndsvda", random_state=0).fit(nmf_3dt_volume)
+    model = NMF(n_components=3, random_state=0).fit(nmf_3dt_volume)
 
     with pytest.raises(ValueError, match="must be 2D"):
         model.inverse_transform(np.zeros((nmf_3dt_volume.sizes["time"], 3, 1)))
@@ -219,7 +207,7 @@ def test_inverse_transform_raises_for_invalid_numpy_shape(nmf_3dt_volume):
 
 def test_inverse_transform_raises_for_invalid_input_type(nmf_3dt_volume):
     """inverse_transform raises TypeError for unsupported input types."""
-    model = NMF(n_components=3, init="nndsvda", random_state=0).fit(nmf_3dt_volume)
+    model = NMF(n_components=3, random_state=0).fit(nmf_3dt_volume)
 
     with pytest.raises(TypeError, match="DataArray or ndarray"):
         model.inverse_transform([1, 2, 3])
@@ -292,7 +280,7 @@ def test_fit_transform_rejects_unexpected_fit_params(nmf_3dt_volume):
 
 def test_transform_checks_spatial_layout(nmf_3dt_volume):
     """transform raises if spatial layout differs from fit."""
-    model = NMF(n_components=3, init="nndsvda", random_state=0).fit(nmf_3dt_volume)
+    model = NMF(n_components=3, random_state=0).fit(nmf_3dt_volume)
     bad = nmf_3dt_volume.isel(x=slice(0, 4))
 
     with pytest.raises(ValueError, match="Spatial dimension 'x' has size"):
@@ -301,7 +289,7 @@ def test_transform_checks_spatial_layout(nmf_3dt_volume):
 
 def test_transform_checks_spatial_dimension_names(nmf_3dt_volume):
     """transform raises if spatial dimension names differ from fit."""
-    model = NMF(n_components=3, init="nndsvda", random_state=0).fit(nmf_3dt_volume)
+    model = NMF(n_components=3, random_state=0).fit(nmf_3dt_volume)
     bad = nmf_3dt_volume.rename({"x": "region"})
 
     with pytest.raises(ValueError, match="spatial dimensions do not match"):
@@ -310,7 +298,7 @@ def test_transform_checks_spatial_dimension_names(nmf_3dt_volume):
 
 def test_transform_without_time_coordinate_uses_index(nmf_3dt_volume):
     """transform falls back to integer time coordinate when absent."""
-    model = NMF(n_components=3, init="nndsvda", random_state=0).fit(nmf_3dt_volume)
+    model = NMF(n_components=3, random_state=0).fit(nmf_3dt_volume)
     no_time_coord = xr.DataArray(
         nmf_3dt_volume.values,
         dims=nmf_3dt_volume.dims,
@@ -331,7 +319,7 @@ def test_transform_without_time_coordinate_uses_index(nmf_3dt_volume):
 
 def test_transform_chunked_time_reports_transform_operation(nmf_3dt_volume):
     """transform chunking error message identifies NMF.transform."""
-    model = NMF(n_components=3, init="nndsvda", random_state=0).fit(nmf_3dt_volume)
+    model = NMF(n_components=3, random_state=0).fit(nmf_3dt_volume)
     chunked = nmf_3dt_volume.chunk({"time": 5})
 
     with pytest.raises(ValueError, match="NMF.transform requires the full time series"):
@@ -340,7 +328,7 @@ def test_transform_chunked_time_reports_transform_operation(nmf_3dt_volume):
 
 def test_sklearn_interface_fitted_state(nmf_3dt_volume):
     """Estimator exposes sklearn fitted-state behavior."""
-    model = NMF(n_components=3, init="nndsvda", random_state=0)
+    model = NMF(n_components=3, random_state=0)
     with pytest.raises(Exception):
         check_is_fitted(model)
 
@@ -356,7 +344,7 @@ def test_fit_failure_does_not_mark_estimator_fitted(nmf_3dt_volume, monkeypatch)
 
     monkeypatch.setattr(nmf_module._SklearnNMF, "fit", _raise_fit)
 
-    model = NMF(n_components=3, init="nndsvda", random_state=0)
+    model = NMF(n_components=3, random_state=0)
     with pytest.raises(RuntimeError, match="fit failed"):
         model.fit(nmf_3dt_volume)
 
@@ -412,18 +400,6 @@ def test_set_params_updates_values():
     assert model.mode == "spatial"
 
 
-def test_reproducible_with_random_state(nmf_3dt_volume):
-    """NMF gives reproducible results with a fixed random_state."""
-    model_1 = NMF(n_components=3, init="nndsvda", random_state=0)
-    model_2 = NMF(n_components=3, init="nndsvda", random_state=0)
-
-    signals_1 = model_1.fit_transform(nmf_3dt_volume)
-    signals_2 = model_2.fit_transform(nmf_3dt_volume)
-
-    np.testing.assert_allclose(signals_1.values, signals_2.values)
-    np.testing.assert_allclose(model_1.maps_.values, model_2.maps_.values)
-
-
 def test_spatial_mode_matches_reference_implementation(nmf_3dt_volume):
     """Spatial mode matches sklearn NMF fitted on transposed data."""
     stacked = nmf_3dt_volume.transpose("time", "z", "y", "x").stack(
@@ -431,10 +407,8 @@ def test_spatial_mode_matches_reference_implementation(nmf_3dt_volume):
     )
     X = np.asarray(stacked.values, dtype=np.float64)
 
-    model = NMF(n_components=3, init="nndsvda", random_state=0, mode="spatial").fit(
-        nmf_3dt_volume
-    )
-    sklearn_model = SklearnNMF(n_components=3, init="nndsvda", random_state=0).fit(X.T)
+    model = NMF(n_components=3, random_state=0, mode="spatial").fit(nmf_3dt_volume)
+    sklearn_model = SklearnNMF(n_components=3, random_state=0).fit(X.T)
 
     spatial_maps = sklearn_model.transform(X.T).T
     voxel_mean = X.mean(axis=0)
@@ -483,9 +457,7 @@ def test_mask_restricts_features(nmf_3dt_volume):
     )
     mask.values[:2, :, :] = True
 
-    model = NMF(n_components=3, init="nndsvda", random_state=0, mask=mask).fit(
-        nmf_3dt_volume
-    )
+    model = NMF(n_components=3, random_state=0, mask=mask).fit(nmf_3dt_volume)
 
     assert model.n_features_in_ == int(mask.values.sum())
 
@@ -510,9 +482,7 @@ def test_masked_fit_reconstructs_full_geometry_with_zero_fill(nmf_3dt_volume):
     )
     mask.values[:2, :, :] = True
 
-    model = NMF(n_components=3, init="nndsvda", random_state=0, mask=mask).fit(
-        nmf_3dt_volume
-    )
+    model = NMF(n_components=3, random_state=0, mask=mask).fit(nmf_3dt_volume)
     reconstructed = model.inverse_transform(model.transform(nmf_3dt_volume))
 
     assert reconstructed.dims == nmf_3dt_volume.dims

--- a/tests/unit/test_decomposition/test_nmf.py
+++ b/tests/unit/test_decomposition/test_nmf.py
@@ -1,0 +1,502 @@
+"""Tests for confusius.decomposition.NMF."""
+
+import numpy as np
+import pytest
+import xarray as xr
+from sklearn.decomposition import NMF as SklearnNMF
+from sklearn.utils.validation import check_is_fitted
+
+from confusius.decomposition import NMF
+
+
+@pytest.fixture
+def nmf_3dt_volume():
+    """3D+t volume with low-rank structure that NMF can factorize quickly.
+
+    Generated as `W @ H` with `W` temporal and `H` spatial, scaled so the
+    rank-`k` signal is well separated from numerical noise. The CD solver
+    converges in a handful of iterations, keeping the test suite fast. Uses
+    a locally seeded RNG so the data is independent of test ordering.
+    """
+    local_rng = np.random.default_rng(0)
+    n_t, n_z, n_y, n_x, k = 40, 4, 6, 8, 3
+    W = local_rng.random((n_t, k))
+    H = local_rng.random((k, n_z * n_y * n_x))
+    data = (10.0 * (W @ H) + 1.0).reshape(n_t, n_z, n_y, n_x)
+    return xr.DataArray(
+        data,
+        name="power_doppler",
+        dims=["time", "z", "y", "x"],
+        coords={
+            "time": xr.DataArray(
+                10.0 + np.arange(n_t) * 0.5,
+                dims=["time"],
+                attrs={"units": "s"},
+            ),
+            "z": xr.DataArray(
+                1.0 + np.arange(n_z) * 0.2,
+                dims=["z"],
+                attrs={"units": "mm", "voxdim": 0.2},
+            ),
+            "y": xr.DataArray(
+                2.0 + np.arange(n_y) * 0.1,
+                dims=["y"],
+                attrs={"units": "mm", "voxdim": 0.1},
+            ),
+            "x": xr.DataArray(
+                3.0 + np.arange(n_x) * 0.05,
+                dims=["x"],
+                attrs={"units": "mm", "voxdim": 0.05},
+            ),
+        },
+        attrs={"long_name": "Intensity", "units": "a.u."},
+    )
+
+
+def test_feature_names_in_for_string_feature_labels(nmf_3dt_volume):
+    """feature_names_in_ is defined when flattened feature labels are strings."""
+    data = (
+        nmf_3dt_volume.isel(z=0, x=0, drop=True)
+        .rename({"y": "region"})
+        .assign_coords(region=["A", "B", "C", "D", "E", "F"])
+    )
+
+    model = NMF(n_components=2, init="nndsvda", random_state=0).fit(data)
+
+    np.testing.assert_array_equal(
+        model.feature_names_in_,
+        np.array(["A", "B", "C", "D", "E", "F"]),
+    )
+
+
+@pytest.mark.parametrize("mode", ["temporal", "spatial"])
+def test_fit_transform_matches_fit_then_transform(nmf_3dt_volume, mode):
+    """fit_transform matches calling fit followed by transform."""
+    model_direct = NMF(n_components=3, init="nndsvda", random_state=0, mode=mode)
+    direct = model_direct.fit_transform(nmf_3dt_volume)
+
+    model_two_step = NMF(n_components=3, init="nndsvda", random_state=0, mode=mode)
+    two_step = model_two_step.fit(nmf_3dt_volume).transform(nmf_3dt_volume)
+
+    xr.testing.assert_identical(direct, two_step)
+
+
+def test_wrapper_matches_sklearn_attributes(nmf_3dt_volume):
+    """Temporal wrapper exposes the same learned quantities as sklearn NMF."""
+    stacked = nmf_3dt_volume.transpose("time", "z", "y", "x").stack(
+        feature=["z", "y", "x"]
+    )
+    X = np.asarray(stacked.values, dtype=np.float64)
+
+    model = NMF(n_components=3, init="nndsvda", random_state=0).fit(nmf_3dt_volume)
+    sklearn_model = SklearnNMF(n_components=3, init="nndsvda", random_state=0).fit(X)
+
+    np.testing.assert_allclose(
+        model.transform(nmf_3dt_volume).values,
+        sklearn_model.transform(X),
+    )
+    np.testing.assert_allclose(
+        model.maps_.stack(feature=["z", "y", "x"]).values,
+        sklearn_model.components_,
+    )
+    assert model.n_components_ == sklearn_model.n_components_
+    assert model.n_iter_ == sklearn_model.n_iter_
+    np.testing.assert_allclose(
+        model.reconstruction_err_, sklearn_model.reconstruction_err_
+    )
+
+
+def test_fit_raises_for_negative_input():
+    """fit raises ValueError when input data contains negative values."""
+    rng = np.random.default_rng(0)
+    data = xr.DataArray(
+        rng.standard_normal((20, 4, 5, 6)),
+        dims=["time", "z", "y", "x"],
+    )
+
+    with pytest.raises(ValueError, match="non-negative input data"):
+        NMF(n_components=3, init="nndsvda", random_state=0).fit(data)
+
+
+def test_fit_raises_for_negative_input_under_mask(nmf_3dt_volume):
+    """fit raises ValueError when masked voxels contain negative values."""
+    data = nmf_3dt_volume - 20.0
+
+    with pytest.raises(ValueError, match="non-negative input data"):
+        NMF(n_components=3, init="nndsvda", random_state=0).fit(data)
+
+
+def test_inverse_transform_runs_in_fitted_geometry(nmf_3dt_volume):
+    """NMF inverse_transform reconstructs in fitted spatial geometry."""
+    model = NMF(n_components=3, init="nndsvda", random_state=0)
+
+    signals = model.fit_transform(nmf_3dt_volume)
+    reconstructed = model.inverse_transform(signals)
+
+    assert reconstructed.dims == nmf_3dt_volume.dims
+    np.testing.assert_allclose(
+        reconstructed.coords["time"], nmf_3dt_volume.coords["time"]
+    )
+    assert reconstructed.name == nmf_3dt_volume.name
+    assert reconstructed.attrs == nmf_3dt_volume.attrs
+
+
+def test_inverse_transform_from_numpy_returns_dataarray(nmf_3dt_volume):
+    """inverse_transform accepts ndarray input and returns DataArray."""
+    model = NMF(n_components=3, init="nndsvda", random_state=0)
+    scores = model.fit_transform(nmf_3dt_volume).values
+
+    reconstructed = model.inverse_transform(scores)
+
+    assert isinstance(reconstructed, xr.DataArray)
+    assert reconstructed.dims == nmf_3dt_volume.dims
+    np.testing.assert_array_equal(
+        reconstructed.coords["time"], np.arange(nmf_3dt_volume.sizes["time"])
+    )
+
+
+def test_inverse_transform_raises_for_invalid_dataarray_dims(nmf_3dt_volume):
+    """inverse_transform raises when DataArray dims are not time/component."""
+    model = NMF(n_components=3, init="nndsvda", random_state=0).fit(nmf_3dt_volume)
+    bad = xr.DataArray(
+        np.zeros((nmf_3dt_volume.sizes["time"], 3)),
+        dims=["time", "region"],
+    )
+
+    with pytest.raises(ValueError, match="exactly the dimensions"):
+        model.inverse_transform(bad)
+
+
+def test_inverse_transform_raises_for_component_count_mismatch(nmf_3dt_volume):
+    """inverse_transform raises when component count differs from fitted NMF."""
+    model = NMF(n_components=3, init="nndsvda", random_state=0).fit(nmf_3dt_volume)
+    scores = model.transform(nmf_3dt_volume)
+    bad = scores.isel(component=slice(0, 2))
+
+    with pytest.raises(ValueError, match="but NMF was fitted with"):
+        model.inverse_transform(bad)
+
+
+def test_inverse_transform_raises_for_invalid_numpy_shape(nmf_3dt_volume):
+    """inverse_transform raises when ndarray input is not 2D."""
+    model = NMF(n_components=3, init="nndsvda", random_state=0).fit(nmf_3dt_volume)
+
+    with pytest.raises(ValueError, match="must be 2D"):
+        model.inverse_transform(np.zeros((nmf_3dt_volume.sizes["time"], 3, 1)))
+
+
+def test_inverse_transform_raises_for_invalid_input_type(nmf_3dt_volume):
+    """inverse_transform raises TypeError for unsupported input types."""
+    model = NMF(n_components=3, init="nndsvda", random_state=0).fit(nmf_3dt_volume)
+
+    with pytest.raises(TypeError, match="DataArray or ndarray"):
+        model.inverse_transform([1, 2, 3])
+
+
+def test_fit_requires_time_dimension(nmf_3dt_volume):
+    """fit raises when the input has no `time` dimension."""
+    no_time = nmf_3dt_volume.isel(time=0, drop=True)
+
+    with pytest.raises(ValueError, match="must have a 'time' dimension"):
+        NMF().fit(no_time)
+
+
+def test_fit_requires_more_than_one_timepoint(nmf_3dt_volume):
+    """fit raises when only one timepoint is provided."""
+    single_timepoint = nmf_3dt_volume.isel(time=[0])
+
+    with pytest.raises(ValueError, match="requires more than 1 timepoint"):
+        NMF().fit(single_timepoint)
+
+
+def test_fit_requires_spatial_dimension():
+    """fit raises when input has no spatial dimensions."""
+    only_time = xr.DataArray(np.arange(30.0), dims=["time"])
+
+    with pytest.raises(ValueError, match="at least one spatial dimension"):
+        NMF().fit(only_time)
+
+
+def test_mask_must_match_full_spatial_dims_in_order(nmf_3dt_volume):
+    """Mask must span all spatial dims in the stacked feature order."""
+    mask = xr.DataArray(
+        np.ones(
+            (
+                nmf_3dt_volume.sizes["y"],
+                nmf_3dt_volume.sizes["z"],
+                nmf_3dt_volume.sizes["x"],
+            ),
+            dtype=bool,
+        ),
+        dims=["y", "z", "x"],
+        coords={
+            "y": nmf_3dt_volume.coords["y"],
+            "z": nmf_3dt_volume.coords["z"],
+            "x": nmf_3dt_volume.coords["x"],
+        },
+    )
+
+    with pytest.raises(ValueError, match="must match all non-time dimensions"):
+        NMF(mask=mask).fit(nmf_3dt_volume)
+
+
+def test_fit_rejects_unexpected_fit_params(nmf_3dt_volume):
+    """fit raises when unexpected sklearn-style fit params are provided."""
+    with pytest.raises(TypeError, match="unexpected keyword argument"):
+        NMF().fit(
+            nmf_3dt_volume,
+            sample_weight=np.ones(nmf_3dt_volume.sizes["time"]),
+        )
+
+
+def test_fit_transform_rejects_unexpected_fit_params(nmf_3dt_volume):
+    """fit_transform raises when unexpected sklearn-style fit params are provided."""
+    with pytest.raises(TypeError, match="Unexpected fit parameters"):
+        NMF().fit_transform(
+            nmf_3dt_volume,
+            sample_weight=np.ones(nmf_3dt_volume.sizes["time"]),
+        )
+
+
+def test_transform_checks_spatial_layout(nmf_3dt_volume):
+    """transform raises if spatial layout differs from fit."""
+    model = NMF(n_components=3, init="nndsvda", random_state=0).fit(nmf_3dt_volume)
+    bad = nmf_3dt_volume.isel(x=slice(0, 4))
+
+    with pytest.raises(ValueError, match="Spatial dimension 'x' has size"):
+        model.transform(bad)
+
+
+def test_transform_checks_spatial_dimension_names(nmf_3dt_volume):
+    """transform raises if spatial dimension names differ from fit."""
+    model = NMF(n_components=3, init="nndsvda", random_state=0).fit(nmf_3dt_volume)
+    bad = nmf_3dt_volume.rename({"x": "region"})
+
+    with pytest.raises(ValueError, match="spatial dimensions do not match"):
+        model.transform(bad)
+
+
+def test_transform_without_time_coordinate_uses_index(nmf_3dt_volume):
+    """transform falls back to integer time coordinate when absent."""
+    model = NMF(n_components=3, init="nndsvda", random_state=0).fit(nmf_3dt_volume)
+    no_time_coord = xr.DataArray(
+        nmf_3dt_volume.values,
+        dims=nmf_3dt_volume.dims,
+        coords={
+            "z": nmf_3dt_volume.coords["z"],
+            "y": nmf_3dt_volume.coords["y"],
+            "x": nmf_3dt_volume.coords["x"],
+        },
+    )
+
+    transformed = model.transform(no_time_coord)
+
+    np.testing.assert_array_equal(
+        transformed.coords["time"].values,
+        np.arange(nmf_3dt_volume.sizes["time"]),
+    )
+
+
+def test_transform_chunked_time_reports_transform_operation(nmf_3dt_volume):
+    """transform chunking error message identifies NMF.transform."""
+    model = NMF(n_components=3, init="nndsvda", random_state=0).fit(nmf_3dt_volume)
+    chunked = nmf_3dt_volume.chunk({"time": 5})
+
+    with pytest.raises(ValueError, match="NMF.transform requires the full time series"):
+        model.transform(chunked)
+
+
+def test_sklearn_interface_fitted_state(nmf_3dt_volume):
+    """Estimator exposes sklearn fitted-state behavior."""
+    model = NMF(n_components=3, init="nndsvda", random_state=0)
+    with pytest.raises(Exception):
+        check_is_fitted(model)
+
+    check_is_fitted(model.fit(nmf_3dt_volume))
+
+
+def test_fit_failure_does_not_mark_estimator_fitted(nmf_3dt_volume, monkeypatch):
+    """Estimator remains unfitted when underlying sklearn NMF fit fails."""
+    import confusius.decomposition.nmf as nmf_module
+
+    def _raise_fit(self, X, y=None):
+        raise RuntimeError("fit failed")
+
+    monkeypatch.setattr(nmf_module._SklearnNMF, "fit", _raise_fit)
+
+    model = NMF(n_components=3, init="nndsvda", random_state=0)
+    with pytest.raises(RuntimeError, match="fit failed"):
+        model.fit(nmf_3dt_volume)
+
+    assert not hasattr(model, "_estimator")
+    assert not model.__sklearn_is_fitted__()
+    with pytest.raises(Exception):
+        check_is_fitted(model)
+
+
+def test_get_params_includes_constructor_arguments():
+    """get_params includes all constructor arguments."""
+    model = NMF(
+        n_components=3,
+        init="nndsvda",
+        solver="mu",
+        beta_loss="kullback-leibler",
+        tol=1e-3,
+        max_iter=500,
+        random_state=42,
+        alpha_W=0.1,
+        alpha_H=0.1,
+        l1_ratio=0.5,
+        mode="spatial",
+    )
+    params = model.get_params()
+
+    assert params["n_components"] == 3
+    assert params["init"] == "nndsvda"
+    assert params["solver"] == "mu"
+    assert params["beta_loss"] == "kullback-leibler"
+    assert params["tol"] == 1e-3
+    assert params["max_iter"] == 500
+    assert params["random_state"] == 42
+    assert params["alpha_W"] == 0.1
+    assert params["alpha_H"] == 0.1
+    assert params["l1_ratio"] == 0.5
+    assert params["mode"] == "spatial"
+
+
+def test_set_params_updates_values():
+    """set_params updates constructor parameters."""
+    model = NMF()
+    model.set_params(
+        n_components=2,
+        init="nndsvdar",
+        random_state=7,
+        mode="spatial",
+    )
+
+    assert model.n_components == 2
+    assert model.init == "nndsvdar"
+    assert model.random_state == 7
+    assert model.mode == "spatial"
+
+
+def test_random_state_reproducible(nmf_3dt_volume):
+    """NMF gives reproducible results with a fixed random_state."""
+    model_1 = NMF(n_components=3, init="nndsvda", random_state=0)
+    model_2 = NMF(n_components=3, init="nndsvda", random_state=0)
+
+    signals_1 = model_1.fit_transform(nmf_3dt_volume)
+    signals_2 = model_2.fit_transform(nmf_3dt_volume)
+
+    np.testing.assert_allclose(signals_1.values, signals_2.values)
+    np.testing.assert_allclose(model_1.maps_.values, model_2.maps_.values)
+
+
+def test_spatial_mode_matches_reference_implementation(nmf_3dt_volume):
+    """Spatial mode matches sklearn NMF fitted on transposed data."""
+    stacked = nmf_3dt_volume.transpose("time", "z", "y", "x").stack(
+        feature=["z", "y", "x"]
+    )
+    X = np.asarray(stacked.values, dtype=np.float64)
+
+    model = NMF(n_components=3, init="nndsvda", random_state=0, mode="spatial").fit(
+        nmf_3dt_volume
+    )
+    sklearn_model = SklearnNMF(n_components=3, init="nndsvda", random_state=0).fit(X.T)
+
+    spatial_maps = sklearn_model.transform(X.T).T
+    voxel_mean = X.mean(axis=0)
+    reference_signals = (X - voxel_mean) @ spatial_maps.T
+    reference_reconstructed = reference_signals @ spatial_maps + voxel_mean
+
+    np.testing.assert_allclose(
+        model.transform(nmf_3dt_volume).values,
+        reference_signals,
+    )
+    np.testing.assert_allclose(
+        model.maps_.stack(feature=["z", "y", "x"]).values,
+        spatial_maps,
+    )
+    np.testing.assert_allclose(
+        model.inverse_transform(model.transform(nmf_3dt_volume))
+        .stack(feature=["z", "y", "x"])
+        .values,
+        reference_reconstructed,
+    )
+
+
+def test_fit_raises_for_invalid_mode(nmf_3dt_volume):
+    """fit raises for unsupported NMF mode."""
+    with pytest.raises(ValueError, match="mode must be 'temporal' or 'spatial'"):
+        NMF(mode="invalid").fit(nmf_3dt_volume)  # type: ignore[arg-type]
+
+
+def test_mask_restricts_features(nmf_3dt_volume):
+    """mask restricts fitted feature count to selected voxels."""
+    mask = xr.DataArray(
+        np.zeros(
+            (
+                nmf_3dt_volume.sizes["z"],
+                nmf_3dt_volume.sizes["y"],
+                nmf_3dt_volume.sizes["x"],
+            ),
+            dtype=bool,
+        ),
+        dims=["z", "y", "x"],
+        coords={
+            "z": nmf_3dt_volume.coords["z"],
+            "y": nmf_3dt_volume.coords["y"],
+            "x": nmf_3dt_volume.coords["x"],
+        },
+    )
+    mask.values[:2, :, :] = True
+
+    model = NMF(n_components=3, init="nndsvda", random_state=0, mask=mask).fit(
+        nmf_3dt_volume
+    )
+
+    assert model.n_features_in_ == int(mask.values.sum())
+
+
+def test_masked_fit_reconstructs_full_geometry_with_zero_fill(nmf_3dt_volume):
+    """Masked NMF keeps full geometry and fills outside-mask voxels with zero."""
+    mask = xr.DataArray(
+        np.zeros(
+            (
+                nmf_3dt_volume.sizes["z"],
+                nmf_3dt_volume.sizes["y"],
+                nmf_3dt_volume.sizes["x"],
+            ),
+            dtype=bool,
+        ),
+        dims=["z", "y", "x"],
+        coords={
+            "z": nmf_3dt_volume.coords["z"],
+            "y": nmf_3dt_volume.coords["y"],
+            "x": nmf_3dt_volume.coords["x"],
+        },
+    )
+    mask.values[:2, :, :] = True
+
+    model = NMF(n_components=3, init="nndsvda", random_state=0, mask=mask).fit(
+        nmf_3dt_volume
+    )
+    reconstructed = model.inverse_transform(model.transform(nmf_3dt_volume))
+
+    assert reconstructed.dims == nmf_3dt_volume.dims
+    np.testing.assert_array_equal(
+        reconstructed.where(~mask, other=np.nan).fillna(0.0).values,
+        0.0,
+    )
+    np.testing.assert_array_equal(
+        model.maps_.where(~mask, other=np.nan).fillna(0.0).values,
+        0.0,
+    )
+
+
+def test_mask_mismatch_raises(nmf_3dt_volume):
+    """fit raises when mask does not match spatial dimensions."""
+    bad_mask = xr.DataArray(np.ones((3, 3), dtype=bool), dims=["y", "x"])
+
+    with pytest.raises(ValueError, match="missing from mask"):
+        NMF(mask=bad_mask).fit(nmf_3dt_volume)

--- a/tests/unit/test_decomposition/test_nmf.py
+++ b/tests/unit/test_decomposition/test_nmf.py
@@ -367,6 +367,7 @@ def test_get_params_includes_constructor_arguments():
         alpha_W=0.1,
         alpha_H=0.1,
         l1_ratio=0.5,
+        shuffle=True,
         mode="spatial",
     )
     params = model.get_params()
@@ -381,6 +382,7 @@ def test_get_params_includes_constructor_arguments():
     assert params["alpha_W"] == 0.1
     assert params["alpha_H"] == 0.1
     assert params["l1_ratio"] == 0.5
+    assert params["shuffle"] is True
     assert params["mode"] == "spatial"
 
 
@@ -391,12 +393,14 @@ def test_set_params_updates_values():
         n_components=2,
         init="nndsvdar",
         random_state=7,
+        shuffle=True,
         mode="spatial",
     )
 
     assert model.n_components == 2
     assert model.init == "nndsvdar"
     assert model.random_state == 7
+    assert model.shuffle is True
     assert model.mode == "spatial"
 
 

--- a/tests/unit/test_decomposition/test_nmf.py
+++ b/tests/unit/test_decomposition/test_nmf.py
@@ -126,8 +126,31 @@ def test_fit_raises_for_negative_input_under_mask(nmf_3dt_volume):
         NMF(n_components=3, init="nndsvda", random_state=0).fit(data)
 
 
+def test_inverse_transform_matches_sklearn_temporal(nmf_3dt_volume):
+    """inverse_transform matches sklearn NMF reconstruction in temporal mode."""
+    stacked = nmf_3dt_volume.transpose("time", "z", "y", "x").stack(
+        feature=["z", "y", "x"]
+    )
+    X = np.asarray(stacked.values, dtype=np.float64)
+
+    model = NMF(n_components=3, init="nndsvda", random_state=0, mode="temporal")
+    reconstructed = model.inverse_transform(model.fit_transform(nmf_3dt_volume))
+
+    sklearn_model = SklearnNMF(
+        n_components=3, init="nndsvda", random_state=0
+    ).fit(X)
+    sklearn_reconstructed = sklearn_model.inverse_transform(
+        sklearn_model.transform(X)
+    )
+
+    np.testing.assert_allclose(
+        reconstructed.stack(feature=["z", "y", "x"]).values,
+        sklearn_reconstructed,
+    )
+
+
 def test_inverse_transform_runs_in_fitted_geometry(nmf_3dt_volume):
-    """NMF inverse_transform reconstructs in fitted spatial geometry."""
+    """NMF inverse_transform reconstructs in fitted spatial geometry with metadata."""
     model = NMF(n_components=3, init="nndsvda", random_state=0)
 
     signals = model.fit_transform(nmf_3dt_volume)
@@ -139,6 +162,15 @@ def test_inverse_transform_runs_in_fitted_geometry(nmf_3dt_volume):
     )
     assert reconstructed.name == nmf_3dt_volume.name
     assert reconstructed.attrs == nmf_3dt_volume.attrs
+
+
+def test_temporal_mode_signals_and_maps_are_non_negative(nmf_3dt_volume):
+    """Temporal-mode signals and maps are non-negative — the defining NMF guarantee."""
+    model = NMF(n_components=3, init="nndsvda", random_state=0, mode="temporal")
+    signals = model.fit_transform(nmf_3dt_volume)
+
+    assert float(signals.min()) >= 0.0
+    assert float(model.maps_.min()) >= 0.0
 
 
 def test_inverse_transform_from_numpy_returns_dataarray(nmf_3dt_volume):
@@ -380,7 +412,7 @@ def test_set_params_updates_values():
     assert model.mode == "spatial"
 
 
-def test_random_state_reproducible(nmf_3dt_volume):
+def test_reproducible_with_random_state(nmf_3dt_volume):
     """NMF gives reproducible results with a fixed random_state."""
     model_1 = NMF(n_components=3, init="nndsvda", random_state=0)
     model_2 = NMF(n_components=3, init="nndsvda", random_state=0)
@@ -425,7 +457,7 @@ def test_spatial_mode_matches_reference_implementation(nmf_3dt_volume):
     )
 
 
-def test_fit_raises_for_invalid_mode(nmf_3dt_volume):
+def test_fit_rejects_invalid_mode(nmf_3dt_volume):
     """fit raises for unsupported NMF mode."""
     with pytest.raises(ValueError, match="mode must be 'temporal' or 'spatial'"):
         NMF(mode="invalid").fit(nmf_3dt_volume)  # type: ignore[arg-type]

--- a/tests/unit/test_gallery/test_index.py
+++ b/tests/unit/test_gallery/test_index.py
@@ -105,6 +105,31 @@ def test_build_index_preserves_section_order_from_input(tmp_path: Path) -> None:
     assert md.index("## IO") < md.index("## DECOMPOSITION")
 
 
+def test_build_index_flattens_links_in_summaries(tmp_path: Path) -> None:
+    """Relative links in a summary are flattened so they can't break the index page.
+
+    Summaries are copied verbatim onto the index page at the examples root, where an
+    example's relative cross-links (written against its own built page) would not
+    resolve and would fail ``zensical build --strict``.
+    """
+    src = tmp_path / "decomposition" / "nmf.py"
+    src.parent.mkdir(parents=True, exist_ok=True)
+    src.touch()
+    rendered = [
+        RenderedExample(
+            spec=_spec(src, "decomposition"),
+            title="NMF",
+            summary="Complements the [PCA](pca_single_recording.md) example.",
+            md_path=src.with_suffix(".md"),
+            thumbnail_light=None,
+            thumbnail_dark=None,
+        ),
+    ]
+    md = build_index(rendered, root=tmp_path)
+    assert "](pca_single_recording.md)" not in md
+    assert "Complements the PCA example." in md
+
+
 def test_build_index_demotes_h1_section_intros(tmp_path: Path) -> None:
     """Section intros starting with H1 are demoted to H2 so there's a single page title."""
     src = tmp_path / "io" / "ex.py"

--- a/tools/gallery/index.py
+++ b/tools/gallery/index.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import html as html_lib
+import re
 from collections import defaultdict
 from pathlib import Path
 
@@ -10,6 +11,28 @@ from ._types import RenderedExample
 
 _DEFAULT_THUMB_LIGHT = "_assets/default_thumb.svg"
 _DEFAULT_THUMB_DARK = "_assets/default_thumb_dark.svg"
+
+# Markdown inline link: [text](url). Card summaries are copied verbatim onto the gallery
+# index page (at the examples root), where an example's relative links — written against
+# its own built page — would not resolve and fail `zensical build --strict`. The full
+# links still render on the example's own page.
+_INLINE_LINK = re.compile(r"\[([^\]]+)\]\([^)]+\)")
+
+
+def _flatten_links(text: str) -> str:
+    """Replace Markdown inline links with their visible text.
+
+    Parameters
+    ----------
+    text : str
+        Markdown text that may contain inline links.
+
+    Returns
+    -------
+    str
+        The text with every `[label](target)` reduced to `label`.
+    """
+    return _INLINE_LINK.sub(r"\1", text)
 
 
 def _demote_h1(text: str) -> str:
@@ -67,7 +90,7 @@ def build_index(rendered: list[RenderedExample], *, root: Path) -> str:
                 f"-   {image}\n\n    ---\n\n    **[{rendered_example.title}]({href})**"
             )
             if rendered_example.summary:
-                card += f"\n\n    {rendered_example.summary}"
+                card += f"\n\n    {_flatten_links(rendered_example.summary)}"
             parts.append(card + "\n\n")
         parts.append("</div>\n\n")
 

--- a/zensical.toml
+++ b/zensical.toml
@@ -74,6 +74,7 @@ nav = [
         { "Decomposition" = [
             { "PCA on a single fUSI recording" = "examples/_built/decomposition/pca_single_recording.md" },
             { "FastICA on a single fUSI recording" = "examples/_built/decomposition/fastica_single_recording.md" },
+            { "NMF on a single fUSI recording" = "examples/_built/decomposition/nmf_single_recording.md" },
         ]},
     ]},
     { "Changelog" = "changelog.md" },


### PR DESCRIPTION
Adds `confusius.decomposition.NMF` as a sibling of `PCA` and `FastICA`, wrapping `sklearn.decomposition.NMF` with the same xarray-aware `fit` / `transform` / `inverse_transform` interface.

- `mode="temporal"` (default) and `mode="spatial"` are both supported
- Raises a clear `ValueError` when input data contains negative values (NMF requires non-negative inputs)
- `scikit-learn` is already a hard dependency, so no `pyproject.toml` change is needed

Closes #117.