### PR TITLE
fix(plotting): default alpha to None so cmap alpha is respected

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -23,6 +23,9 @@ Current development version for the next ConfUSIus release.
 
 ### :bug: Fixes
 
+- Image plotting functions now leave `alpha` unset by default (`None`), so a
+  colormap's built-in alpha channel is respected
+  ([#225](https://github.com/confusius-tools/confusius/pull/225)).
 - `load_nifti` no longer drops affines loaded from the JSON sidecar (e.g.
   `bspline_initialization` written by the registration pipeline) when merging in the
   NIfTI qform/sform affines

--- a/src/confusius/plotting/image.py
+++ b/src/confusius/plotting/image.py
@@ -733,7 +733,7 @@ class VolumePlotter:
         vmax: float | None = None,
         threshold: float | None = None,
         threshold_mode: Literal["lower", "upper"] = "lower",
-        alpha: float = 1.0,
+        alpha: float | None = None,
         show_colorbar: bool = True,
         cbar_label: str | None = None,
         roi_labels: dict[int, str] | None = None,
@@ -779,8 +779,9 @@ class VolumePlotter:
             Threshold value for masking.
         threshold_mode : {"lower", "upper"}, default: "lower"
             Whether to mask values below or above threshold.
-        alpha : float, default: 1.0
-            Opacity of the image.
+        alpha : float, optional
+            Opacity of the image. If not provided, the colormap's own alpha
+            channel is respected.
         show_colorbar : bool, default: True
             Whether to add a colorbar.
         cbar_label : str, optional
@@ -969,7 +970,7 @@ class VolumePlotter:
         normalize_strategy: Literal["per_volume", "per_slice", "shared"] = "per_volume",
         slice_coords: Sequence[float] | None = None,
         match_coordinates: bool = False,
-        alpha: float = 1.0,
+        alpha: float | None = None,
         show_titles: bool = True,
         show_axis_labels: bool = True,
         show_axis_ticks: bool = True,
@@ -1037,8 +1038,9 @@ class VolumePlotter:
             If True, match slice coordinates to the stored coordinate mapping of an
             existing figure (for use as an overlay). If False, plot sequentially on
             a fresh grid of axes — the natural mode for a standalone composite plot.
-        alpha : float, default: 1.0
-            Opacity of the composite image.
+        alpha : float, optional
+            Opacity of the composite image. If not provided, the image is fully
+            opaque.
         show_titles : bool, default: True
             Whether to display subplot titles showing the slice coordinate.
         show_axis_labels : bool, default: True
@@ -1757,7 +1759,7 @@ def plot_volume(
     vmax: float | None = None,
     threshold: float | None = None,
     threshold_mode: Literal["lower", "upper"] = "lower",
-    alpha: float = 1.0,
+    alpha: float | None = None,
     show_colorbar: bool = True,
     cbar_label: str | None = None,
     roi_labels: dict[int, str] | None = None,
@@ -1817,8 +1819,9 @@ def plot_volume(
         - `"lower"`: set pixels where `|data| < threshold` to NaN.
         - `"upper"`: set pixels where `|data| > threshold` to NaN.
 
-    alpha : float, default: 1.0
-        Opacity of the image.
+    alpha : float, optional
+        Opacity of the image. If not provided, the colormap's own alpha channel
+        is respected.
     show_colorbar : bool, default: True
         Whether to add a shared colorbar to the figure.
     cbar_label : str, optional
@@ -1970,7 +1973,7 @@ def plot_composite(
     normalize_strategy: Literal["per_volume", "per_slice", "shared"] = "per_volume",
     slice_coords: Sequence[float] | None = None,
     slice_mode: str = "z",
-    alpha: float = 1.0,
+    alpha: float | None = None,
     show_titles: bool = True,
     show_axis_labels: bool = True,
     show_axis_ticks: bool = True,
@@ -2038,8 +2041,9 @@ def plot_composite(
     slice_mode : str, default: "z"
         Dimension along which to slice (e.g. `"x"`, `"y"`, `"z"`). After slicing, each
         panel must be 2D.
-    alpha : float, default: 1.0
-        Opacity of the composite image.
+    alpha : float, optional
+        Opacity of the composite image. If not provided, the image is fully
+        opaque.
     show_titles : bool, default: True
         Whether to display subplot titles showing the slice coordinate.
     show_axis_labels : bool, default: True

--- a/src/confusius/xarray/plotting.py
+++ b/src/confusius/xarray/plotting.py
@@ -362,7 +362,7 @@ class FUSIPlotAccessor:
         norm: "Normalize | None" = None,
         vmin: float | None = None,
         vmax: float | None = None,
-        alpha: float = 1.0,
+        alpha: float | None = None,
         show_colorbar: bool = True,
         cbar_label: str | None = None,
         show_titles: bool = True,
@@ -422,8 +422,9 @@ class FUSIPlotAccessor:
             Upper bound of the colormap. Defaults to the 98th percentile. Ignored
             when `norm` is provided explicitly (that is, not just inherited from data
             attributes).
-        alpha : float, default: 1.0
-            Opacity of the image.
+        alpha : float, optional
+            Opacity of the image. If not provided, the colormap's own alpha
+            channel is respected.
         show_colorbar : bool, default: True
             Whether to add a shared colorbar to the figure.
         cbar_label : str, optional
@@ -634,7 +635,7 @@ class FUSIPlotAccessor:
         normalize_strategy: Literal["per_volume", "per_slice", "shared"] = "per_volume",
         slice_coords: list[float] | None = None,
         slice_mode: str = "z",
-        alpha: float = 1.0,
+        alpha: float | None = None,
         show_titles: bool = True,
         show_axis_labels: bool = True,
         show_axis_ticks: bool = True,
@@ -697,8 +698,9 @@ class FUSIPlotAccessor:
         slice_mode : str, default: "z"
             Dimension along which to slice (e.g. `"x"`, `"y"`, `"z"`). After
             slicing, each panel must be 2D.
-        alpha : float, default: 1.0
-            Opacity of the composite image.
+        alpha : float, optional
+            Opacity of the composite image. If not provided, the image is fully
+            opaque.
         show_titles : bool, default: True
             Whether to display subplot titles showing the slice coordinate.
         show_axis_labels : bool, default: True

--- a/tests/unit/test_plotting/test_image.py
+++ b/tests/unit/test_plotting/test_image.py
@@ -132,6 +132,29 @@ class TestPlotVolume:
         assert collection.norm.vmin == pytest.approx(-3.0)
         assert collection.norm.vmax == pytest.approx(3.0)
 
+    def test_default_alpha_preserves_cmap_alpha(
+        self, sample_3d_volume, matplotlib_pyplot
+    ):
+        """Default alpha (None) lets a colormap's own alpha channel through."""
+        from matplotlib.colors import ListedColormap
+
+        # Semi-transparent colormap; the old alpha=1.0 default would erase it.
+        cmap = ListedColormap([(1.0, 0.0, 0.0, 0.3), (0.0, 0.0, 1.0, 0.7)])
+        z_coord = sample_3d_volume.coords["z"].values[0]
+        plotter = plot_volume(
+            sample_3d_volume,
+            slice_mode="z",
+            slice_coords=[z_coord],
+            cmap=cmap,
+            show_colorbar=False,
+        )
+
+        quadmesh = plotter.axes[0, 0].collections[0]
+        quadmesh.update_scalarmappable()
+        alphas = np.unique(quadmesh.get_facecolor()[:, 3])
+        assert alphas.size > 0
+        assert np.all(np.isclose(alphas[:, None], [0.3, 0.7]).any(axis=1))
+
     def test_colorbar_added_by_default(self, sample_3d_volume, matplotlib_pyplot):
         """plot_volume adds a colorbar when show_colorbar=True (default)."""
         z_coord = sample_3d_volume.coords["z"].values[0]


### PR DESCRIPTION
## Summary

The matplotlib image plotters defaulted `alpha` to `1.0`, which forces full opacity and overrides a colormap's own alpha channel. This defaults `alpha` to `None` (the matplotlib-native value) so a colormap's built-in alpha is respected.

Affected: `plot_volume`, `plot_composite`, the `VolumePlotter.add_volume` / `add_composite` methods, and the `.fusi.plot_volume` / `.fusi.plot_composite` accessors.

## Test

Added `test_default_alpha_preserves_cmap_alpha`: renders a volume with a semi-transparent `ListedColormap` and asserts the QuadMesh facecolors keep the colormap's alpha (the old `alpha=1.0` default flattened them to `1.0`).

Closes #224