### PR TITLE
feat(registration): unify initial transforms

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,17 @@ icon: lucide/history
 
 Current development version for the next ConfUSIus release.
 
+### :boom: Breaking changes
+
+- Registration now takes a single `initialization` parameter in place of
+  `centering_initialization` and `initial_transform`. `initialization` accepts
+  `"center_geometry"`, `"center_moments"`, a homogeneous affine matrix or `None` for an
+  identity initialization. Affects
+  [`register_volume`][confusius.registration.register_volume],
+  [`register_volumewise`][confusius.registration.register_volumewise], and the
+  `data.fusi.register` accessor
+  ([#215](https://github.com/confusius-tools/confusius/pull/215)).
+
 ## 0.4.0
 
 *Released 2026-06-25.*

--- a/docs/examples/02_registration/01_register_volume_same_subject.py
+++ b/docs/examples/02_registration/01_register_volume_same_subject.py
@@ -113,7 +113,7 @@ cf.plotting.plot_composite(fixed, moving, bg_color=bg_color)
 # !!! warning "Registration is sensitive to its arguments"
 #     The result depends heavily on the choice of `transform_type`, `metric`,
 #     `learning_rate`, `number_of_iterations`, `convergence_window_size`,
-#     `centering_initialization`, and the multi-resolution settings
+#     `initialization`, and the multi-resolution settings
 #     (`use_multi_resolution`, `shrink_factors`, `smoothing_sigmas`). The values used in
 #     this example were empirically found to work well in this case, but you should
 #     definitely try different arguments (start with the default!) if the result is not

--- a/src/confusius/registration/bspline.py
+++ b/src/confusius/registration/bspline.py
@@ -14,7 +14,7 @@ A B-spline deformation field is represented as a DataArray with:
       "affines":   {
           "bspline_initialization": [[...]]   # optional (N+1, N+1) pre-affine;
                                               # only present when register_volume
-                                              # was called with initial_transform.
+                                              # was called with affine initialization.
       }
   }
   ```

--- a/src/confusius/registration/volume.py
+++ b/src/confusius/registration/volume.py
@@ -418,7 +418,8 @@ def register_volume(
         Number of values of the similarity metric which are used to estimate the energy
         profile of the similarity metric.
     initialization : {"center_geometry", "center_moments"} or (N+1, N+1) numpy.ndarray, default: "center_geometry"
-        Initial transform applied before optimization:
+        Initial transform mapping `fixed` to `moving` coordinates, applied before
+        optimization:
 
         - `"center_geometry"`: aligns image centers.
         - `"center_moments"`: aligns centers of mass.

--- a/src/confusius/registration/volume.py
+++ b/src/confusius/registration/volume.py
@@ -33,7 +33,9 @@ def _validate_register_volume_inputs(
     learning_rate: float | Literal["auto"],
     number_of_iterations: int,
     convergence_window_size: int,
-    centering_initialization: Literal["geometry", "moments", "none"],
+    initialization: Literal["center_geometry", "center_moments"]
+    | npt.NDArray[np.floating]
+    | None,
     shrink_factors: Sequence[int],
     smoothing_sigmas: Sequence[int],
     resample_interpolation: Literal["linear", "bspline"],
@@ -62,8 +64,8 @@ def _validate_register_volume_inputs(
         Maximum number of optimizer iterations.
     convergence_window_size : int
         Window size for convergence checking.
-    centering_initialization : {"geometry", "moments", "none"}
-        Transform initializer name.
+    initialization : {"center_geometry", "center_moments"} or (N+1, N+1) numpy.ndarray, optional
+        Transform initialization mode or precomputed affine transform.
     shrink_factors : sequence of int
         Downsampling factors per pyramid level.
     smoothing_sigmas : sequence of int
@@ -134,12 +136,14 @@ def _validate_register_volume_inputs(
             f"Invalid metric {metric!r}. Expected one of {sorted(valid_metrics)}."
         )
 
-    valid_initializations = {"geometry", "moments", "none"}
-    if centering_initialization not in valid_initializations:
-        raise ValueError(
-            f"Invalid initialization {centering_initialization!r}. "
-            f"Expected one of {sorted(valid_initializations)}."
-        )
+    valid_initializations = {"center_geometry", "center_moments"}
+    if initialization is not None and not isinstance(initialization, np.ndarray):
+        if initialization not in valid_initializations:
+            raise ValueError(
+                f"Invalid initialization {initialization!r}. "
+                f"Expected one of {sorted(valid_initializations)}, None, or a "
+                "homogeneous affine matrix."
+            )
 
     valid_interpolations = {"linear", "bspline"}
     if resample_interpolation not in valid_interpolations:
@@ -245,9 +249,10 @@ def register_volume(  # numpydoc ignore=GL08,PR01,RT01
     number_of_iterations: int = ...,
     convergence_minimum_value: float = ...,
     convergence_window_size: int = ...,
-    centering_initialization: Literal["geometry", "moments", "none"] = ...,
+    initialization: Literal["center_geometry", "center_moments"]
+    | npt.NDArray[np.floating]
+    | None = ...,
     optimizer_weights: list[float] | None = ...,
-    initial_transform: "npt.NDArray[np.floating] | None" = ...,
     mesh_size: tuple[int, int, int] = ...,
     use_multi_resolution: bool = ...,
     shrink_factors: Sequence[int] = ...,
@@ -278,9 +283,10 @@ def register_volume(  # numpydoc ignore=GL08,PR01,RT01
     number_of_iterations: int = ...,
     convergence_minimum_value: float = ...,
     convergence_window_size: int = ...,
-    centering_initialization: Literal["geometry", "moments", "none"] = ...,
+    initialization: Literal["center_geometry", "center_moments"]
+    | npt.NDArray[np.floating]
+    | None = ...,
     optimizer_weights: list[float] | None = ...,
-    initial_transform: "npt.NDArray[np.floating] | None" = ...,
     mesh_size: tuple[int, int, int] = ...,
     use_multi_resolution: bool = ...,
     shrink_factors: Sequence[int] = ...,
@@ -310,9 +316,10 @@ def register_volume(  # numpydoc ignore=GL08,PR01,RT01
     number_of_iterations: int = ...,
     convergence_minimum_value: float = ...,
     convergence_window_size: int = ...,
-    centering_initialization: Literal["geometry", "moments", "none"] = ...,
+    initialization: Literal["center_geometry", "center_moments"]
+    | npt.NDArray[np.floating]
+    | None = ...,
     optimizer_weights: list[float] | None = ...,
-    initial_transform: "npt.NDArray[np.floating] | None" = ...,
     mesh_size: tuple[int, int, int] = ...,
     use_multi_resolution: bool = ...,
     shrink_factors: Sequence[int] = ...,
@@ -342,9 +349,10 @@ def register_volume(
     number_of_iterations: int = 100,
     convergence_minimum_value: float = 1e-6,
     convergence_window_size: int = 10,
-    centering_initialization: Literal["geometry", "moments", "none"] = "geometry",
+    initialization: Literal["center_geometry", "center_moments"]
+    | npt.NDArray[np.floating]
+    | None = "center_geometry",
     optimizer_weights: list[float] | None = None,
-    initial_transform: "npt.NDArray[np.floating] | None" = None,
     mesh_size: tuple[int, int, int] = (10, 10, 10),
     use_multi_resolution: bool = False,
     shrink_factors: Sequence[int] = (6, 2, 1),
@@ -406,11 +414,17 @@ def register_volume(
     convergence_window_size : int, default: 10
         Number of values of the similarity metric which are used to estimate the energy
         profile of the similarity metric.
-    centering_initialization : {"geometry", "moments", "none"}, default: "geometry"
-        Transform initializer applied before optimization. `"geometry"` aligns the
-        image centers (safe default, no assumptions about content). `"moments"` aligns
-        centers of mass (better when images are offset but share the same content).
-        `"none"` uses the identity transform. Ignored for `transform_type="bspline"`.
+    initialization : {"center_geometry", "center_moments"} or (N+1, N+1) numpy.ndarray, default: "center_geometry"
+        Initial transform applied before optimization:
+
+        - `"center_geometry"`: aligns image centers.
+        - `"center_moments"`: aligns centers of mass.
+        - `(N+1, N+1)` homogeneous affine matrix: uses a precomputed affine
+          transform.
+        - `None`: uses the identity transform.
+
+        For `transform_type="bspline"`, centering modes are ignored but affine
+        initialization is supported.
     optimizer_weights : list of float, optional
         Per-parameter weights applied on top of the auto-estimated physical shift
         scales. `None` uses identity weights (all ones). A list is passed directly to
@@ -421,14 +435,6 @@ def register_volume(
         `1` leaves it unchanged. For the 3D Euler transform the parameter order is
         `[angleX, angleY, angleZ, tx, ty, tz]`; to disable rotations around x and y
         set weights to `[0, 0, 1, 1, 1, 1]`.
-    initial_transform : (N+1, N+1) numpy.ndarray, optional
-        Pre-computed affine matrix (pull/inverse convention, as returned by a previous
-        call to `register_volume`) used as a warm-start before optimisation. When
-        provided the optimized transform (`transform_type`) is composed on top of this
-        pre-alignment. Primarily useful for the affine → B-spline composition
-        workflow: run an affine registration first, then pass its result here together
-        with `transform_type="bspline"` to refine the deformation.  When not provided
-        the existing `centering_initialization` behaviour is unchanged.
     mesh_size : tuple of int, default: (10, 10, 10)
         Number of B-spline mesh nodes along each spatial dimension. Only used when
         `transform_type="bspline"`.
@@ -495,7 +501,7 @@ def register_volume(
         coordinates to moving-space coordinates. For `transform_type="bspline"`,
         returns a DataArray encoding the B-spline control-point grid (see
         [`confusius.registration.bspline`][confusius.registration.bspline] for the
-        DataArray schema). When `initial_transform` was also supplied, the DataArray
+        DataArray schema). When an affine `initialization` was also supplied, the DataArray
         includes `attrs["affines"]["bspline_initialization"]` so that the full composite
         (pre-affine + B-spline) can be reconstructed for resampling.
     diagnostics : confusius.registration.RegistrationDiagnostics
@@ -510,7 +516,7 @@ def register_volume(
     ValueError
         If `moving` or `fixed` contains NaN values.
     ValueError
-        If `transform_type`, `metric`, `centering_initialization`, or
+        If `transform_type`, `metric`, `initialization`, or
         `resample_interpolation` is not a recognised value.
     ValueError
         If `learning_rate` is not a positive finite float or `"auto"`.
@@ -520,8 +526,8 @@ def register_volume(
     ValueError
         If `shrink_factors` and `smoothing_sigmas` have different lengths.
     ValueError
-        If `initial_transform` is provided and its shape does not match the image
-        dimensionality.
+        If an affine `initialization` is provided and its shape does not match the
+        image dimensionality.
     TypeError
         If `fixed_mask` or `moving_mask` is not a boolean DataArray.
     ValueError
@@ -541,7 +547,7 @@ def register_volume(
         learning_rate=learning_rate,
         number_of_iterations=number_of_iterations,
         convergence_window_size=convergence_window_size,
-        centering_initialization=centering_initialization,
+        initialization=initialization,
         shrink_factors=shrink_factors,
         smoothing_sigmas=smoothing_sigmas,
         resample_interpolation=resample_interpolation,
@@ -564,12 +570,16 @@ def register_volume(
 
     ndim = fixed_reg.GetDimension()
 
-    # Validate initial_transform shape now that ndim is known.
-    if initial_transform is not None:
+    # Validate affine initialization shape now that ndim is known.
+    initialization_mode = initialization if isinstance(initialization, str) else None
+    affine_initialization = (
+        initialization if isinstance(initialization, np.ndarray) else None
+    )
+    if affine_initialization is not None:
         expected_shape = (ndim + 1, ndim + 1)
-        if initial_transform.shape != expected_shape:
+        if affine_initialization.shape != expected_shape:
             raise ValueError(
-                f"initial_transform shape {initial_transform.shape} does not match "
+                f"initialization shape {affine_initialization.shape} does not match "
                 f"image dimensionality {ndim}D (expected {expected_shape})."
             )
 
@@ -652,14 +662,16 @@ def register_volume(
         # CenteredTransformInitializer requires a transform with a center parameter
         # (e.g. Euler, Affine). TranslationTransform has no center, so centering
         # initialization is always skipped for translation.
-        if centering_initialization == "geometry" and transform_type != "translation":
+        if initialization_mode == "center_geometry" and transform_type != "translation":
             sitk_centering_transform = sitk.CenteredTransformInitializer(
                 fixed_reg,
                 moving_reg,
                 sitk_centering_transform,
                 sitk.CenteredTransformInitializerFilter.GEOMETRY,
             )
-        elif centering_initialization == "moments" and transform_type != "translation":
+        elif (
+            initialization_mode == "center_moments" and transform_type != "translation"
+        ):
             sitk_centering_transform = sitk.CenteredTransformInitializer(
                 fixed_reg,
                 moving_reg,
@@ -669,8 +681,8 @@ def register_volume(
         else:
             sitk_centering_transform = sitk_centering_transform
 
-    if initial_transform is not None:
-        pre_tx = affine_to_sitk_linear_transform(initial_transform)
+    if affine_initialization is not None:
+        pre_tx = affine_to_sitk_linear_transform(affine_initialization)
 
         sitk_initial_transform: sitk.Transform = sitk.CompositeTransform(ndim)
         sitk_initial_transform.AddTransform(pre_tx)
@@ -757,7 +769,7 @@ def register_volume(
         from confusius.registration.bspline import sitk_bspline_to_dataarray
 
         optimized_transform = sitk_bspline_to_dataarray(
-            sitk_optimized_transform, pre_affine=initial_transform
+            sitk_optimized_transform, pre_affine=affine_initialization
         )
     else:
         optimized_transform = sitk_linear_transform_to_affine(sitk_optimized_transform)

--- a/src/confusius/registration/volume.py
+++ b/src/confusius/registration/volume.py
@@ -137,13 +137,16 @@ def _validate_register_volume_inputs(
         )
 
     valid_initializations = {"center_geometry", "center_moments"}
-    if initialization is not None and not isinstance(initialization, np.ndarray):
-        if initialization not in valid_initializations:
-            raise ValueError(
-                f"Invalid initialization {initialization!r}. "
-                f"Expected one of {sorted(valid_initializations)}, None, or a "
-                "homogeneous affine matrix."
-            )
+    if (
+        initialization is not None
+        and not isinstance(initialization, np.ndarray)
+        and initialization not in valid_initializations
+    ):
+        raise ValueError(
+            f"Invalid initialization {initialization!r}. "
+            f"Expected one of {sorted(valid_initializations)}, None, or a "
+            "homogeneous affine matrix."
+        )
 
     valid_interpolations = {"linear", "bspline"}
     if resample_interpolation not in valid_interpolations:

--- a/src/confusius/registration/volume.py
+++ b/src/confusius/registration/volume.py
@@ -140,7 +140,9 @@ def _validate_register_volume_inputs(
     if (
         initialization is not None
         and not isinstance(initialization, np.ndarray)
-        and initialization not in valid_initializations
+        and not (
+            isinstance(initialization, str) and initialization in valid_initializations
+        )
     ):
         raise ValueError(
             f"Invalid initialization {initialization!r}. "

--- a/src/confusius/registration/volume.py
+++ b/src/confusius/registration/volume.py
@@ -684,8 +684,6 @@ def register_volume(
                 sitk_centering_transform,
                 sitk.CenteredTransformInitializerFilter.MOMENTS,
             )
-        else:
-            sitk_centering_transform = sitk_centering_transform
 
     if affine_initialization is not None:
         pre_tx = affine_to_sitk_linear_transform(affine_initialization)

--- a/src/confusius/registration/volume.py
+++ b/src/confusius/registration/volume.py
@@ -64,7 +64,7 @@ def _validate_register_volume_inputs(
         Maximum number of optimizer iterations.
     convergence_window_size : int
         Window size for convergence checking.
-    initialization : {"center_geometry", "center_moments"} or (N+1, N+1) numpy.ndarray, optional
+    initialization : {"center_geometry", "center_moments"} or (N+1, N+1) numpy.ndarray
         Transform initialization mode or precomputed affine transform.
     shrink_factors : sequence of int
         Downsampling factors per pyramid level.

--- a/src/confusius/registration/volumewise.py
+++ b/src/confusius/registration/volumewise.py
@@ -27,7 +27,8 @@ def register_volumewise(
     number_of_iterations: int = 100,
     convergence_minimum_value: float = 1e-6,
     convergence_window_size: int = 10,
-    initialization: Literal["geometry", "moments", "none"] = "geometry",
+    initialization: Literal["center_geometry", "center_moments"]
+    | None = "center_geometry",
     optimizer_weights: list[float] | None = None,
     use_multi_resolution: bool = False,
     shrink_factors: Sequence[int] = (6, 2, 1),
@@ -73,11 +74,12 @@ def register_volumewise(
     convergence_window_size : int, default: 10
         Number of recent metric values used to estimate the energy profile
         for convergence checking.
-    initialization : {"geometry", "moments", "none"}, default: "geometry"
-        Transform initializer applied before optimization. `"geometry"`
-        aligns the image centers (safe default, no assumptions about content).
-        `"moments"` aligns centers of mass (better when images are offset
-        but share the same content). `"none"` uses the identity transform.
+    initialization : {"center_geometry", "center_moments"}, default: "center_geometry"
+        Initial transform applied before optimization:
+
+        - `"center_geometry"`: aligns image centers.
+        - `"center_moments"`: aligns centers of mass.
+        - `None`: uses the identity transform.
     optimizer_weights : list of float, optional
         Per-parameter weights applied on top of the auto-estimated physical shift
         scales. If not provided, identity weights are used. A list is passed directly to
@@ -197,7 +199,7 @@ def register_volumewise(
                     number_of_iterations=number_of_iterations,
                     convergence_minimum_value=convergence_minimum_value,
                     convergence_window_size=convergence_window_size,
-                    centering_initialization=initialization,
+                    initialization=initialization,
                     optimizer_weights=optimizer_weights,
                     use_multi_resolution=use_multi_resolution,
                     shrink_factors=shrink_factors,

--- a/src/confusius/registration/volumewise.py
+++ b/src/confusius/registration/volumewise.py
@@ -75,11 +75,13 @@ def register_volumewise(
         Number of recent metric values used to estimate the energy profile
         for convergence checking.
     initialization : {"center_geometry", "center_moments"}, default: "center_geometry"
-        Initial transform applied before optimization:
+        Initial transform mapping `fixed` to `moving` coordinates, applied before
+        optimization:
 
         - `"center_geometry"`: aligns image centers.
         - `"center_moments"`: aligns centers of mass.
         - `None`: uses the identity transform.
+
     optimizer_weights : list of float, optional
         Per-parameter weights applied on top of the auto-estimated physical shift
         scales. If not provided, identity weights are used. A list is passed directly to

--- a/src/confusius/xarray/registration.py
+++ b/src/confusius/xarray/registration.py
@@ -41,7 +41,9 @@ class FUSIRegistrationAccessor:
         number_of_iterations: int = 100,
         convergence_minimum_value: float = 1e-6,
         convergence_window_size: int = 10,
-        initialization: Literal["geometry", "moments", "none"] = "geometry",
+        initialization: Literal["center_geometry", "center_moments"]
+        | npt.NDArray[np.floating]
+        | None = "center_geometry",
         optimizer_weights: list[float] | None = None,
         mesh_size: tuple[int, int, int] = (10, 10, 10),
         use_multi_resolution: bool = False,
@@ -75,8 +77,17 @@ class FUSIRegistrationAccessor:
             Convergence threshold for early stopping.
         convergence_window_size : int, default: 10
             Window size for convergence check.
-        initialization : {"geometry", "moments", "none"}, default: "geometry"
-            Transform initialization strategy. Ignored for bspline transforms.
+        initialization : {"center_geometry", "center_moments"} or (N+1, N+1) numpy.ndarray, default: "center_geometry"
+            Initial transform applied before optimization:
+
+            - `"center_geometry"`: aligns image centers.
+            - `"center_moments"`: aligns centers of mass.
+            - `(N+1, N+1)` homogeneous affine matrix: uses a precomputed affine
+              transform.
+            - `None`: uses the identity transform.
+
+            For `transform="bspline"`, centering modes are ignored but affine
+            initialization is supported.
         optimizer_weights : list of float, optional
             Per-parameter weights applied on top of auto-estimated scales via
             `SetOptimizerWeights()`. If not provided, no additional weighting is
@@ -144,7 +155,7 @@ class FUSIRegistrationAccessor:
             number_of_iterations=number_of_iterations,
             convergence_minimum_value=convergence_minimum_value,
             convergence_window_size=convergence_window_size,
-            centering_initialization=initialization,
+            initialization=initialization,
             optimizer_weights=optimizer_weights,
             mesh_size=mesh_size,
             use_multi_resolution=use_multi_resolution,
@@ -170,7 +181,8 @@ class FUSIRegistrationAccessor:
         number_of_iterations: int = 100,
         convergence_minimum_value: float = 1e-6,
         convergence_window_size: int = 10,
-        initialization: Literal["geometry", "moments", "none"] = "geometry",
+        initialization: Literal["center_geometry", "center_moments"]
+        | None = "center_geometry",
         optimizer_weights: list[float] | None = None,
         use_multi_resolution: bool = False,
         shrink_factors: Sequence[int] = (6, 2, 1),
@@ -203,8 +215,12 @@ class FUSIRegistrationAccessor:
             Convergence threshold for early stopping.
         convergence_window_size : int, default: 10
             Window size for convergence check.
-        initialization : {"geometry", "moments", "none"}, default: "geometry"
-            Transform initialization strategy.
+        initialization : {"center_geometry", "center_moments"}, default: "center_geometry"
+            Initial transform applied before optimization:
+
+            - `"center_geometry"`: aligns image centers.
+            - `"center_moments"`: aligns centers of mass.
+            - `None`: uses the identity transform.
         optimizer_weights : list of float, optional
             Per-parameter weights applied on top of auto-estimated scales via
             `SetOptimizerWeights()`. If not provided, no additional weighting is

--- a/src/confusius/xarray/registration.py
+++ b/src/confusius/xarray/registration.py
@@ -78,7 +78,8 @@ class FUSIRegistrationAccessor:
         convergence_window_size : int, default: 10
             Window size for convergence check.
         initialization : {"center_geometry", "center_moments"} or (N+1, N+1) numpy.ndarray, default: "center_geometry"
-            Initial transform applied before optimization:
+            Initial transform mapping `fixed` to `moving` coordinates, applied before
+            optimization:
 
             - `"center_geometry"`: aligns image centers.
             - `"center_moments"`: aligns centers of mass.
@@ -216,11 +217,13 @@ class FUSIRegistrationAccessor:
         convergence_window_size : int, default: 10
             Window size for convergence check.
         initialization : {"center_geometry", "center_moments"}, default: "center_geometry"
-            Initial transform applied before optimization:
+            Initial transform mapping `fixed` to `moving` coordinates, applied before
+            optimization:
 
             - `"center_geometry"`: aligns image centers.
             - `"center_moments"`: aligns centers of mass.
             - `None`: uses the identity transform.
+
         optimizer_weights : list of float, optional
             Per-parameter weights applied on top of auto-estimated scales via
             `SetOptimizerWeights()`. If not provided, no additional weighting is

--- a/tests/unit/test_registration/test_volume.py
+++ b/tests/unit/test_registration/test_volume.py
@@ -57,6 +57,17 @@ class TestRegisterVolumeValidation:
                 initialization="moments",
             )
 
+    def test_non_array_initialization_raises_value_error(
+        self, sample_2d_dataarray_spatial
+    ):
+        """A non-ndarray sequence raises ValueError, not an unhashable TypeError."""
+        with pytest.raises(ValueError, match="Invalid initialization"):
+            register_volume(
+                sample_2d_dataarray_spatial,
+                sample_2d_dataarray_spatial,
+                initialization=[[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+            )
+
     def test_shape_mismatch_no_error(
         self, sample_2d_image, sample_2d_dataarray_spatial
     ):
@@ -560,9 +571,7 @@ class TestInitialization:
             calls.append(operation_mode)
             return original_initializer(fixed, moving, transform, operation_mode)
 
-        monkeypatch.setattr(
-            sitk, "CenteredTransformInitializer", wrapped_initializer
-        )
+        monkeypatch.setattr(sitk, "CenteredTransformInitializer", wrapped_initializer)
 
         register_volume(
             sample_2d_dataarray_spatial,

--- a/tests/unit/test_registration/test_volume.py
+++ b/tests/unit/test_registration/test_volume.py
@@ -48,6 +48,15 @@ class TestRegisterVolumeValidation:
         with pytest.raises(ValueError, match="Unexpected dimensions"):
             register_volume(da, da)
 
+    def test_invalid_initialization_raises(self, sample_2d_dataarray_spatial):
+        """Unknown initialization mode raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid initialization"):
+            register_volume(
+                sample_2d_dataarray_spatial,
+                sample_2d_dataarray_spatial,
+                initialization="moments",
+            )
+
     def test_shape_mismatch_no_error(
         self, sample_2d_image, sample_2d_dataarray_spatial
     ):

--- a/tests/unit/test_registration/test_volume.py
+++ b/tests/unit/test_registration/test_volume.py
@@ -497,38 +497,38 @@ class TestResampleVolume:
         assert_allclose(result.values, resampled_direct.values, atol=1e-5)
 
 
-class TestInitialTransform:
-    """Tests for the initial_transform parameter of register_volume."""
+class TestInitialization:
+    """Tests for the initialization parameter of register_volume."""
 
     def test_wrong_shape_raises(self, sample_2d_dataarray_spatial):
-        """initial_transform with wrong shape raises ValueError."""
-        with pytest.raises(ValueError, match="initial_transform shape"):
+        """Affine initialization with wrong shape raises ValueError."""
+        with pytest.raises(ValueError, match="initialization shape"):
             register_volume(
                 sample_2d_dataarray_spatial,
                 sample_2d_dataarray_spatial,
                 transform_type="bspline",
-                initial_transform=np.eye(4),  # wrong: 3D affine for 2D images
+                initialization=np.eye(4),  # wrong: 3D affine for 2D images
             )
 
-    def test_bspline_with_initial_transform_stores_pre_affine(
+    def test_bspline_with_affine_initialization_stores_pre_affine(
         self, sample_2d_dataarray_spatial
     ):
-        """B-spline result DataArray stores the pre-affine in attrs when initial_transform is given."""
+        """B-spline result stores the pre-affine when affine initialization is given."""
         pre_affine = np.eye(3)
         _, bspline_tx, _ = register_volume(
             sample_2d_dataarray_spatial,
             sample_2d_dataarray_spatial,
             transform_type="bspline",
-            initial_transform=pre_affine,
+            initialization=pre_affine,
         )
         assert isinstance(bspline_tx, xr.DataArray)
         assert "affines" in bspline_tx.attrs
         assert "bspline_initialization" in bspline_tx.attrs["affines"]
 
-    def test_bspline_without_initial_transform_has_no_pre_affine(
+    def test_bspline_without_affine_initialization_has_no_pre_affine(
         self, sample_2d_dataarray_spatial
     ):
-        """B-spline result DataArray without initial_transform has no bspline_initialization key."""
+        """B-spline result without affine initialization has no bspline_initialization key."""
         _, bspline_tx, _ = register_volume(
             sample_2d_dataarray_spatial,
             sample_2d_dataarray_spatial,
@@ -569,7 +569,7 @@ class TestResampleVolumeWithBspline:
     def test_resample_like_with_composite_bspline_matches_direct_resample(
         self, sample_2d_image, sample_2d_dataarray_spatial
     ):
-        """resample_like with composite B-spline (with initial_transform) matches register_volume(resample=True)."""
+        """resample_like with composite B-spline matches register_volume(resample=True)."""
         rng = np.random.default_rng(1)
         shift = rng.integers(2, 4, size=2)
         shifted = np.roll(
@@ -591,7 +591,7 @@ class TestResampleVolumeWithBspline:
             moving,
             sample_2d_dataarray_spatial,
             transform_type="bspline",
-            initial_transform=affine_tx,
+            initialization=affine_tx,
             resample=True,
         )
         assert isinstance(bspline_tx, xr.DataArray)
@@ -651,7 +651,9 @@ class TestResampleLike:
                 "x": sample_2d_dataarray_spatial.coords["x"].values[:8],
             },
         )
-        result = resample_like(moving, sample_2d_dataarray_spatial, np.eye(3), default_value=0.0)
+        result = resample_like(
+            moving, sample_2d_dataarray_spatial, np.eye(3), default_value=0.0
+        )
         assert float(result.values[-1, -1]) == pytest.approx(0.0, abs=1e-5)
 
     def test_output_coords_match_reference(
@@ -726,10 +728,10 @@ class TestResampleLike:
         result = resample_like(moving, sample_3d_dataarray_spatial, affine)
         assert_allclose(result.values, resampled_direct.values, atol=1e-5)
 
-    def test_matches_register_volume_with_initial_transform(
+    def test_matches_register_volume_with_affine_initialization(
         self, sample_2d_image, sample_2d_dataarray_spatial
     ):
-        """resample_like matches register_volume(resample=True) when initial_transform is used.
+        """resample_like matches register_volume(resample=True) when affine initialization is used.
 
         Regression test for a bug where CompositeTransform sub-transforms were
         composed in the wrong order in _sitk_linear_transform_to_affine, causing
@@ -753,7 +755,7 @@ class TestResampleLike:
             moving,
             sample_2d_dataarray_spatial,
             transform_type="affine",
-            initial_transform=affine_init,
+            initialization=affine_init,
             resample=True,
         )
         result = resample_like(moving, sample_2d_dataarray_spatial, affine)
@@ -882,4 +884,6 @@ class TestRegisterVolumeFillValue:
             transform_type="translation",
         )
         # Default fill should be moving.min() == 2.0, not 0.0.
-        assert float(result.values[0, 0]) == pytest.approx(float(moving.min()), abs=1e-5)
+        assert float(result.values[0, 0]) == pytest.approx(
+            float(moving.min()), abs=1e-5
+        )

--- a/tests/unit/test_registration/test_volume.py
+++ b/tests/unit/test_registration/test_volume.py
@@ -538,6 +538,32 @@ class TestInitialization:
         affines = bspline_tx.attrs.get("affines", {})
         assert "bspline_initialization" not in affines
 
+    def test_center_moments_uses_moments_initializer(
+        self, sample_2d_dataarray_spatial, monkeypatch
+    ):
+        """center_moments uses SimpleITK's moments-based centering initializer."""
+        import SimpleITK as sitk
+
+        original_initializer = sitk.CenteredTransformInitializer
+        calls = []
+
+        def wrapped_initializer(fixed, moving, transform, operation_mode):
+            calls.append(operation_mode)
+            return original_initializer(fixed, moving, transform, operation_mode)
+
+        monkeypatch.setattr(
+            sitk, "CenteredTransformInitializer", wrapped_initializer
+        )
+
+        register_volume(
+            sample_2d_dataarray_spatial,
+            sample_2d_dataarray_spatial,
+            transform_type="affine",
+            initialization="center_moments",
+        )
+
+        assert calls == [sitk.CenteredTransformInitializerFilter.MOMENTS]
+
 
 class TestResampleVolumeWithBspline:
     """Tests for resample_volume and resample_like with a B-spline DataArray transform."""

--- a/tests/unit/test_xarray/test_wrapper_calls.py
+++ b/tests/unit/test_xarray/test_wrapper_calls.py
@@ -37,7 +37,9 @@ def test_scale_wrappers_forward_calls(monkeypatch, sample_3dt_volume):
     assert calls["power"] == (sample_3dt_volume, 2.0)
 
 
-def test_extract_wrappers_forward_calls(monkeypatch, sample_3dt_volume, sample_roi_labels):
+def test_extract_wrappers_forward_calls(
+    monkeypatch, sample_3dt_volume, sample_roi_labels
+):
     """Extract accessor methods forward arguments to extraction functions."""
     expected = xr.DataArray(np.array([1.0]), dims=["k"])
     mask = sample_roi_labels > 0
@@ -59,7 +61,10 @@ def test_extract_wrappers_forward_calls(monkeypatch, sample_3dt_volume, sample_r
     monkeypatch.setattr("confusius.extract.mask.extract_with_mask", _with_mask)
     monkeypatch.setattr("confusius.extract.reconstruction.unmask", _unmask)
 
-    assert sample_3dt_volume.fusi.extract.with_labels(sample_roi_labels, reduction="sum") is expected
+    assert (
+        sample_3dt_volume.fusi.extract.with_labels(sample_roi_labels, reduction="sum")
+        is expected
+    )
     assert calls["labels"] == (sample_3dt_volume, sample_roi_labels, "sum")
 
     assert sample_3dt_volume.fusi.extract.with_mask(mask) is expected
@@ -122,17 +127,20 @@ def test_iq_wrappers_forward_calls(monkeypatch, sample_3dt_volume_complex):
         coords={k: sample_3dt_volume_complex.coords[k] for k in ("z", "y", "x")},
     )
 
-    assert sample_3dt_volume_complex.fusi.iq.process_to_power_doppler(
-        clutter_window_width=11,
-        clutter_window_stride=7,
-        filter_method="butterworth",
-        clutter_mask=mask,
-        low_cutoff=30.5,
-        high_cutoff=80.0,
-        butterworth_order=6,
-        doppler_window_width=9,
-        doppler_window_stride=3,
-    ) is expected
+    assert (
+        sample_3dt_volume_complex.fusi.iq.process_to_power_doppler(
+            clutter_window_width=11,
+            clutter_window_stride=7,
+            filter_method="butterworth",
+            clutter_mask=mask,
+            low_cutoff=30.5,
+            high_cutoff=80.0,
+            butterworth_order=6,
+            doppler_window_width=9,
+            doppler_window_stride=3,
+        )
+        is expected
+    )
     assert calls["pwd"] == (
         sample_3dt_volume_complex,
         {
@@ -148,21 +156,24 @@ def test_iq_wrappers_forward_calls(monkeypatch, sample_3dt_volume_complex):
         },
     )
 
-    assert sample_3dt_volume_complex.fusi.iq.process_to_axial_velocity(
-        clutter_window_width=13,
-        clutter_window_stride=5,
-        filter_method="svd_energy",
-        clutter_mask=mask,
-        low_cutoff=2,
-        high_cutoff=12,
-        butterworth_order=2,
-        velocity_window_width=8,
-        velocity_window_stride=4,
-        lag=2,
-        absolute_velocity=True,
-        spatial_kernel=3,
-        estimation_method="angle_average",
-    ) is expected
+    assert (
+        sample_3dt_volume_complex.fusi.iq.process_to_axial_velocity(
+            clutter_window_width=13,
+            clutter_window_stride=5,
+            filter_method="svd_energy",
+            clutter_mask=mask,
+            low_cutoff=2,
+            high_cutoff=12,
+            butterworth_order=2,
+            velocity_window_width=8,
+            velocity_window_stride=4,
+            lag=2,
+            absolute_velocity=True,
+            spatial_kernel=3,
+            estimation_method="angle_average",
+        )
+        is expected
+    )
     assert calls["vel"] == (
         sample_3dt_volume_complex,
         {
@@ -210,31 +221,36 @@ def test_registration_wrappers_forward_calls(monkeypatch, sample_3d_volume):
         return volumewise_result
 
     monkeypatch.setattr("confusius.xarray.registration.register_volume", _to_volume)
-    monkeypatch.setattr("confusius.xarray.registration.register_volumewise", _volumewise)
+    monkeypatch.setattr(
+        "confusius.xarray.registration.register_volumewise", _volumewise
+    )
 
     fixed = sample_3d_volume.copy()
-    assert sample_3d_volume.fusi.register.to_volume(
-        fixed,
-        transform="affine",
-        metric="mattes_mi",
-        number_of_histogram_bins=40,
-        learning_rate=0.2,
-        number_of_iterations=25,
-        convergence_minimum_value=1e-4,
-        convergence_window_size=4,
-        initialization="moments",
-        optimizer_weights=[0, 0, 1, 1, 1, 1],
-        mesh_size=(3, 4, 5),
-        use_multi_resolution=True,
-        shrink_factors=(4, 2, 1),
-        smoothing_sigmas=(3, 1, 0),
-        resample=True,
-        resample_interpolation="bspline",
-        show_progress=True,
-        plot_metric=False,
-        plot_composite=False,
-        fill_value=-1.0,
-    ) is reg_result
+    assert (
+        sample_3d_volume.fusi.register.to_volume(
+            fixed,
+            transform="affine",
+            metric="mattes_mi",
+            number_of_histogram_bins=40,
+            learning_rate=0.2,
+            number_of_iterations=25,
+            convergence_minimum_value=1e-4,
+            convergence_window_size=4,
+            initialization="center_moments",
+            optimizer_weights=[0, 0, 1, 1, 1, 1],
+            mesh_size=(3, 4, 5),
+            use_multi_resolution=True,
+            shrink_factors=(4, 2, 1),
+            smoothing_sigmas=(3, 1, 0),
+            resample=True,
+            resample_interpolation="bspline",
+            show_progress=True,
+            plot_metric=False,
+            plot_composite=False,
+            fill_value=-1.0,
+        )
+        is reg_result
+    )
     assert calls["to_volume"] == (
         sample_3d_volume,
         fixed,
@@ -246,7 +262,7 @@ def test_registration_wrappers_forward_calls(monkeypatch, sample_3d_volume):
             "number_of_iterations": 25,
             "convergence_minimum_value": 1e-4,
             "convergence_window_size": 4,
-            "centering_initialization": "moments",
+            "initialization": "center_moments",
             "optimizer_weights": [0, 0, 1, 1, 1, 1],
             "mesh_size": (3, 4, 5),
             "use_multi_resolution": True,
@@ -261,25 +277,28 @@ def test_registration_wrappers_forward_calls(monkeypatch, sample_3d_volume):
         },
     )
 
-    assert sample_3d_volume.fusi.register.volumewise(
-        reference_time=2,
-        n_jobs=1,
-        transform="translation",
-        metric="mattes_mi",
-        number_of_histogram_bins=20,
-        learning_rate=0.15,
-        number_of_iterations=30,
-        convergence_minimum_value=1e-5,
-        convergence_window_size=5,
-        initialization="none",
-        optimizer_weights=[1, 1, 1, 0, 0, 1],
-        use_multi_resolution=True,
-        shrink_factors=(3, 1),
-        smoothing_sigmas=(2, 0),
-        resample_interpolation="bspline",
-        show_progress=False,
-        keep_diagnostics=True,
-    ) is volumewise_result
+    assert (
+        sample_3d_volume.fusi.register.volumewise(
+            reference_time=2,
+            n_jobs=1,
+            transform="translation",
+            metric="mattes_mi",
+            number_of_histogram_bins=20,
+            learning_rate=0.15,
+            number_of_iterations=30,
+            convergence_minimum_value=1e-5,
+            convergence_window_size=5,
+            initialization=None,
+            optimizer_weights=[1, 1, 1, 0, 0, 1],
+            use_multi_resolution=True,
+            shrink_factors=(3, 1),
+            smoothing_sigmas=(2, 0),
+            resample_interpolation="bspline",
+            show_progress=False,
+            keep_diagnostics=True,
+        )
+        is volumewise_result
+    )
     assert calls["volumewise"] == (
         sample_3d_volume,
         {
@@ -292,7 +311,7 @@ def test_registration_wrappers_forward_calls(monkeypatch, sample_3d_volume):
             "number_of_iterations": 30,
             "convergence_minimum_value": 1e-5,
             "convergence_window_size": 5,
-            "initialization": "none",
+            "initialization": None,
             "optimizer_weights": [1, 1, 1, 0, 0, 1],
             "use_multi_resolution": True,
             "shrink_factors": (3, 1),
@@ -455,24 +474,21 @@ def test_plot_wrappers_forward_calls(monkeypatch, sample_3d_volume, sample_roi_l
     assert sample_3d_volume.fusi.plot.labels_from_layer("layer") is sample_roi_labels
     assert calls["labels"] == ("layer", sample_3d_volume)
 
-    assert (
-        sample_3d_volume.fusi.plot.carpet(
-            mask=sample_roi_labels > 0,
-            detrend_order=1,
-            standardize=False,
-            cmap="viridis",
-            vmin=-1.0,
-            vmax=2.0,
-            decimation_threshold=None,
-            figsize=(6, 4),
-            title="carpet",
-            fontsize=12,
-            bg_color="black",
-            fg_color="white",
-            ax="existing_ax",
-        )
-        == ("fig", "ax")
-    )
+    assert sample_3d_volume.fusi.plot.carpet(
+        mask=sample_roi_labels > 0,
+        detrend_order=1,
+        standardize=False,
+        cmap="viridis",
+        vmin=-1.0,
+        vmax=2.0,
+        decimation_threshold=None,
+        figsize=(6, 4),
+        title="carpet",
+        fontsize=12,
+        bg_color="black",
+        fg_color="white",
+        ax="existing_ax",
+    ) == ("fig", "ax")
     assert calls["carpet"][0] is sample_3d_volume
     assert calls["carpet"][1]["detrend_order"] == 1
 


### PR DESCRIPTION
## Summary
- replace `centering_initialization` and `initial_transform` with a single `initialization` argument
- support centering modes, `None`, and affine warm starts through one API
- update volumewise/xarray wrappers and tests

Closes #213
