### PR TITLE
fix(nifti): preserve sidecar affines when loading

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,6 +21,13 @@ Current development version for the next ConfUSIus release.
   `data.fusi.register` accessor
   ([#215](https://github.com/confusius-tools/confusius/pull/215)).
 
+### :bug: Fixes
+
+- `load_nifti` no longer drops affines loaded from the JSON sidecar (e.g.
+  `bspline_initialization` written by the registration pipeline) when merging in the
+  NIfTI qform/sform affines
+  ([#222](https://github.com/confusius-tools/confusius/pull/222)).
+
 ## 0.4.0
 
 *Released 2026-06-25.*
@@ -50,10 +57,6 @@ Current development version for the next ConfUSIus release.
 
 ### :bug: Fixes
 
-- `load_nifti` no longer drops affines loaded from the JSON sidecar (e.g.
-  `bspline_initialization` written by the registration pipeline) when merging in the
-  NIfTI qform/sform affines
-  ([#221](https://github.com/confusius-tools/confusius/issues/221)).
 - Masks are now coerced to boolean by `validate_mask` (added `return_dtype_as_bool`
   parameter that defaults to `True`) to avoid DataArrays using *positional indexing*.
   Previously these masks could select the wrong voxels or, for `register_volume`,

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -27,6 +27,10 @@ Current development version for the next ConfUSIus release.
 
 ### :bug: Fixes
 
+- `load_nifti` no longer drops affines loaded from the JSON sidecar (e.g.
+  `bspline_initialization` written by the registration pipeline) when merging in the
+  NIfTI qform/sform affines
+  ([#221](https://github.com/confusius-tools/confusius/issues/221)).
 - `process_iq_blocks` now handles strongly overlapping IQ windows without corrupting
   the output time dimension, so power Doppler and related IQ reducers work when
   `window_stride < window_width / 2`

--- a/src/confusius/io/nifti.py
+++ b/src/confusius/io/nifti.py
@@ -799,6 +799,11 @@ def load_nifti(
     spatial_coords, affine_attrs = _create_spatial_coords_from_nifti(
         img=img, extractor=extractor, dims=nifti_dims
     )
+    # Merge NIfTI-header-derived affines with any pre-existing affines (e.g. loaded
+    # from the sidecar) so sidecar entries like `bspline_initialization` are not
+    # clobbered by the qform/sform keys coming from the file header.
+    if "affines" in attrs and "affines" in affine_attrs:
+        affine_attrs["affines"] = {**attrs["affines"], **affine_attrs["affines"]}
     attrs.update(affine_attrs)
 
     if "time" in nifti_dims:

--- a/tests/unit/test_io/test_nifti.py
+++ b/tests/unit/test_io/test_nifti.py
@@ -746,6 +746,37 @@ class TestLoadNifti:
         assert da.attrs.get("custom_meta") == "test_value"
         assert da.attrs.get("acquisition") == "test_acq"
 
+    def test_load_nifti_preserves_sidecar_extra_affines(self, tmp_path: Path) -> None:
+        """Sidecar `ConfUSIusAffines` entries survive qform/sform merge (#221)."""
+        rng = np.random.default_rng(0)
+        data = rng.random((8, 6, 4)).astype(np.float32)
+        nifti_path = tmp_path / "extra_affines.nii.gz"
+        nib.Nifti1Image(data, np.eye(4)).to_filename(nifti_path)
+
+        extra_affine = [
+            [1.0, 0.0, 0.0, 0.5],
+            [0.0, 1.0, 0.0, -1.0],
+            [0.0, 0.0, 1.0, 2.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ]
+        sidecar = {"ConfUSIusAffines": {"bspline_initialization": extra_affine}}
+        with open(tmp_path / "extra_affines.json", "w") as f:
+            json.dump(sidecar, f)
+
+        da = load_nifti(nifti_path)
+
+        assert "affines" in da.attrs
+        assert "bspline_initialization" in da.attrs["affines"]
+        np.testing.assert_allclose(
+            da.attrs["affines"]["bspline_initialization"], extra_affine
+        )
+        # The NIfTI header affines (qform/sform) must still be present alongside
+        # the sidecar entry.
+        nifti_affine_keys = {
+            k for k in da.attrs["affines"] if k.startswith("physical_to_")
+        }
+        assert nifti_affine_keys, "expected qform/sform from the NIfTI header"
+
     def test_load_nifti_invalid_sidecar_warns(self, tmp_path: Path) -> None:
         """Loading warns when the sidecar violates fUSI-BIDS validation rules."""
         data = np.arange(2 * 3 * 4 * 5, dtype=np.float32).reshape(2, 3, 4, 5)


### PR DESCRIPTION
Fixes #221.

`load_nifti` was overwriting the sidecar-loaded `affines` dict (e.g. `bspline_initialization` from registration outputs) with the qform/sform affines derived from the NIfTI header. The two are now merged, with NIfTI-header keys taking precedence.