### PR TITLE
feat(datasets): add fetcher for Landemard 2026

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -28,7 +28,7 @@ Current development version for the next ConfUSIus release.
   xarray-aware `fit`/`transform`/`inverse_transform` interface as
   [`PCA`][confusius.decomposition.PCA] and [`FastICA`][confusius.decomposition.FastICA].
   Both `mode='temporal'` and `mode='spatial'` are supported
-  ([#117](https://github.com/confusius-tools/confusius/issues/117)).
+  ([#117](https://github.com/confusius-tools/confusius/pull/211)).
 - Added [`adjust_pvalues`][confusius.stats.adjust_pvalues] for generic
   multiple-comparison correction of p-value maps, and
   [`apply_statistical_threshold`][confusius.stats.apply_statistical_threshold] to
@@ -40,7 +40,7 @@ Current development version for the next ConfUSIus release.
 - Added [`fetch_landemard_2026`][confusius.datasets.fetch_landemard_2026] for
   downloading the Landemard et al. (2026) fUSI-BIDS dataset from OSF, with
   `datasets`, `subjects`, `acqs`, and `datatypes` filters
-  ([#228](https://github.com/confusius-tools/confusius/issues/228)).
+  ([#228](https://github.com/confusius-tools/confusius/pull/230)).
 
 ### :bug: Fixes
 
@@ -67,7 +67,7 @@ Current development version for the next ConfUSIus release.
 - The `confusius` CLI now accepts multiple fUSI data files in a single
   invocation (e.g. `confusius fixed.nii moving.nii`). Each file is added as its
   own image layer, named after the file's basename
-  ([#205](https://github.com/confusius-tools/confusius/issues/205)).
+  ([#205](https://github.com/confusius-tools/confusius/pull/206)).
 - `data.fusi.affine.apply` now accepts affines with rotation and shear. The
   axis-aligned part updates the 1D `z`/`y`/`x` coordinates and the method returns
   the residual orientation as a 4x4 affine (the identity for diagonal affines)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -67,7 +67,7 @@ Current development version for the next ConfUSIus release.
 - The `confusius` CLI now accepts multiple fUSI data files in a single
   invocation (e.g. `confusius fixed.nii moving.nii`). Each file is added as its
   own image layer, named after the file's basename
-  ([#205](https://github.com/confusius-tools/confusius/pull/206)).
+  ([#206](https://github.com/confusius-tools/confusius/pull/206)).
 - `data.fusi.affine.apply` now accepts affines with rotation and shear. The
   axis-aligned part updates the 1D `z`/`y`/`x` coordinates and the method returns
   the residual orientation as a 4x4 affine (the identity for diagonal affines)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -37,6 +37,10 @@ Current development version for the next ConfUSIus release.
   false-discovery-rate (Benjamini-Hochberg, Benjamini-Yekutieli) corrections, plus an
   optional cluster-extent threshold
   ([#204](https://github.com/confusius-tools/confusius/pull/204)).
+- Added [`fetch_landemard_2026`][confusius.datasets.fetch_landemard_2026] for
+  downloading the Landemard et al. (2026) fUSI-BIDS dataset from OSF, with
+  `datasets`, `subjects`, `acqs`, and `datatypes` filters
+  ([#228](https://github.com/confusius-tools/confusius/issues/228)).
 
 ### :bug: Fixes
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -28,7 +28,7 @@ Current development version for the next ConfUSIus release.
   xarray-aware `fit`/`transform`/`inverse_transform` interface as
   [`PCA`][confusius.decomposition.PCA] and [`FastICA`][confusius.decomposition.FastICA].
   Both `mode='temporal'` and `mode='spatial'` are supported
-  ([#117](https://github.com/confusius-tools/confusius/pull/211)).
+  ([#211](https://github.com/confusius-tools/confusius/pull/211)).
 - Added [`adjust_pvalues`][confusius.stats.adjust_pvalues] for generic
   multiple-comparison correction of p-value maps, and
   [`apply_statistical_threshold`][confusius.stats.apply_statistical_threshold] to

--- a/docs/citing.md
+++ b/docs/citing.md
@@ -204,9 +204,25 @@ The [`fetch_landemard_2026`][confusius.datasets.fetch_landemard_2026]
 function provides an fUSI-BIDS re-export of this dataset. If you use it,
 please cite:
 
-> Landemard, A. et al. (2026). Functional ultrasound imaging in head-fixed,
-> freely-running mice. *Nature*.
+> Landemard, A., Krumin, M., Harris, K. D., & Carandini, M. (2026). Brainwide
+> blood volume reflects opposing neural populations. *Nature*.
 > https://doi.org/10.1038/s41586-026-10350-9
+
+Or in BibTeX format:
+
+```bibtex
+@article{landemard_brainwide_2026,
+  title = {Brainwide blood volume reflects opposing neural populations},
+  author = {Landemard, Agn{\`e}s and Krumin, Michael and Harris, Kenneth D. and
+            Carandini, Matteo},
+  year = {2026},
+  month = apr,
+  journal = {Nature},
+  publisher = {Springer Science and Business Media {LLC}},
+  doi = {10.1038/s41586-026-10350-9},
+  url = {https://doi.org/10.1038/s41586-026-10350-9}
+}
+```
 
 License: **[CC BY-NC 4.0](https://creativecommons.org/licenses/by-nc/4.0/)**.
 

--- a/docs/citing.md
+++ b/docs/citing.md
@@ -181,7 +181,10 @@ Or in BibTeX format:
 ```bibtex
 @article{cybispereiraVascularCodeSpeed2026,
   title = {A Vascular Code for Speed in the Spatial Navigation System},
-  author = {Cybis Pereira, Felipe and Castedo, Sebastian H. and {Meur-Diebolt}, Samuel Le and {Ialy-Radio}, Nathalie and Bhattacharya, Soumee and Ferrier, Jeremy and Osmanski, Bruno F{\'e}lix and Cocco, Simona and Monasson, Remi and Pezet, Sophie and Tanter, Micka{\"e}l},
+  author = {Cybis Pereira, Felipe and Castedo, Sebastian H. and {Meur-Diebolt}, Samuel Le and
+            {Ialy-Radio}, Nathalie and Bhattacharya, Soumee and Ferrier, Jeremy and
+            Osmanski, Bruno F{\'e}lix and Cocco, Simona and Monasson, Remi and
+            Pezet, Sophie and Tanter, Micka{\"e}l},
   year = 2026,
   month = jan,
   journal = {Cell Reports},

--- a/docs/citing.md
+++ b/docs/citing.md
@@ -192,7 +192,9 @@ Or in BibTeX format:
   doi = {10.1016/j.celrep.2025.116791},
   urldate = {2025-12-30},
   langid = {english},
-  keywords = {animal speed,cerebral blood volume,continuous attractor network,CP: neuroscience,freely moving,functional ultrasound imaging,hippocampus,locomotion,path integration,spatial navigation},
+  keywords = {animal speed,cerebral blood volume,continuous attractor network,
+              CP: neuroscience,freely moving,functional ultrasound imaging,
+              hippocampus,locomotion,path integration,spatial navigation},
 }
 ```
 

--- a/docs/citing.md
+++ b/docs/citing.md
@@ -198,6 +198,18 @@ Or in BibTeX format:
 
 License: **[CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)**.
 
+### Landemard et al. (2026)
+
+The [`fetch_landemard_2026`][confusius.datasets.fetch_landemard_2026]
+function provides an fUSI-BIDS re-export of this dataset. If you use it,
+please cite:
+
+> Landemard, A. et al. (2026). Functional ultrasound imaging in head-fixed,
+> freely-running mice. *Nature*.
+> https://doi.org/10.1038/s41586-026-10350-9
+
+License: **[CC BY-NC 4.0](https://creativecommons.org/licenses/by-nc/4.0/)**.
+
 ## Templates
 
 ### Huang et al. (2025)

--- a/docs/user-guide/datasets.md
+++ b/docs/user-guide/datasets.md
@@ -196,11 +196,10 @@ fraction of this (see the examples below).
     | `acqs`      | `acq-`              | `["ref04", "ref11"]`             |
     | `datatypes` | datatype directory  | `"fusi"`, `["fusi", "angio"]`    |
 
-    The Landemard dataset has no session layer: every recording sits directly
-    under `sub-*/fusi/` or `sub-*/angio/`. Files that lack an `acq-` entity
-    (e.g. `sub-ALD001_scans.tsv`,
-    `sub-ALD001/angio/sub-ALD001_pwd.nii.gz`) are always included regardless
-    of the `acqs` filter.
+    The Landemard dataset has no session layer: every recording sits directly under
+    `sub-*/fusi/` or `sub-*/angio/`. Files that lack an `acq-` entity (e.g.
+    `sub-ALD001_scans.tsv`, `sub-ALD001/angio/sub-ALD001_pwd.nii.gz`) are always
+    included regardless of the `acqs` filter.
 
     The `datasets` filter accepts:
 

--- a/docs/user-guide/datasets.md
+++ b/docs/user-guide/datasets.md
@@ -191,7 +191,7 @@ fraction of this (see the examples below).
 
     | Filter      | BIDS entity / scope | Example                          |
     |-------------|---------------------|----------------------------------|
-    | `datasets`  | dataset name        | `"atlas-mapping"`, `["rawdata", "processed-data"]` |
+    | `datasets`  | dataset name        | `"atlas_mapping"`, `["rawdata", "processed_data"]` |
     | `subjects`  | `sub-`              | `["ALD001", "ALD019"]`           |
     | `acqs`      | `acq-`              | `["ref04", "ref11"]`             |
     | `datatypes` | datatype directory  | `"fusi"`, `["fusi", "angio"]`    |
@@ -206,14 +206,14 @@ fraction of this (see the examples below).
     | Name              | Contents                                                              |
     |-------------------|-----------------------------------------------------------------------|
     | `rawdata`         | Raw fUSI and angiography acquisitions per subject                     |
-    | `atlas-mapping`   | Per-subject Allen atlas alignment and region/session matches          |
-    | `processed-data`  | Dataset-level compact representations, PSTHs, and ephys→fUSI filters  |
+    | `atlas_mapping`   | Per-subject Allen atlas alignment and region/session matches          |
+    | `processed_data`  | Dataset-level compact representations, PSTHs, and ephys→fUSI filters  |
 
     ```python
     from confusius.datasets import fetch_landemard_2026
 
-    # All subjects, atlas-mapping derivative only.
-    bids_root = fetch_landemard_2026(datasets="atlas-mapping")
+    # All subjects, atlas_mapping derivative only.
+    bids_root = fetch_landemard_2026(datasets="atlas_mapping")
 
     # Or raw fUSI data for a single subject, with a single acquisition.
     bids_root = fetch_landemard_2026(

--- a/docs/user-guide/datasets.md
+++ b/docs/user-guide/datasets.md
@@ -85,6 +85,7 @@ list_datasets()
 ┃ Fetch function                   ┃     Size ┃ On disk ┃
 ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━┩
 │ fetch_cybis_pereira_2026         │ 12.88 GB │    ✗    │
+│ fetch_landemard_2026             │ 42.04 GB │    ✗    │
 │ fetch_nunez_elizalde_2022        │ 6.983 GB │    ✗    │
 │ fetch_template_huang_2025        │ 16.34 MB │    ✗    │
 │ fetch_template_pepe_mariani_2026 │ 5.508 MB │    ✗    │
@@ -177,6 +178,54 @@ fraction of this (see the examples below).
     )
     ```
 
+=== "Landemard 2026"
+
+    Functional ultrasound imaging recordings from awake, head-fixed,
+    freely-running mice, from Landemard et al. (2026)[^landemard2026],
+    hosted on [OSF (dkseb)](https://osf.io/dkseb/overview).
+    Total size: **~42 GB**.
+
+    Use [`fetch_landemard_2026`][confusius.datasets.fetch_landemard_2026] to
+    download the dataset. Four filters narrow the download:
+
+    | Filter      | BIDS entity / scope | Example                          |
+    |-------------|---------------------|----------------------------------|
+    | `datasets`  | dataset name        | `"atlas-mapping"`, `["rawdata", "processed-data"]` |
+    | `subjects`  | `sub-`              | `["ALD001", "ALD019"]`           |
+    | `acqs`      | `acq-`              | `["ref04", "ref11"]`             |
+    | `datatypes` | datatype directory  | `"fusi"`, `["fusi", "angio"]`    |
+
+    The Landemard dataset has no session layer: every recording sits directly
+    under `sub-*/fusi/` or `sub-*/angio/`. Compound acquisition labels such as
+    `ref11_run-1` are matched by their prefix — passing `acqs=["ref11"]`
+    selects both `ref11_run-1` and `ref11_run-2`. Files that lack an
+    `acq-` entity (e.g. `sub-ALD001_scans.tsv`,
+    `sub-ALD001/angio/sub-ALD001_pwd.nii.gz`) are always included regardless
+    of the `acqs` filter.
+
+    The `datasets` filter accepts:
+
+    | Name              | Contents                                                              |
+    |-------------------|-----------------------------------------------------------------------|
+    | `rawdata`         | Raw fUSI and angiography acquisitions per subject                     |
+    | `atlas-mapping`   | Per-subject Allen atlas alignment and region/session matches          |
+    | `processed-data`  | Dataset-level compact representations, PSTHs, and ephys→fUSI filters  |
+
+    ```python
+    from confusius.datasets import fetch_landemard_2026
+
+    # All subjects, atlas-mapping derivative only.
+    bids_root = fetch_landemard_2026(datasets="atlas-mapping")
+
+    # Or raw fUSI data for a single subject, with a single acquisition.
+    bids_root = fetch_landemard_2026(
+        datasets="rawdata",
+        subjects="ALD001",
+        acqs="ref04",
+        datatypes="fusi",
+    )
+    ```
+
 ## Working with fUSI-BIDS Datasets
 
 fUSI-BIDS dataset fetchers return a [`pathlib.Path`][pathlib.Path] to the dataset's root
@@ -263,6 +312,11 @@ parameters and return types.
     Cybis Pereira, F. et al. (2026). A vascular code for speed in the spatial
     navigation system. *Cell Reports*, 45(1).
     <https://doi.org/10.1016/j.celrep.2025.116791>
+
+[^landemard2026]:
+    Landemard, A. et al. (2026). Functional ultrasound imaging in head-fixed,
+    freely-running mice. *Nature*.
+    <https://doi.org/10.1038/s41586-026-10350-9>
 
 [^huang2025]:
     Huang, Y.-A. et al. (2025). OfUSA: OpenfUS Analyzer, a versatile open-source

--- a/docs/user-guide/datasets.md
+++ b/docs/user-guide/datasets.md
@@ -182,7 +182,8 @@ fraction of this (see the examples below).
 
     Functional ultrasound imaging recordings from awake, head-fixed,
     freely-running mice, from Landemard et al. (2026)[^landemard2026],
-    hosted on [OSF (dkseb)](https://osf.io/dkseb/overview).
+    re-exported to fUSI-BIDS format and hosted on
+    [OSF (dkseb)](https://osf.io/dkseb/overview).
     Total size: **~42 GB**.
 
     Use [`fetch_landemard_2026`][confusius.datasets.fetch_landemard_2026] to
@@ -314,8 +315,8 @@ parameters and return types.
     <https://doi.org/10.1016/j.celrep.2025.116791>
 
 [^landemard2026]:
-    Landemard, A. et al. (2026). Functional ultrasound imaging in head-fixed,
-    freely-running mice. *Nature*.
+    Landemard, A., Krumin, M., Harris, K. D., & Carandini, M. (2026). Brainwide
+    blood volume reflects opposing neural populations. *Nature*.
     <https://doi.org/10.1038/s41586-026-10350-9>
 
 [^huang2025]:

--- a/docs/user-guide/datasets.md
+++ b/docs/user-guide/datasets.md
@@ -197,10 +197,8 @@ fraction of this (see the examples below).
     | `datatypes` | datatype directory  | `"fusi"`, `["fusi", "angio"]`    |
 
     The Landemard dataset has no session layer: every recording sits directly
-    under `sub-*/fusi/` or `sub-*/angio/`. Compound acquisition labels such as
-    `ref11_run-1` are matched by their prefix — passing `acqs=["ref11"]`
-    selects both `ref11_run-1` and `ref11_run-2`. Files that lack an
-    `acq-` entity (e.g. `sub-ALD001_scans.tsv`,
+    under `sub-*/fusi/` or `sub-*/angio/`. Files that lack an `acq-` entity
+    (e.g. `sub-ALD001_scans.tsv`,
     `sub-ALD001/angio/sub-ALD001_pwd.nii.gz`) are always included regardless
     of the `acqs` filter.
 

--- a/src/confusius/datasets/__init__.py
+++ b/src/confusius/datasets/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from ._cybis_pereira_2026 import fetch_cybis_pereira_2026
 from ._huang_2025 import fetch_template_huang_2025
+from ._landemard_2026 import fetch_landemard_2026
 from ._nunez_elizalde_2022 import fetch_nunez_elizalde_2022
 from ._pepe_mariani_2026 import fetch_template_pepe_mariani_2026
 from ._registry import list_datasets
@@ -11,6 +12,7 @@ from ._utils import get_datasets_dir
 
 __all__ = [
     "fetch_cybis_pereira_2026",
+    "fetch_landemard_2026",
     "fetch_nunez_elizalde_2022",
     "fetch_template_huang_2025",
     "fetch_template_pepe_mariani_2026",

--- a/src/confusius/datasets/_cybis_pereira_2026.py
+++ b/src/confusius/datasets/_cybis_pereira_2026.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import cast
 
 from ._osf import OsfFileInfo, download_missing_osf_files, get_index
 from ._utils import get_datasets_dir
@@ -293,10 +292,7 @@ def fetch_cybis_pereira_2026(
                 f"Valid options: {sorted(_VALID_DATATYPES)}"
             )
 
-    index = cast(
-        "dict[str, OsfFileInfo]",
-        get_index(bids_dir, _OSF_PROJECT_ID, _BIDS_ROOT, refresh=refresh),
-    )
+    index = get_index(bids_dir, _OSF_PROJECT_ID, _BIDS_ROOT, refresh=refresh)
     files = _filter_files(index, datasets, subjects, sessions, acqs, datatypes)
 
     download_missing_osf_files(bids_dir, files)

--- a/src/confusius/datasets/_landemard_2026.py
+++ b/src/confusius/datasets/_landemard_2026.py
@@ -1,0 +1,263 @@
+"""Fetcher for the Landemard et al. (2026) fUSI-BIDS dataset."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import cast
+
+from ._osf import OsfFileInfo, download_missing_osf_files, get_index
+from ._utils import get_datasets_dir
+
+_OSF_PROJECT_ID = "dkseb"
+_BIDS_ROOT = "landemard-2026-bids"
+_TOTAL_SIZE_BYTES = 42_036_009_786
+
+_MISSING_INDEX_HINT = (
+    "Run 'landemard-upload --index-only' from the landemard-2026-bids "
+    "repository to generate it."
+)
+
+
+_VALID_DATASETS = frozenset({"rawdata", "atlas-mapping", "processed-data"})
+"""Valid values for the `datasets` parameter of `fetch_landemard_2026`."""
+
+
+_VALID_DATATYPES = frozenset({"fusi", "angio"})
+"""Valid values for the `datatypes` parameter of `fetch_landemard_2026`."""
+
+
+_DATASET_DIRS = {
+    "atlas-mapping": "atlas_mapping",
+    "processed-data": "processed_data",
+}
+"""Map public dataset names (hyphen-separated) to their on-disk directory names."""
+
+
+def _filter_files(
+    index: dict[str, OsfFileInfo],
+    datasets: list[str] | None,
+    subjects: list[str] | None,
+    acqs: list[str] | None,
+    datatypes: list[str] | None,
+) -> dict[str, OsfFileInfo]:
+    """Filter the index to files matching the requested datasets and subjects.
+
+    Top-level BIDS metadata files (dataset_description.json, participants.*,
+    etc.) and subject-level files (e.g. `sub-ALD001_scans.tsv`) are always
+    included. Unlike `fetch_cybis_pereira_2026`, the Landemard dataset has no
+    session layer: every recording sits directly under `sub-*/fusi/` or
+    `sub-*/angio/`.
+
+    Parameters
+    ----------
+    index : dict[str, OsfFileInfo]
+        Full dataset index as returned by `get_index`.
+    datasets : list[str] or None
+        Datasets to include. Use `"rawdata"` for the raw fUSI/angio data and
+        derivative names for processed outputs: `"atlas-mapping"`,
+        `"processed-data"`. If `None`, all datasets are included.
+    subjects : list[str] or None
+        Subject IDs to include (without "sub-" prefix), e.g. `["ALD001"]`.
+        If `None`, all subjects are included.
+    acqs : list[str] or None
+        Acquisition labels to include (without "acq-" prefix), e.g.
+        `["ref04", "ref11"]`. If `None`, all acquisitions are included.
+        Files with no `acq-` entity are passed through. The Landemard
+        dataset uses compound labels such as `ref11_run-1`; passing the
+        prefix `ref11` selects both `ref11_run-1` and `ref11_run-2`.
+    datatypes : list[str] or None
+        BIDS datatype directories to include, e.g. `["fusi"]` or
+        `["fusi", "angio"]`. Valid values are `"fusi"` and `"angio"`.
+        If `None`, all datatypes are included. Files that do not sit
+        under a datatype directory (e.g. subject-level `scans.tsv`)
+        are passed through.
+
+    Returns
+    -------
+    dict[str, OsfFileInfo]
+        Subset of the index matching the filters.
+    """
+    filtered: dict[str, OsfFileInfo] = {}
+
+    for path, file_info in index.items():
+        parts = Path(path).parts
+
+        # Derivatives.
+        if parts[0] == "derivatives":
+            # Filter by derivative name.
+            if len(parts) >= 2:
+                deriv_name = parts[1]
+                if datasets is not None:
+                    accepted_dirs = {_DATASET_DIRS.get(name, name) for name in datasets}
+                    if deriv_name not in accepted_dirs:
+                        continue
+
+            # Subject filter within derivatives.
+            derivative_sub = next((p for p in parts if p.startswith("sub-")), None)
+            if derivative_sub is not None:
+                sub_id = derivative_sub.removeprefix("sub-")
+                if subjects is not None and sub_id not in subjects:
+                    continue
+
+            filtered[path] = file_info
+            continue
+
+        # Always include top-level BIDS metadata files.
+        if not parts[0].startswith("sub-"):
+            filtered[path] = file_info
+            continue
+
+        # Rawdata (sub-* at root).
+        if datasets is not None and "rawdata" not in datasets:
+            continue
+
+        sub_id = parts[0].removeprefix("sub-")
+        if subjects is not None and sub_id not in subjects:
+            continue
+
+        # Subject-level files (e.g. sub-ALD001_scans.tsv) — pass through.
+        if len(parts) == 1:
+            filtered[path] = file_info
+            continue
+
+        # Datatype filter — only applies when sitting under a known datatype.
+        if datatypes is not None and parts[1] in _VALID_DATATYPES:
+            if parts[1] not in datatypes:
+                continue
+
+        # Acquisition filter.
+        if acqs is not None:
+            match = re.search(r"acq-([^_]+)", parts[-1])
+            if match is not None and match.group(1) not in acqs:
+                continue
+
+        filtered[path] = file_info
+
+    return filtered
+
+
+def fetch_landemard_2026(
+    data_dir: str | Path | None = None,
+    datasets: str | list[str] | None = None,
+    subjects: str | list[str] | None = None,
+    acqs: str | list[str] | None = None,
+    datatypes: str | list[str] | None = None,
+    refresh: bool = False,
+) -> Path:
+    """Fetch the Landemard 2026 fUSI-BIDS dataset.
+
+    Downloads functional ultrasound imaging recordings from awake,
+    head-fixed, freely-running mice, distributed in fUSI-BIDS format
+    from Landemard et al. (2026).
+
+    Files are downloaded on first call and cached locally. Subsequent calls
+    with the same `data_dir` return immediately for already-cached files.
+
+    Parameters
+    ----------
+    data_dir : str or pathlib.Path, optional
+        Directory in which to cache the dataset. Defaults to the platform
+        cache directory (e.g. `~/.cache/confusius` on Linux,
+        `~/Library/Caches/confusius` on macOS,
+        `%LOCALAPPDATA%\\confusius\\Cache` on Windows),
+        overridable via the `CONFUSIUS_DATA` environment variable.
+    datasets : str or list[str], optional
+        Datasets to download. Use `"rawdata"` for the raw fUSI/angio data
+        and derivative names for processed outputs: `"atlas-mapping"`,
+        `"processed-data"`. Accepts a single string or a list. If not
+        provided, all datasets are downloaded.
+    subjects : str or list[str], optional
+        Subject IDs to download (without "sub-" prefix), e.g. `"ALD001"`
+        or `["ALD001", "ALD019"]`. If not provided, all subjects are
+        downloaded.
+    acqs : str or list[str], optional
+        Acquisition labels to download (without "acq-" prefix), e.g.
+        `"ref04"` or `["ref04", "ref11"]`. The Landemard dataset uses
+        compound labels such as `ref11_run-1`; passing the prefix
+        `ref11` selects both `ref11_run-1` and `ref11_run-2`. If not
+        provided, all acquisitions are downloaded. Files with no
+        `acq-` entity (e.g. `sub-ALD001_scans.tsv`,
+        `sub-ALD001/angio/sub-ALD001_pwd.nii.gz`) are always included.
+    datatypes : str or list[str], optional
+        BIDS datatype directories to download, e.g. `"fusi"`, `"angio"`,
+        `["fusi", "angio"]`. Valid values are `"fusi"` and `"angio"`.
+        If not provided, all datatypes are downloaded. Files that do
+        not sit under a datatype directory (e.g. subject-level
+        `scans.tsv`) are always included.
+    refresh : bool, default: False
+        Whether to re-fetch the dataset index from OSF and download any files
+        that are missing locally. If `False` and all requested files are
+        already cached, the function returns immediately without any network
+        access.
+
+    Returns
+    -------
+    pathlib.Path
+        Path to the BIDS root directory of the cached dataset.
+
+    Raises
+    ------
+    ValueError
+        If an unknown dataset name is passed in `datasets`, or an
+        unknown datatype is passed in `datatypes`.
+
+    References
+    ----------
+    [^1]:
+        Landemard, A. et al. (2026). Functional ultrasound imaging in
+        head-fixed, freely-running mice. *Nature*.
+        [https://doi.org/10.1038/s41586-026-10350-9](https://doi.org/10.1038/s41586-026-10350-9)
+
+    [^2]:
+        fUSI-BIDS dataset on OSF:
+        [https://osf.io/dkseb/](https://osf.io/dkseb/overview)
+
+    [^3]:
+        Dataset license (CC BY-NC 4.0):
+        [https://creativecommons.org/licenses/by-nc/4.0/](https://creativecommons.org/licenses/by-nc/4.0/)
+    """
+    bids_dir = get_datasets_dir(data_dir) / _BIDS_ROOT
+    bids_dir.mkdir(parents=True, exist_ok=True)
+
+    # Normalize str to list.
+    if isinstance(datasets, str):
+        datasets = [datasets]
+    if isinstance(subjects, str):
+        subjects = [subjects]
+    if isinstance(acqs, str):
+        acqs = [acqs]
+    if isinstance(datatypes, str):
+        datatypes = [datatypes]
+
+    if datasets is not None:
+        invalid = set(datasets) - _VALID_DATASETS
+        if invalid:
+            raise ValueError(
+                f"Unknown dataset(s): {invalid}. "
+                f"Valid options: {sorted(_VALID_DATASETS)}"
+            )
+
+    if datatypes is not None:
+        invalid = set(datatypes) - _VALID_DATATYPES
+        if invalid:
+            raise ValueError(
+                f"Unknown datatype(s): {invalid}. "
+                f"Valid options: {sorted(_VALID_DATATYPES)}"
+            )
+
+    index = cast(
+        "dict[str, OsfFileInfo]",
+        get_index(
+            bids_dir,
+            _OSF_PROJECT_ID,
+            _BIDS_ROOT,
+            refresh=refresh,
+            missing_index_hint=_MISSING_INDEX_HINT,
+        ),
+    )
+    files = _filter_files(index, datasets, subjects, acqs, datatypes)
+
+    download_missing_osf_files(bids_dir, files)
+
+    return bids_dir

--- a/src/confusius/datasets/_landemard_2026.py
+++ b/src/confusius/datasets/_landemard_2026.py
@@ -63,9 +63,8 @@ def _filter_files(
     acqs : list[str] or None
         Acquisition labels to include (without "acq-" prefix), e.g.
         `["ref04", "ref11"]`. If `None`, all acquisitions are included.
-        Files with no `acq-` entity are passed through. The Landemard
-        dataset uses compound labels such as `ref11_run-1`; passing the
-        prefix `ref11` selects both `ref11_run-1` and `ref11_run-2`.
+        Files with no `acq-` entity are passed through. The `run-` entity
+        is not exposed as a filter.
     datatypes : list[str] or None
         BIDS datatype directories to include, e.g. `["fusi"]` or
         `["fusi", "angio"]`. Valid values are `"fusi"` and `"angio"`.
@@ -173,12 +172,11 @@ def fetch_landemard_2026(
         downloaded.
     acqs : str or list[str], optional
         Acquisition labels to download (without "acq-" prefix), e.g.
-        `"ref04"` or `["ref04", "ref11"]`. The Landemard dataset uses
-        compound labels such as `ref11_run-1`; passing the prefix
-        `ref11` selects both `ref11_run-1` and `ref11_run-2`. If not
-        provided, all acquisitions are downloaded. Files with no
-        `acq-` entity (e.g. `sub-ALD001_scans.tsv`,
+        `"ref04"` or `["ref04", "ref11"]`. If not provided, all
+        acquisitions are downloaded. Files with no `acq-` entity
+        (e.g. `sub-ALD001_scans.tsv`,
         `sub-ALD001/angio/sub-ALD001_pwd.nii.gz`) are always included.
+        The `run-` entity is not exposed as a filter.
     datatypes : str or list[str], optional
         BIDS datatype directories to download, e.g. `"fusi"`, `"angio"`,
         `["fusi", "angio"]`. Valid values are `"fusi"` and `"angio"`.

--- a/src/confusius/datasets/_landemard_2026.py
+++ b/src/confusius/datasets/_landemard_2026.py
@@ -97,15 +97,16 @@ def _filter_files(
         if subjects is not None and sub_id not in subjects:
             continue
 
-        # Subject-level files (e.g. sub-ALD001_scans.tsv) — pass through.
-        if len(parts) == 1:
+        # Subject-level files (e.g. sub-ALD001/sub-ALD001_scans.tsv) pass
+        # through: they sit directly under the subject folder with no
+        # datatype layer, so the acq filter does not apply.
+        if len(parts) == 1 or parts[1] not in _VALID_DATATYPES:
             filtered[path] = file_info
             continue
 
         # Datatype filter (only applies when sitting under a known datatype).
-        if datatypes is not None and parts[1] in _VALID_DATATYPES:
-            if parts[1] not in datatypes:
-                continue
+        if datatypes is not None and parts[1] not in datatypes:
+            continue
 
         # Acquisition filter.
         if acqs is not None:

--- a/src/confusius/datasets/_landemard_2026.py
+++ b/src/confusius/datasets/_landemard_2026.py
@@ -13,25 +13,13 @@ _OSF_PROJECT_ID = "dkseb"
 _BIDS_ROOT = "landemard-2026-bids"
 _TOTAL_SIZE_BYTES = 42_036_009_786
 
-_MISSING_INDEX_HINT = (
-    "Run 'landemard-upload --index-only' from the landemard-2026-bids "
-    "repository to generate it."
-)
 
-
-_VALID_DATASETS = frozenset({"rawdata", "atlas-mapping", "processed-data"})
+_VALID_DATASETS = frozenset({"rawdata", "atlas_mapping", "processed_data"})
 """Valid values for the `datasets` parameter of `fetch_landemard_2026`."""
 
 
 _VALID_DATATYPES = frozenset({"fusi", "angio"})
 """Valid values for the `datatypes` parameter of `fetch_landemard_2026`."""
-
-
-_DATASET_DIRS = {
-    "atlas-mapping": "atlas_mapping",
-    "processed-data": "processed_data",
-}
-"""Map public dataset names (hyphen-separated) to their on-disk directory names."""
 
 
 def _filter_files(
@@ -53,9 +41,9 @@ def _filter_files(
     index : dict[str, OsfFileInfo]
         Full dataset index as returned by `get_index`.
     datasets : list[str] or None
-        Datasets to include. Use `"rawdata"` for the raw fUSI/angio data and derivative
-        names for processed outputs: `"atlas-mapping"`, `"processed-data"`. If `None`,
-        all datasets are included.
+        Datasets to include. Use `"rawdata"` for the raw fUSI/angio data and
+        derivative names for processed outputs: `"atlas_mapping"`,
+        `"processed_data"`. If `None`, all datasets are included.
     subjects : list[str] or None
         Subject IDs to include (without "sub-" prefix), e.g. `["ALD001"]`. If `None`,
         all subjects are included.
@@ -84,10 +72,8 @@ def _filter_files(
             # Filter by derivative name.
             if len(parts) >= 2:
                 deriv_name = parts[1]
-                if datasets is not None:
-                    accepted_dirs = {_DATASET_DIRS.get(name, name) for name in datasets}
-                    if deriv_name not in accepted_dirs:
-                        continue
+                if datasets is not None and deriv_name not in datasets:
+                    continue
 
             # Subject filter within derivatives.
             derivative_sub = next((p for p in parts if p.startswith("sub-")), None)
@@ -117,7 +103,7 @@ def _filter_files(
             filtered[path] = file_info
             continue
 
-        # Datatype filter — only applies when sitting under a known datatype.
+        # Datatype filter (only applies when sitting under a known datatype).
         if datatypes is not None and parts[1] in _VALID_DATATYPES:
             if parts[1] not in datatypes:
                 continue
@@ -143,48 +129,41 @@ def fetch_landemard_2026(
 ) -> Path:
     """Fetch the Landemard 2026 fUSI-BIDS dataset.
 
-    Downloads functional ultrasound imaging recordings from awake,
-    head-fixed, freely-running mice, re-exported to fUSI-BIDS format
-    from Landemard et al. (2026).
+    Downloads functional ultrasound imaging recordings from awake, head-fixed,
+    freely-running mice, re-exported to fUSI-BIDS format from Landemard et al. (2026).
 
-    Files are downloaded on first call and cached locally. Subsequent calls
-    with the same `data_dir` return immediately for already-cached files.
+    Files are downloaded on first call and cached locally. Subsequent calls with the
+    same `data_dir` return immediately for already-cached files.
 
     Parameters
     ----------
     data_dir : str or pathlib.Path, optional
-        Directory in which to cache the dataset. Defaults to the platform
-        cache directory (e.g. `~/.cache/confusius` on Linux,
-        `~/Library/Caches/confusius` on macOS,
-        `%LOCALAPPDATA%\\confusius\\Cache` on Windows),
-        overridable via the `CONFUSIUS_DATA` environment variable.
+        Directory in which to cache the dataset. Defaults to the platform cache
+        directory (e.g. `~/.cache/confusius` on Linux, `~/Library/Caches/confusius` on
+        macOS, `%LOCALAPPDATA%\\confusius\\Cache` on Windows), overridable via the
+        `CONFUSIUS_DATA` environment variable.
     datasets : str or list[str], optional
-        Datasets to download. Use `"rawdata"` for the raw fUSI/angio data
-        and derivative names for processed outputs: `"atlas-mapping"`,
-        `"processed-data"`. Accepts a single string or a list. If not
-        provided, all datasets are downloaded.
+        Datasets to download. Use `"rawdata"` for the raw fUSI/angio data and derivative
+        names for processed outputs: `"atlas_mapping"`, `"processed_data"`. Accepts a
+        single string or a list. If not provided, all datasets are downloaded.
     subjects : str or list[str], optional
-        Subject IDs to download (without "sub-" prefix), e.g. `"ALD001"`
-        or `["ALD001", "ALD019"]`. If not provided, all subjects are
-        downloaded.
+        Subject IDs to download (without "sub-" prefix), e.g. `"ALD001"` or `["ALD001",
+        "ALD019"]`. If not provided, all subjects are downloaded.
     acqs : str or list[str], optional
-        Acquisition labels to download (without "acq-" prefix), e.g.
-        `"ref04"` or `["ref04", "ref11"]`. If not provided, all
-        acquisitions are downloaded. Files with no `acq-` entity
-        (e.g. `sub-ALD001_scans.tsv`,
-        `sub-ALD001/angio/sub-ALD001_pwd.nii.gz`) are always included.
-        The `run-` entity is not exposed as a filter.
+        Acquisition labels to download (without "acq-" prefix), e.g. `"ref04"` or
+        `["ref04", "ref11"]`. If not provided, all acquisitions are downloaded. Files
+        with no `acq-` entity (e.g. `sub-ALD001_scans.tsv`,
+        `sub-ALD001/angio/sub-ALD001_pwd.nii.gz`) are always included. The `run-` entity
+        is not exposed as a filter.
     datatypes : str or list[str], optional
-        BIDS datatype directories to download, e.g. `"fusi"`, `"angio"`,
-        `["fusi", "angio"]`. Valid values are `"fusi"` and `"angio"`.
-        If not provided, all datatypes are downloaded. Files that do
-        not sit under a datatype directory (e.g. subject-level
-        `scans.tsv`) are always included.
+        BIDS datatype directories to download, e.g. `"fusi"`, `"angio"`, `["fusi",
+        "angio"]`. Valid values are `"fusi"` and `"angio"`. If not provided, all
+        datatypes are downloaded. Files that do not sit under a datatype directory (e.g.
+        subject-level `scans.tsv`) are always included.
     refresh : bool, default: False
-        Whether to re-fetch the dataset index from OSF and download any files
-        that are missing locally. If `False` and all requested files are
-        already cached, the function returns immediately without any network
-        access.
+        Whether to re-fetch the dataset index from OSF and download any files that are
+        missing locally. If `False` and all requested files are already cached, the
+        function returns immediately without any network access.
 
     Returns
     -------
@@ -194,8 +173,8 @@ def fetch_landemard_2026(
     Raises
     ------
     ValueError
-        If an unknown dataset name is passed in `datasets`, or an
-        unknown datatype is passed in `datatypes`.
+        If an unknown dataset name is passed in `datasets`, or an unknown datatype is
+        passed in `datatypes`.
 
     References
     ----------
@@ -248,7 +227,6 @@ def fetch_landemard_2026(
             _OSF_PROJECT_ID,
             _BIDS_ROOT,
             refresh=refresh,
-            missing_index_hint=_MISSING_INDEX_HINT,
         ),
     )
     files = _filter_files(index, datasets, subjects, acqs, datatypes)

--- a/src/confusius/datasets/_landemard_2026.py
+++ b/src/confusius/datasets/_landemard_2026.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import cast
 
 from ._osf import OsfFileInfo, download_missing_osf_files, get_index
 from ._utils import get_datasets_dir
@@ -194,7 +193,6 @@ def fetch_landemard_2026(
     bids_dir = get_datasets_dir(data_dir) / _BIDS_ROOT
     bids_dir.mkdir(parents=True, exist_ok=True)
 
-    # Normalize str to list.
     if isinstance(datasets, str):
         datasets = [datasets]
     if isinstance(subjects, str):
@@ -220,15 +218,7 @@ def fetch_landemard_2026(
                 f"Valid options: {sorted(_VALID_DATATYPES)}"
             )
 
-    index = cast(
-        "dict[str, OsfFileInfo]",
-        get_index(
-            bids_dir,
-            _OSF_PROJECT_ID,
-            _BIDS_ROOT,
-            refresh=refresh,
-        ),
-    )
+    index = get_index(bids_dir, _OSF_PROJECT_ID, _BIDS_ROOT, refresh=refresh)
     files = _filter_files(index, datasets, subjects, acqs, datatypes)
 
     download_missing_osf_files(bids_dir, files)

--- a/src/confusius/datasets/_landemard_2026.py
+++ b/src/confusius/datasets/_landemard_2026.py
@@ -43,34 +43,31 @@ def _filter_files(
 ) -> dict[str, OsfFileInfo]:
     """Filter the index to files matching the requested datasets and subjects.
 
-    Top-level BIDS metadata files (dataset_description.json, participants.*,
-    etc.) and subject-level files (e.g. `sub-ALD001_scans.tsv`) are always
-    included. Unlike `fetch_cybis_pereira_2026`, the Landemard dataset has no
-    session layer: every recording sits directly under `sub-*/fusi/` or
-    `sub-*/angio/`.
+    Top-level BIDS metadata files (dataset_description.json, participants.*, etc.) and
+    subject-level files (e.g. `sub-ALD001_scans.tsv`) are always included. Unlike
+    `fetch_cybis_pereira_2026`, the Landemard dataset has no session layer: every
+    recording sits directly under `sub-*/fusi/` or `sub-*/angio/`.
 
     Parameters
     ----------
     index : dict[str, OsfFileInfo]
         Full dataset index as returned by `get_index`.
     datasets : list[str] or None
-        Datasets to include. Use `"rawdata"` for the raw fUSI/angio data and
-        derivative names for processed outputs: `"atlas-mapping"`,
-        `"processed-data"`. If `None`, all datasets are included.
+        Datasets to include. Use `"rawdata"` for the raw fUSI/angio data and derivative
+        names for processed outputs: `"atlas-mapping"`, `"processed-data"`. If `None`,
+        all datasets are included.
     subjects : list[str] or None
-        Subject IDs to include (without "sub-" prefix), e.g. `["ALD001"]`.
-        If `None`, all subjects are included.
+        Subject IDs to include (without "sub-" prefix), e.g. `["ALD001"]`. If `None`,
+        all subjects are included.
     acqs : list[str] or None
-        Acquisition labels to include (without "acq-" prefix), e.g.
-        `["ref04", "ref11"]`. If `None`, all acquisitions are included.
-        Files with no `acq-` entity are passed through. The `run-` entity
-        is not exposed as a filter.
-    datatypes : list[str] or None
-        BIDS datatype directories to include, e.g. `["fusi"]` or
-        `["fusi", "angio"]`. Valid values are `"fusi"` and `"angio"`.
-        If `None`, all datatypes are included. Files that do not sit
-        under a datatype directory (e.g. subject-level `scans.tsv`)
+        Acquisition labels to include (without "acq-" prefix), e.g. `["ref04",
+        "ref11"]`. If `None`, all acquisitions are included. Files with no `acq-` entity
         are passed through.
+    datatypes : list[str] or None
+        BIDS datatype directories to include, e.g. `["fusi"]` or `["fusi", "angio"]`.
+        Valid values are `"fusi"` and `"angio"`. If `None`, all datatypes are included.
+        Files that do not sit under a datatype directory (e.g. subject-level
+        `scans.tsv`) are passed through.
 
     Returns
     -------

--- a/src/confusius/datasets/_landemard_2026.py
+++ b/src/confusius/datasets/_landemard_2026.py
@@ -148,7 +148,7 @@ def fetch_landemard_2026(
     """Fetch the Landemard 2026 fUSI-BIDS dataset.
 
     Downloads functional ultrasound imaging recordings from awake,
-    head-fixed, freely-running mice, distributed in fUSI-BIDS format
+    head-fixed, freely-running mice, re-exported to fUSI-BIDS format
     from Landemard et al. (2026).
 
     Files are downloaded on first call and cached locally. Subsequent calls
@@ -205,8 +205,8 @@ def fetch_landemard_2026(
     References
     ----------
     [^1]:
-        Landemard, A. et al. (2026). Functional ultrasound imaging in
-        head-fixed, freely-running mice. *Nature*.
+        Landemard, A., Krumin, M., Harris, K. D., & Carandini, M. (2026).
+        Brainwide blood volume reflects opposing neural populations. *Nature*.
         [https://doi.org/10.1038/s41586-026-10350-9](https://doi.org/10.1038/s41586-026-10350-9)
 
     [^2]:

--- a/src/confusius/datasets/_nunez_elizalde_2022.py
+++ b/src/confusius/datasets/_nunez_elizalde_2022.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import cast
 
 from ._osf import OsfFileInfo, download_missing_osf_files, get_index
 from ._utils import get_datasets_dir
@@ -193,15 +192,7 @@ def fetch_nunez_elizalde_2022(
     if isinstance(acqs, str):
         acqs = [acqs]
 
-    index = cast(
-        "dict[str, OsfFileInfo]",
-        get_index(
-            bids_dir,
-            _OSF_PROJECT_ID,
-            _BIDS_ROOT,
-            refresh=refresh,
-        ),
-    )
+    index = get_index(bids_dir, _OSF_PROJECT_ID, _BIDS_ROOT, refresh=refresh)
     files = _filter_files(index, subjects, sessions, tasks, acqs)
 
     download_missing_osf_files(bids_dir, files)

--- a/src/confusius/datasets/_nunez_elizalde_2022.py
+++ b/src/confusius/datasets/_nunez_elizalde_2022.py
@@ -13,11 +13,6 @@ _OSF_PROJECT_ID = "43skw"
 _BIDS_ROOT = "nunez-elizalde-2022-bids"
 _TOTAL_SIZE_BYTES = 6_982_575_320
 
-_MISSING_INDEX_HINT = (
-    "Run 'nunez-upload --index-only' from the nunez-elizalde-2022-bids "
-    "repository to generate it."
-)
-
 
 def _filter_files(
     index: dict[str, OsfFileInfo],
@@ -205,7 +200,6 @@ def fetch_nunez_elizalde_2022(
             _OSF_PROJECT_ID,
             _BIDS_ROOT,
             refresh=refresh,
-            missing_index_hint=_MISSING_INDEX_HINT,
         ),
     )
     files = _filter_files(index, subjects, sessions, tasks, acqs)

--- a/src/confusius/datasets/_osf.py
+++ b/src/confusius/datasets/_osf.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, TypedDict
+from typing import TypedDict
 
 import pooch
 import requests
@@ -90,7 +90,7 @@ def get_index(
     project_id: str,
     bids_root: str,
     refresh: bool = False,
-) -> dict[str, Any]:
+) -> dict[str, OsfFileInfo]:
     """Return the dataset index, preferring a locally cached copy.
 
     When `refresh` is `False` and a cached index exists in `data_dir`,
@@ -113,10 +113,12 @@ def get_index(
 
     Returns
     -------
-    dict[str, Any]
-        Mapping from BIDS-relative file paths to OSF-side identifiers.
-        The value schema is dataset-specific; callers narrow the type at
-        their assignment site.
+    dict[str, OsfFileInfo]
+        Mapping from BIDS-relative file paths to
+        [`OsfFileInfo`][confusius.datasets._osf.OsfFileInfo] entries (`osf_path` and
+        `size` in bytes). The schema is the same for every dataset: the index is
+        produced by the per-dataset upload script in the confusius-tools GitHub
+        organisation and stored on OSF as `dataset_index.json`.
     """
     index_path = data_dir / _INDEX_FILENAME
     if not refresh and index_path.exists():

--- a/src/confusius/datasets/_osf.py
+++ b/src/confusius/datasets/_osf.py
@@ -35,11 +35,7 @@ class OsfFileInfo(TypedDict):
     size: int
 
 
-def resolve_index_url(
-    project_id: str,
-    bids_root: str,
-    missing_index_hint: str | None = None,
-) -> str:
+def resolve_index_url(project_id: str, bids_root: str) -> str:
     """Return the OSF download URL for a dataset's index file.
 
     Makes two OSF API calls: one to locate the BIDS root folder within the
@@ -52,10 +48,6 @@ def resolve_index_url(
     bids_root : str
         Name of the BIDS root folder on OSF,
         e.g. `"nunez-elizalde-2022-bids"`.
-    missing_index_hint : str, optional
-        Additional sentence appended to the `RuntimeError` message when
-        the index file itself is not found on OSF. Useful for pointing
-        maintainers at the tool that generates the index.
 
     Returns
     -------
@@ -88,10 +80,9 @@ def resolve_index_url(
         if item["attributes"]["name"] == _INDEX_FILENAME:
             return item["links"]["download"]
 
-    message = f"{_INDEX_FILENAME!r} was not found on OSF (project {project_id})."
-    if missing_index_hint:
-        message = f"{message} {missing_index_hint}"
-    raise RuntimeError(message)
+    raise RuntimeError(
+        f"{_INDEX_FILENAME!r} was not found on OSF (project {project_id})."
+    )
 
 
 def get_index(
@@ -99,7 +90,6 @@ def get_index(
     project_id: str,
     bids_root: str,
     refresh: bool = False,
-    missing_index_hint: str | None = None,
 ) -> dict[str, Any]:
     """Return the dataset index, preferring a locally cached copy.
 
@@ -120,9 +110,6 @@ def get_index(
     refresh : bool, default: False
         If `True`, always re-fetch the latest index from OSF even if a
         local copy exists.
-    missing_index_hint : str, optional
-        Forwarded to
-        [`resolve_index_url`][confusius.datasets._osf.resolve_index_url].
 
     Returns
     -------
@@ -135,9 +122,7 @@ def get_index(
     if not refresh and index_path.exists():
         return json.loads(index_path.read_text(encoding="utf-8"))
 
-    url = resolve_index_url(
-        project_id, bids_root, missing_index_hint=missing_index_hint
-    )
+    url = resolve_index_url(project_id, bids_root)
     response = requests.get(url)
     response.raise_for_status()
     index = response.json()

--- a/src/confusius/datasets/_registry.py
+++ b/src/confusius/datasets/_registry.py
@@ -8,6 +8,8 @@ from ._cybis_pereira_2026 import _BIDS_ROOT as _cybis_pereira_2026_bids_root
 from ._cybis_pereira_2026 import _TOTAL_SIZE_BYTES as _cybis_pereira_2026_size
 from ._huang_2025 import _TEMPLATE_ROOT as _huang_2025_template_root
 from ._huang_2025 import _TOTAL_SIZE_BYTES as _huang_2025_size
+from ._landemard_2026 import _BIDS_ROOT as _landemard_2026_bids_root
+from ._landemard_2026 import _TOTAL_SIZE_BYTES as _landemard_2026_size
 from ._nunez_elizalde_2022 import _BIDS_ROOT as _nunez_elizalde_2022_bids_root
 from ._nunez_elizalde_2022 import _TOTAL_SIZE_BYTES as _nunez_elizalde_2022_size
 from ._pepe_mariani_2026 import _TEMPLATE_ROOT as _pepe_mariani_2026_template_root
@@ -23,6 +25,11 @@ _REGISTRY: tuple[RegistryEntry, ...] = (
         "fetch_cybis_pereira_2026",
         _cybis_pereira_2026_size,
         _cybis_pereira_2026_bids_root,
+    ),
+    (
+        "fetch_landemard_2026",
+        _landemard_2026_size,
+        _landemard_2026_bids_root,
     ),
     (
         "fetch_nunez_elizalde_2022",

--- a/tests/unit/test_datasets/test_landemard_2026.py
+++ b/tests/unit/test_datasets/test_landemard_2026.py
@@ -231,8 +231,8 @@ def test_fetch_acq_filter(tmp_path, mock_get_index, mock_retrieve):
     assert "Atlas_alignment_ALD001.npz" in downloaded
 
 
-def test_fetch_acq_filter_compound_prefix(tmp_path, mock_get_index, mock_retrieve):
-    """Passing `ref11` selects both `ref11_run-1` and any sibling compound labels."""
+def test_fetch_acq_filter_includes_sidecars(tmp_path, mock_get_index, mock_retrieve):
+    """`acqs` keeps all sidecar files (e.g. physio) for the matching acquisition."""
     fetch_landemard_2026(data_dir=tmp_path, acqs=["ref11"])
 
     downloaded = _downloaded_paths(mock_retrieve)

--- a/tests/unit/test_datasets/test_landemard_2026.py
+++ b/tests/unit/test_datasets/test_landemard_2026.py
@@ -42,6 +42,11 @@ _FAKE_INDEX = {
         "osf_path": "/file008",
         "size": 200,
     },
+    # Fusi file with no `acq-` entity (mirrors the cybis fetcher's fixture).
+    "sub-ALD001/fusi/sub-ALD001_task-awake_pwd.nii.gz": {
+        "osf_path": "/file008b",
+        "size": 1000,
+    },
     "sub-ALD001/sub-ALD001_scans.tsv": {"osf_path": "/file009", "size": 50},
     # Second subject with one acquisition.
     "sub-ALD002/fusi/sub-ALD002_task-awake_acq-ref04_pwd.nii.gz": {
@@ -199,6 +204,17 @@ def test_fetch_dataset_filter_processed_data(tmp_path, mock_get_index, mock_retr
     assert "sub-ALD001_task-awake_acq-ref04_pwd.nii.gz" not in downloaded
 
 
+def test_fetch_dataset_filter_combined(tmp_path, mock_get_index, mock_retrieve):
+    """Combining `rawdata` (default-mapped) and a hyphen-mapped derivative."""
+    fetch_landemard_2026(data_dir=tmp_path, datasets=["rawdata", "atlas-mapping"])
+
+    downloaded = _downloaded_paths(mock_retrieve)
+    assert "sub-ALD001_task-awake_acq-ref04_pwd.nii.gz" in downloaded
+    assert "Atlas_alignment_ALD001.npz" in downloaded
+    # Non-listed derivative still excluded.
+    assert "Compact_data_regions_ALD001.npz" not in downloaded
+
+
 def test_fetch_subject_filter(tmp_path, mock_get_index, mock_retrieve):
     fetch_landemard_2026(data_dir=tmp_path, subjects=["ALD001"])
 
@@ -228,6 +244,7 @@ def test_fetch_acq_filter(tmp_path, mock_get_index, mock_retrieve):
     # Files with no acq entity pass through.
     assert "sub-ALD001_scans.tsv" in downloaded
     assert "sub-ALD001_pwd.nii.gz" in downloaded
+    assert "sub-ALD001_task-awake_pwd.nii.gz" in downloaded
     assert "Atlas_alignment_ALD001.npz" in downloaded
 
 

--- a/tests/unit/test_datasets/test_landemard_2026.py
+++ b/tests/unit/test_datasets/test_landemard_2026.py
@@ -1,0 +1,414 @@
+"""Unit tests for confusius.datasets._landemard_2026."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import requests
+
+from confusius.datasets import fetch_landemard_2026
+from confusius.datasets._landemard_2026 import (
+    _BIDS_ROOT,
+    _MISSING_INDEX_HINT,
+    _OSF_PROJECT_ID,
+)
+from confusius.datasets._pooch import _MAX_DOWNLOAD_RETRIES
+
+# Minimal fake index representing the different file categories in the dataset.
+_FAKE_INDEX = {
+    # Top-level BIDS metadata — always included.
+    "dataset_description.json": {"osf_path": "/file001", "size": 100},
+    "participants.tsv": {"osf_path": "/file002", "size": 200},
+    "README.txt": {"osf_path": "/file002b", "size": 50},
+    # Rawdata — fusi and angio, two acquisitions (ref04 and ref11_run-1) and
+    # a subject-level scans.tsv with no datatype.
+    "sub-ALD001/angio/sub-ALD001_pwd.json": {"osf_path": "/file003", "size": 50},
+    "sub-ALD001/angio/sub-ALD001_pwd.nii.gz": {"osf_path": "/file004", "size": 800},
+    "sub-ALD001/fusi/sub-ALD001_task-awake_acq-ref04_pwd.nii.gz": {
+        "osf_path": "/file005",
+        "size": 1000,
+    },
+    "sub-ALD001/fusi/sub-ALD001_task-awake_acq-ref04_pwd.json": {
+        "osf_path": "/file006",
+        "size": 50,
+    },
+    "sub-ALD001/fusi/sub-ALD001_task-awake_acq-ref11_run-1_pwd.nii.gz": {
+        "osf_path": "/file007",
+        "size": 1000,
+    },
+    "sub-ALD001/fusi/sub-ALD001_task-awake_acq-ref11_run-1_recording-wheel_physio.tsv.gz": {
+        "osf_path": "/file008",
+        "size": 200,
+    },
+    "sub-ALD001/sub-ALD001_scans.tsv": {"osf_path": "/file009", "size": 50},
+    # Second subject with one acquisition.
+    "sub-ALD002/fusi/sub-ALD002_task-awake_acq-ref04_pwd.nii.gz": {
+        "osf_path": "/file010",
+        "size": 1000,
+    },
+    "sub-ALD002/fusi/sub-ALD002_task-awake_acq-ref04_pwd.json": {
+        "osf_path": "/file011",
+        "size": 50,
+    },
+    "sub-ALD002/sub-ALD002_scans.tsv": {"osf_path": "/file012", "size": 50},
+    # Derivatives — atlas-mapping has per-subject files, processed-data is
+    # dataset-level with subject IDs embedded in the filename.
+    "derivatives/atlas_mapping/dataset_description.json": {
+        "osf_path": "/file013",
+        "size": 100,
+    },
+    "derivatives/atlas_mapping/sub-ALD001/Atlas_alignment_ALD001.npz": {
+        "osf_path": "/file014",
+        "size": 500,
+    },
+    "derivatives/atlas_mapping/sub-ALD002/Atlas_alignment_ALD002.npz": {
+        "osf_path": "/file015",
+        "size": 500,
+    },
+    "derivatives/processed_data/Compact_data_regions_ALD001.npz": {
+        "osf_path": "/file016",
+        "size": 500,
+    },
+    "derivatives/processed_data/Compact_data_regions_ALD002.npz": {
+        "osf_path": "/file017",
+        "size": 500,
+    },
+}
+
+
+def _make_retrieve(bids_dir: Path):
+    """Return a pooch.retrieve side-effect that creates stub files on disk."""
+
+    def _retrieve(url, known_hash, fname, path, progressbar):
+        dest = Path(path) / fname
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.touch()
+        return str(dest)
+
+    return _retrieve
+
+
+@pytest.fixture
+def mock_get_index(tmp_path):
+    """Stub `get_index` so fetch tests don't hit the network."""
+    with patch(
+        "confusius.datasets._landemard_2026.get_index",
+        return_value=_FAKE_INDEX,
+    ) as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_retrieve(tmp_path):
+    """Patch pooch.retrieve to create stub files instead of downloading."""
+    bids_dir = tmp_path / _BIDS_ROOT
+    with patch(
+        "confusius.datasets._pooch.pooch.retrieve",
+        side_effect=_make_retrieve(bids_dir),
+    ) as mock:
+        yield mock
+
+
+# ---------------------------------------------------------------------------
+# fetch_landemard_2026 — return value and caching
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_returns_bids_root(tmp_path, mock_get_index, mock_retrieve):
+    result = fetch_landemard_2026(data_dir=tmp_path)
+    assert result == tmp_path / _BIDS_ROOT
+    assert isinstance(result, Path)
+
+
+def test_fetch_downloads_all_missing_files(tmp_path, mock_get_index, mock_retrieve):
+    fetch_landemard_2026(data_dir=tmp_path)
+    assert mock_retrieve.call_count == len(_FAKE_INDEX)
+
+
+def test_fetch_skips_existing_files(tmp_path, mock_get_index, mock_retrieve):
+    # Pre-create two files in the cache.
+    bids_dir = tmp_path / _BIDS_ROOT
+    for rel in ["dataset_description.json", "participants.tsv"]:
+        dest = bids_dir / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.touch()
+
+    fetch_landemard_2026(data_dir=tmp_path)
+    assert mock_retrieve.call_count == len(_FAKE_INDEX) - 2
+
+
+def test_fetch_returns_immediately_when_all_cached(tmp_path, mock_get_index):
+    # Pre-create every file in the cache.
+    bids_dir = tmp_path / _BIDS_ROOT
+    for rel in _FAKE_INDEX:
+        dest = bids_dir / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.touch()
+
+    with patch("confusius.datasets._pooch.pooch.retrieve") as mock_retrieve:
+        fetch_landemard_2026(data_dir=tmp_path)
+        mock_retrieve.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# fetch_landemard_2026 — filters
+# ---------------------------------------------------------------------------
+
+
+def _downloaded_paths(mock_retrieve) -> set[str]:
+    """Return the set of file basenames passed to pooch.retrieve."""
+    return {c.kwargs["fname"] for c in mock_retrieve.call_args_list}
+
+
+def test_fetch_dataset_filter_rawdata_only(tmp_path, mock_get_index, mock_retrieve):
+    fetch_landemard_2026(data_dir=tmp_path, datasets=["rawdata"])
+
+    downloaded = _downloaded_paths(mock_retrieve)
+    # Rawdata files included.
+    assert "sub-ALD001_task-awake_acq-ref04_pwd.nii.gz" in downloaded
+    # Top-level metadata always included.
+    assert "dataset_description.json" in downloaded
+    # Derivatives excluded.
+    assert "Atlas_alignment_ALD001.npz" not in downloaded
+    assert "Compact_data_regions_ALD001.npz" not in downloaded
+
+
+def test_fetch_dataset_filter_atlas_mapping(tmp_path, mock_get_index, mock_retrieve):
+    fetch_landemard_2026(data_dir=tmp_path, datasets=["atlas-mapping"])
+
+    downloaded = _downloaded_paths(mock_retrieve)
+    # Matching derivative included.
+    assert "Atlas_alignment_ALD001.npz" in downloaded
+    assert "Atlas_alignment_ALD002.npz" in downloaded
+    assert "dataset_description.json" in downloaded
+    # Non-matching derivative excluded.
+    assert "Compact_data_regions_ALD001.npz" not in downloaded
+    # Rawdata excluded.
+    assert "sub-ALD001_task-awake_acq-ref04_pwd.nii.gz" not in downloaded
+
+
+def test_fetch_dataset_filter_processed_data(tmp_path, mock_get_index, mock_retrieve):
+    fetch_landemard_2026(data_dir=tmp_path, datasets=["processed-data"])
+
+    downloaded = _downloaded_paths(mock_retrieve)
+    assert "Compact_data_regions_ALD001.npz" in downloaded
+    assert "Compact_data_regions_ALD002.npz" in downloaded
+    assert "Atlas_alignment_ALD001.npz" not in downloaded
+    assert "sub-ALD001_task-awake_acq-ref04_pwd.nii.gz" not in downloaded
+
+
+def test_fetch_subject_filter(tmp_path, mock_get_index, mock_retrieve):
+    fetch_landemard_2026(data_dir=tmp_path, subjects=["ALD001"])
+
+    downloaded = _downloaded_paths(mock_retrieve)
+    # Matching subject included (rawdata and derivatives).
+    assert "sub-ALD001_task-awake_acq-ref04_pwd.nii.gz" in downloaded
+    assert "Atlas_alignment_ALD001.npz" in downloaded
+    # Non-matching subject excluded.
+    assert "sub-ALD002_task-awake_acq-ref04_pwd.nii.gz" not in downloaded
+    assert "Atlas_alignment_ALD002.npz" not in downloaded
+    # Dataset-level processed-data files pass through (no sub-* directory).
+    assert "Compact_data_regions_ALD001.npz" in downloaded
+    assert "Compact_data_regions_ALD002.npz" in downloaded
+    # Top-level metadata always included.
+    assert "dataset_description.json" in downloaded
+
+
+def test_fetch_acq_filter(tmp_path, mock_get_index, mock_retrieve):
+    """`acqs` keeps matching acquisitions and files with no acq entity."""
+    fetch_landemard_2026(data_dir=tmp_path, acqs=["ref04"])
+
+    downloaded = _downloaded_paths(mock_retrieve)
+    # Matching acquisition included.
+    assert "sub-ALD001_task-awake_acq-ref04_pwd.nii.gz" in downloaded
+    # Non-matching acquisition excluded (ref11 prefix not requested).
+    assert "sub-ALD001_task-awake_acq-ref11_run-1_pwd.nii.gz" not in downloaded
+    # Files with no acq entity pass through.
+    assert "sub-ALD001_scans.tsv" in downloaded
+    assert "sub-ALD001_pwd.nii.gz" in downloaded
+    assert "Atlas_alignment_ALD001.npz" in downloaded
+
+
+def test_fetch_acq_filter_compound_prefix(tmp_path, mock_get_index, mock_retrieve):
+    """Passing `ref11` selects both `ref11_run-1` and any sibling compound labels."""
+    fetch_landemard_2026(data_dir=tmp_path, acqs=["ref11"])
+
+    downloaded = _downloaded_paths(mock_retrieve)
+    assert "sub-ALD001_task-awake_acq-ref11_run-1_pwd.nii.gz" in downloaded
+    assert (
+        "sub-ALD001_task-awake_acq-ref11_run-1_recording-wheel_physio.tsv.gz"
+        in downloaded
+    )
+    assert "sub-ALD001_task-awake_acq-ref04_pwd.nii.gz" not in downloaded
+
+
+def test_fetch_datatype_filter_fusi_only(tmp_path, mock_get_index, mock_retrieve):
+    """`datatypes=["fusi"]` excludes angio files but keeps files without a datatype."""
+    fetch_landemard_2026(data_dir=tmp_path, datatypes=["fusi"])
+
+    downloaded = _downloaded_paths(mock_retrieve)
+    # fusi files included.
+    assert "sub-ALD001_task-awake_acq-ref04_pwd.nii.gz" in downloaded
+    # angio files excluded.
+    assert "sub-ALD001_pwd.nii.gz" not in downloaded
+    assert "sub-ALD001_pwd.json" not in downloaded
+    # Files with no datatype layer pass through.
+    assert "sub-ALD001_scans.tsv" in downloaded
+    assert "Atlas_alignment_ALD001.npz" in downloaded
+    # Top-level metadata always included.
+    assert "dataset_description.json" in downloaded
+
+
+def test_fetch_datatype_filter_angio_only(tmp_path, mock_get_index, mock_retrieve):
+    """`datatypes=["angio"]` keeps angio files and excludes fusi files."""
+    fetch_landemard_2026(data_dir=tmp_path, datatypes=["angio"])
+
+    downloaded = _downloaded_paths(mock_retrieve)
+    assert "sub-ALD001_pwd.nii.gz" in downloaded
+    assert "sub-ALD001_task-awake_acq-ref04_pwd.nii.gz" not in downloaded
+    # Files with no datatype layer still pass through.
+    assert "sub-ALD001_scans.tsv" in downloaded
+
+
+def test_fetch_combined_subject_and_acq_filters(
+    tmp_path, mock_get_index, mock_retrieve
+):
+    """Subject and acquisition filters compose."""
+    fetch_landemard_2026(
+        data_dir=tmp_path, subjects=["ALD001"], acqs=["ref04"], datatypes=["fusi"]
+    )
+
+    downloaded = _downloaded_paths(mock_retrieve)
+    assert "sub-ALD001_task-awake_acq-ref04_pwd.nii.gz" in downloaded
+    assert "sub-ALD001_task-awake_acq-ref11_run-1_pwd.nii.gz" not in downloaded
+    assert "sub-ALD002_task-awake_acq-ref04_pwd.nii.gz" not in downloaded
+    assert "Atlas_alignment_ALD001.npz" in downloaded
+
+
+def test_fetch_invalid_dataset_raises(tmp_path):
+    with pytest.raises(ValueError, match="Unknown dataset"):
+        fetch_landemard_2026(data_dir=tmp_path, datasets=["nonexistent"])
+
+
+def test_fetch_invalid_datatype_raises(tmp_path):
+    with pytest.raises(ValueError, match="Unknown datatype"):
+        fetch_landemard_2026(data_dir=tmp_path, datatypes=["nonexistent"])
+
+
+def test_fetch_accepts_string_datasets(tmp_path, mock_get_index, mock_retrieve):
+    """A single string is accepted and normalized to a list."""
+    fetch_landemard_2026(data_dir=tmp_path, datasets="rawdata")
+
+    downloaded = _downloaded_paths(mock_retrieve)
+    assert "sub-ALD001_task-awake_acq-ref04_pwd.nii.gz" in downloaded
+    assert "Atlas_alignment_ALD001.npz" not in downloaded
+
+
+def test_fetch_accepts_string_subjects(tmp_path, mock_get_index, mock_retrieve):
+    """A single string is accepted and normalized to a list."""
+    fetch_landemard_2026(data_dir=tmp_path, subjects="ALD001")
+
+    downloaded = _downloaded_paths(mock_retrieve)
+    assert "sub-ALD001_task-awake_acq-ref04_pwd.nii.gz" in downloaded
+    assert "sub-ALD002_task-awake_acq-ref04_pwd.nii.gz" not in downloaded
+
+
+def test_fetch_accepts_string_acqs_and_datatypes(
+    tmp_path, mock_get_index, mock_retrieve
+):
+    """`acqs` and `datatypes` strings are normalized to lists."""
+    fetch_landemard_2026(data_dir=tmp_path, acqs="ref04", datatypes="fusi")
+
+    downloaded = _downloaded_paths(mock_retrieve)
+    assert "sub-ALD001_task-awake_acq-ref04_pwd.nii.gz" in downloaded
+    assert "sub-ALD001_task-awake_acq-ref11_run-1_pwd.nii.gz" not in downloaded
+    assert "sub-ALD001_pwd.nii.gz" not in downloaded
+
+
+# ---------------------------------------------------------------------------
+# fetch_landemard_2026 — retry behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_retries_on_transient_failure(tmp_path, mock_get_index):
+    """Transient network errors are retried and eventually succeed."""
+    bids_dir = tmp_path / _BIDS_ROOT
+
+    # Pre-create every file except one so only that file goes through retrieve.
+    target_rel = "sub-ALD001/fusi/sub-ALD001_task-awake_acq-ref04_pwd.nii.gz"
+    for rel in _FAKE_INDEX:
+        if rel == target_rel:
+            continue
+        dest = bids_dir / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.touch()
+
+    call_count = {"n": 0}
+
+    def flaky_retrieve(url, known_hash, fname, path, progressbar):
+        call_count["n"] += 1
+        if call_count["n"] < _MAX_DOWNLOAD_RETRIES:
+            raise requests.exceptions.ReadTimeout("simulated timeout")
+        dest = Path(path) / fname
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.touch()
+        return str(dest)
+
+    with (
+        patch(
+            "confusius.datasets._pooch.pooch.retrieve",
+            side_effect=flaky_retrieve,
+        ),
+        patch("confusius.datasets._pooch.time.sleep"),
+    ):
+        fetch_landemard_2026(data_dir=tmp_path)
+
+    assert call_count["n"] == _MAX_DOWNLOAD_RETRIES
+
+
+def test_fetch_raises_after_max_retries(tmp_path, mock_get_index):
+    """Persistent network errors propagate after the retry budget is exhausted."""
+    bids_dir = tmp_path / _BIDS_ROOT
+
+    target_rel = "sub-ALD001/fusi/sub-ALD001_task-awake_acq-ref04_pwd.nii.gz"
+    for rel in _FAKE_INDEX:
+        if rel == target_rel:
+            continue
+        dest = bids_dir / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.touch()
+
+    def always_fails(url, known_hash, fname, path, progressbar):
+        raise requests.exceptions.ReadTimeout("persistent timeout")
+
+    with (
+        patch(
+            "confusius.datasets._pooch.pooch.retrieve",
+            side_effect=always_fails,
+        ) as mock_retrieve,
+        patch("confusius.datasets._pooch.time.sleep"),
+    ):
+        with pytest.raises(requests.exceptions.ReadTimeout):
+            fetch_landemard_2026(data_dir=tmp_path)
+
+    assert mock_retrieve.call_count == _MAX_DOWNLOAD_RETRIES
+
+
+# ---------------------------------------------------------------------------
+# fetch_landemard_2026 — refresh behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_refresh_passes_flag_to_get_index(
+    tmp_path, mock_get_index, mock_retrieve
+):
+    fetch_landemard_2026(data_dir=tmp_path, refresh=True)
+    mock_get_index.assert_called_once_with(
+        tmp_path / _BIDS_ROOT,
+        _OSF_PROJECT_ID,
+        _BIDS_ROOT,
+        refresh=True,
+        missing_index_hint=_MISSING_INDEX_HINT,
+    )

--- a/tests/unit/test_datasets/test_landemard_2026.py
+++ b/tests/unit/test_datasets/test_landemard_2026.py
@@ -9,11 +9,7 @@ import pytest
 import requests
 
 from confusius.datasets import fetch_landemard_2026
-from confusius.datasets._landemard_2026 import (
-    _BIDS_ROOT,
-    _MISSING_INDEX_HINT,
-    _OSF_PROJECT_ID,
-)
+from confusius.datasets._landemard_2026 import _BIDS_ROOT, _OSF_PROJECT_ID
 from confusius.datasets._pooch import _MAX_DOWNLOAD_RETRIES
 
 # Minimal fake index representing the different file categories in the dataset.
@@ -58,7 +54,7 @@ _FAKE_INDEX = {
         "size": 50,
     },
     "sub-ALD002/sub-ALD002_scans.tsv": {"osf_path": "/file012", "size": 50},
-    # Derivatives — atlas-mapping has per-subject files, processed-data is
+    # Derivatives — atlas_mapping has per-subject files, processed_data is
     # dataset-level with subject IDs embedded in the filename.
     "derivatives/atlas_mapping/dataset_description.json": {
         "osf_path": "/file013",
@@ -181,7 +177,7 @@ def test_fetch_dataset_filter_rawdata_only(tmp_path, mock_get_index, mock_retrie
 
 
 def test_fetch_dataset_filter_atlas_mapping(tmp_path, mock_get_index, mock_retrieve):
-    fetch_landemard_2026(data_dir=tmp_path, datasets=["atlas-mapping"])
+    fetch_landemard_2026(data_dir=tmp_path, datasets=["atlas_mapping"])
 
     downloaded = _downloaded_paths(mock_retrieve)
     # Matching derivative included.
@@ -195,7 +191,7 @@ def test_fetch_dataset_filter_atlas_mapping(tmp_path, mock_get_index, mock_retri
 
 
 def test_fetch_dataset_filter_processed_data(tmp_path, mock_get_index, mock_retrieve):
-    fetch_landemard_2026(data_dir=tmp_path, datasets=["processed-data"])
+    fetch_landemard_2026(data_dir=tmp_path, datasets=["processed_data"])
 
     downloaded = _downloaded_paths(mock_retrieve)
     assert "Compact_data_regions_ALD001.npz" in downloaded
@@ -205,8 +201,8 @@ def test_fetch_dataset_filter_processed_data(tmp_path, mock_get_index, mock_retr
 
 
 def test_fetch_dataset_filter_combined(tmp_path, mock_get_index, mock_retrieve):
-    """Combining `rawdata` (default-mapped) and a hyphen-mapped derivative."""
-    fetch_landemard_2026(data_dir=tmp_path, datasets=["rawdata", "atlas-mapping"])
+    """`datasets` may combine rawdata and a derivative name in a single call."""
+    fetch_landemard_2026(data_dir=tmp_path, datasets=["rawdata", "atlas_mapping"])
 
     downloaded = _downloaded_paths(mock_retrieve)
     assert "sub-ALD001_task-awake_acq-ref04_pwd.nii.gz" in downloaded
@@ -225,7 +221,7 @@ def test_fetch_subject_filter(tmp_path, mock_get_index, mock_retrieve):
     # Non-matching subject excluded.
     assert "sub-ALD002_task-awake_acq-ref04_pwd.nii.gz" not in downloaded
     assert "Atlas_alignment_ALD002.npz" not in downloaded
-    # Dataset-level processed-data files pass through (no sub-* directory).
+    # Dataset-level processed_data files pass through (no sub-* directory).
     assert "Compact_data_regions_ALD001.npz" in downloaded
     assert "Compact_data_regions_ALD002.npz" in downloaded
     # Top-level metadata always included.
@@ -427,5 +423,4 @@ def test_fetch_refresh_passes_flag_to_get_index(
         _OSF_PROJECT_ID,
         _BIDS_ROOT,
         refresh=True,
-        missing_index_hint=_MISSING_INDEX_HINT,
     )

--- a/tests/unit/test_datasets/test_nunez_elizalde_2022.py
+++ b/tests/unit/test_datasets/test_nunez_elizalde_2022.py
@@ -11,7 +11,6 @@ import requests
 from confusius.datasets import fetch_nunez_elizalde_2022, get_datasets_dir
 from confusius.datasets._nunez_elizalde_2022 import (
     _BIDS_ROOT,
-    _MISSING_INDEX_HINT,
     _OSF_PROJECT_ID,
 )
 from confusius.datasets._pooch import _MAX_DOWNLOAD_RETRIES
@@ -380,5 +379,4 @@ def test_fetch_refresh_passes_flag_to_get_index(
         _OSF_PROJECT_ID,
         _BIDS_ROOT,
         refresh=True,
-        missing_index_hint=_MISSING_INDEX_HINT,
     )

--- a/tests/unit/test_datasets/test_osf.py
+++ b/tests/unit/test_datasets/test_osf.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import re
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -74,9 +73,7 @@ def _make_osf_responses(
 def test_get_index_downloads_and_caches(tmp_path):
     """When no cache exists, the index is fetched from OSF and written to disk."""
     responses = _make_osf_responses(_FAKE_INDEX)
-    with patch(
-        "confusius.datasets._osf.requests.get", side_effect=responses
-    ):
+    with patch("confusius.datasets._osf.requests.get", side_effect=responses):
         result = get_index(tmp_path, _FAKE_PROJECT, _FAKE_BIDS_ROOT)
 
     assert result == _FAKE_INDEX
@@ -101,9 +98,7 @@ def test_get_index_refreshes_when_requested(tmp_path):
     (tmp_path / _INDEX_FILENAME).write_text(json.dumps({"stale": "data"}))
 
     responses = _make_osf_responses(_FAKE_INDEX)
-    with patch(
-        "confusius.datasets._osf.requests.get", side_effect=responses
-    ):
+    with patch("confusius.datasets._osf.requests.get", side_effect=responses):
         result = get_index(tmp_path, _FAKE_PROJECT, _FAKE_BIDS_ROOT, refresh=True)
 
     assert result == _FAKE_INDEX
@@ -129,7 +124,9 @@ def test_resolve_index_url_raises_if_bids_folder_not_on_osf():
 
 def test_resolve_index_url_raises_if_index_file_not_on_osf():
     """RuntimeError propagates when dataset_index.json is absent from OSF."""
-    folder_href = f"https://api.osf.io/v2/nodes/{_FAKE_PROJECT}/files/osfstorage/folder/"
+    folder_href = (
+        f"https://api.osf.io/v2/nodes/{_FAKE_PROJECT}/files/osfstorage/folder/"
+    )
 
     root_resp = MagicMock()
     root_resp.raise_for_status.return_value = None
@@ -154,36 +151,3 @@ def test_resolve_index_url_raises_if_index_file_not_on_osf():
     ):
         with pytest.raises(RuntimeError, match=_INDEX_FILENAME):
             resolve_index_url(_FAKE_PROJECT, _FAKE_BIDS_ROOT)
-
-
-def test_resolve_index_url_appends_missing_index_hint():
-    """The optional hint is appended verbatim to the error message."""
-    folder_href = f"https://api.osf.io/v2/nodes/{_FAKE_PROJECT}/files/osfstorage/folder/"
-
-    root_resp = MagicMock()
-    root_resp.raise_for_status.return_value = None
-    root_resp.json.return_value = {
-        "data": [
-            {
-                "attributes": {"name": _FAKE_BIDS_ROOT},
-                "relationships": {
-                    "files": {"links": {"related": {"href": folder_href}}}
-                },
-            }
-        ]
-    }
-
-    folder_resp = MagicMock()
-    folder_resp.raise_for_status.return_value = None
-    folder_resp.json.return_value = {"data": []}
-
-    hint = "Run 'some-tool --index-only' to regenerate it."
-
-    with patch(
-        "confusius.datasets._osf.requests.get",
-        side_effect=[root_resp, folder_resp],
-    ):
-        with pytest.raises(RuntimeError, match=re.escape(hint)):
-            resolve_index_url(
-                _FAKE_PROJECT, _FAKE_BIDS_ROOT, missing_index_hint=hint
-            )


### PR DESCRIPTION
Closes #228

Adds `fetch_landemard_2026` for downloading the Landemard et al. (2026) fUSI-BIDS dataset from OSF, with `datasets`, `subjects`, `acqs`, and `datatypes` filters.

- New fetcher at `src/confusius/datasets/_landemard_2026.py` (modeled on `fetch_cybis_pereira_2026`, adapted for the Landemard dataset's no-session layout).
- Registered in `_registry.py` and exported from `confusius.datasets`.
- User guide tab, listing-table entry, and citation footnote.
- Changelog entry under the in-development version.
- Unit tests (21 cases) covering caching, filters, error validation, retries, and refresh.