### PR TITLE
feat(cli): add datasets namespace

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -23,6 +23,10 @@ Current development version for the next ConfUSIus release.
 
 ### :sparkles: Enhancements
 
+- Added a `datasets` CLI namespace, listed in `confusius --help`:
+  `confusius datasets --list` prints the table of available datasets, their sizes,
+  and whether each is cached on disk. A bare `confusius PATH...` still launches the
+  viewer ([#234](https://github.com/confusius-tools/confusius/pull/234)).
 - Added [`NMF`][confusius.decomposition.NMF] for non-negative matrix factorization
   of fUSI time series, wrapping `sklearn.decomposition.NMF` with the same
   xarray-aware `fit`/`transform`/`inverse_transform` interface as

--- a/docs/user-guide/datasets.md
+++ b/docs/user-guide/datasets.md
@@ -94,6 +94,12 @@ list_datasets()
 The sizes shown are for the **full** dataset. Filtered fetches are typically a small
 fraction of this (see the examples below).
 
+The same table is available from the command line:
+
+```bash
+confusius datasets --list
+```
+
 ## Available fUSI-BIDS Datasets
 
 === "Nunez-Elizalde 2022"

--- a/src/confusius/_cli.py
+++ b/src/confusius/_cli.py
@@ -120,7 +120,7 @@ def build_datasets_parser() -> argparse.ArgumentParser:
     """
     parser = argparse.ArgumentParser(
         prog="confusius datasets",
-        description="Work with ConfUSIus fetchable datasets.",
+        description="Interact with ConfUSIus fetchable datasets.",
         add_help=False,
     )
     _add_help_option(parser)

--- a/src/confusius/_cli.py
+++ b/src/confusius/_cli.py
@@ -12,17 +12,24 @@ if TYPE_CHECKING:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    """Build the `confusius` command-line argument parser.
+    """Build the default (Napari plugin) `confusius` argument parser.
+
+    A bare `confusius PATH...` invocation launches the napari plugin, so the launcher is
+    the nameless default rather than a subcommand. Alternative namespaces (i.e.
+    [`build_datasets_parser`][confusius._cli.build_datasets_parser]) are dispatched by
+    [`main`][confusius._cli.main] and advertised under the `namespaces` help section.
 
     Returns
     -------
     argparse.ArgumentParser
-        The parser configured with the CLI's positional path argument and
+        The parser configured with the launcher's positional path argument and
         `--lazy` / `--video` options.
     """
     parser = argparse.ArgumentParser(
         prog="confusius",
         description="Launch the ConfUSIus napari plugin.",
+        epilog="Run `confusius <namespace> --help` for the namespace's own options.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(
         "path",
@@ -51,7 +58,59 @@ def build_parser() -> argparse.ArgumentParser:
             "with the first fUSI data file. Requires at least one data file."
         ),
     )
+    # The `datasets` namespace is dispatched in `main`, not by this parser, so
+    # it cannot be a real subparser without clashing with the greedy `path`
+    # positional. Advertise it with a display-only pseudo-action (as argparse
+    # does internally for subcommand choices) so it is colored and aligned like
+    # a native entry while staying invisible to parsing.
+    namespaces = parser.add_argument_group("namespaces")
+    namespaces._group_actions.append(
+        argparse.Action(
+            option_strings=[],
+            dest=argparse.SUPPRESS,
+            nargs=0,
+            metavar="datasets",
+            help="Work with datasets, e.g. `confusius datasets --list`",
+        )
+    )
     return parser
+
+
+def build_datasets_parser() -> argparse.ArgumentParser:
+    """Build the parser for the `confusius datasets` namespace.
+
+    Returns
+    -------
+    argparse.ArgumentParser
+        The parser configured with the `datasets` namespace options.
+    """
+    parser = argparse.ArgumentParser(
+        prog="confusius datasets",
+        description="Work with ConfUSIus fetchable datasets.",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="List available datasets, their sizes, and whether each is cached.",
+    )
+    return parser
+
+
+def run_datasets(args: argparse.Namespace) -> None:
+    """Handle a parsed `confusius datasets` invocation.
+
+    Parameters
+    ----------
+    args : argparse.Namespace
+        Parsed arguments, as produced by
+        [`build_datasets_parser`][confusius._cli.build_datasets_parser].
+    """
+    if args.list:
+        from confusius.datasets import list_datasets
+
+        list_datasets()
+    else:
+        build_datasets_parser().print_help()
 
 
 def run(args: argparse.Namespace, viewer: napari.Viewer | None = None) -> napari.Viewer:
@@ -96,8 +155,19 @@ def run(args: argparse.Namespace, viewer: napari.Viewer | None = None) -> napari
 
 
 def main() -> None:
-    """Parse CLI arguments, run the plugin, and start the napari event loop."""
-    args = build_parser().parse_args()
+    """Parse CLI arguments, dispatch the namespace, and run the requested action.
+
+    A bare `confusius PATH...` invocation launches the napari plugin, while
+    `confusius datasets ...` routes to the `datasets` namespace.
+    """
+    import sys
+
+    argv = sys.argv[1:]
+    if argv and argv[0] == "datasets":
+        run_datasets(build_datasets_parser().parse_args(argv[1:]))
+        return
+
+    args = build_parser().parse_args(argv)
     run(args)
     import napari
 

--- a/src/confusius/_cli.py
+++ b/src/confusius/_cli.py
@@ -27,9 +27,11 @@ def build_parser() -> argparse.ArgumentParser:
     """
     parser = argparse.ArgumentParser(
         prog="confusius",
-        description="Launch the ConfUSIus napari plugin.",
+        description=(
+            "Launch the ConfUSIus napari plugin. Alternative subcommands are "
+            "listed under `namespaces` below."
+        ),
         epilog="Run `confusius <namespace> --help` for the namespace's own options.",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(
         "path",

--- a/src/confusius/_cli.py
+++ b/src/confusius/_cli.py
@@ -3,12 +3,35 @@
 from __future__ import annotations
 
 import argparse
+from importlib import metadata
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
     import napari
     import napari.layers
+
+
+def _add_help_option(parser: argparse.ArgumentParser) -> None:
+    """Add a harmonized `-h`/`--help` option to a parser.
+
+    Registered explicitly (with `add_help=False` on the parser) so its help
+    string follows the same capitalized, full-stop style as the other
+    arguments, instead of argparse's lowercase default.
+
+    Parameters
+    ----------
+    parser : argparse.ArgumentParser
+        The parser to add the option to. It must be created with
+        `add_help=False`.
+    """
+    parser.add_argument(
+        "-h",
+        "--help",
+        action="help",
+        default=argparse.SUPPRESS,
+        help="Show this help message and exit.",
+    )
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -32,6 +55,15 @@ def build_parser() -> argparse.ArgumentParser:
             "listed under `namespaces` below."
         ),
         epilog="Run `confusius <namespace> --help` for the namespace's own options.",
+        add_help=False,
+    )
+    _add_help_option(parser)
+    parser.add_argument(
+        "-V",
+        "--version",
+        action="version",
+        version=f"ConfUSIus {metadata.version('confusius')}",
+        help="Show the version number and exit.",
     )
     parser.add_argument(
         "path",
@@ -72,7 +104,7 @@ def build_parser() -> argparse.ArgumentParser:
             dest=argparse.SUPPRESS,
             nargs=0,
             metavar="datasets",
-            help="Work with datasets, e.g. `confusius datasets --list`",
+            help="Work with datasets, e.g. `confusius datasets --list`.",
         )
     )
     return parser
@@ -89,7 +121,9 @@ def build_datasets_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="confusius datasets",
         description="Work with ConfUSIus fetchable datasets.",
+        add_help=False,
     )
+    _add_help_option(parser)
     parser.add_argument(
         "--list",
         action="store_true",

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 
 class TestBuildParser:
-    """The CLI parser accepts zero, one, or many positional paths."""
+    """The default parser accepts zero, one, or many positional paths."""
 
     def test_no_path(self) -> None:
         from confusius._cli import build_parser
@@ -40,6 +40,49 @@ class TestBuildParser:
         ns = build_parser().parse_args(["fixed.nii", "--lazy", "--video", "v.mp4"])
         assert ns.lazy is True
         assert ns.video == Path("v.mp4")
+
+
+class TestDatasetsNamespace:
+    """The `datasets` namespace parses `--list` and dispatches to `list_datasets`."""
+
+    def test_list_flag_parsed(self) -> None:
+        from confusius._cli import build_datasets_parser
+
+        ns = build_datasets_parser().parse_args(["--list"])
+        assert ns.list is True
+
+    def test_list_defaults_false(self) -> None:
+        from confusius._cli import build_datasets_parser
+
+        ns = build_datasets_parser().parse_args([])
+        assert ns.list is False
+
+    def test_run_datasets_list_calls_list_datasets(self, monkeypatch) -> None:
+        import confusius.datasets
+        from confusius._cli import build_datasets_parser, run_datasets
+
+        called = False
+
+        def fake_list_datasets() -> None:
+            nonlocal called
+            called = True
+
+        monkeypatch.setattr(confusius.datasets, "list_datasets", fake_list_datasets)
+        run_datasets(build_datasets_parser().parse_args(["--list"]))
+        assert called
+
+    def test_main_dispatches_to_datasets(self, monkeypatch) -> None:
+        import confusius._cli as cli
+
+        seen = {}
+
+        def fake_run_datasets(args) -> None:
+            seen["list"] = args.list
+
+        monkeypatch.setattr("sys.argv", ["confusius", "datasets", "--list"])
+        monkeypatch.setattr(cli, "run_datasets", fake_run_datasets)
+        cli.main()
+        assert seen == {"list": True}
 
 
 class TestRun:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -41,6 +41,18 @@ class TestBuildParser:
         assert ns.lazy is True
         assert ns.video == Path("v.mp4")
 
+    def test_version_flag(self, capsys) -> None:
+        from importlib import metadata
+
+        import pytest
+
+        from confusius._cli import build_parser
+
+        with pytest.raises(SystemExit) as exc:
+            build_parser().parse_args(["--version"])
+        assert exc.value.code == 0
+        assert metadata.version("confusius") in capsys.readouterr().out
+
 
 class TestDatasetsNamespace:
     """The `datasets` namespace parses `--list` and dispatches to `list_datasets`."""


### PR DESCRIPTION
## Summary

Adds a `datasets` namespace to the `confusius` CLI, as requested in #232. `confusius datasets --list` prints the same table as `confusius.datasets.list_datasets()` — available datasets, their full download sizes, and whether each is cached on disk.

```console
$ confusius datasets --list      # prints the dataset table
                   Available Datasets
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━┓
┃ Fetch function                   ┃     Size ┃ On disk ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━┩
│ fetch_cybis_pereira_2026         │ 12.88 GB │    ✓    │
│ fetch_nunez_elizalde_2022        │ 6.983 GB │    ✓    │
│ fetch_template_huang_2025        │ 16.34 MB │    ✓    │
│ fetch_template_pepe_mariani_2026 │ 5.508 MB │    ✓    │
└──────────────────────────────────┴──────────┴─────────┘
```

The viewer remains the nameless default, and the namespace is now discoverable
from the top-level help, rendered as a native (theme-colored, aligned) entry:

```console
$ confusius --help
usage: confusius [-h] [--lazy] [--video VIDEO] [PATH ...]

Launch the ConfUSIus napari plugin. Alternative subcommands are listed under `namespaces` below.

positional arguments:
  PATH           Path to a fUSI data file (.nii, .nii.gz, .scan, .zarr) to open on launch. May be passed multiple times to open several layers at once, e.g. `confusius fixed.nii
                 moving.nii`.

options:
  -h, --help     show this help message and exit
  --lazy         Load the files as Dask-backed arrays without computing. By default the full arrays are loaded into memory.
  --video VIDEO  Path to a video file (.mp4, .mov, .avi) to display side-by-side with the first fUSI data file. Requires at least one data file.

namespaces:
  datasets       Work with datasets, e.g. `confusius datasets --list`

Run `confusius <namespace> --help` for the namespace's own options.
```

## Details

- `build_datasets_parser()` / `run_datasets()` implement the namespace; `--list`
  calls `list_datasets()`, and `confusius datasets` with no flag prints its help.
- `main()` dispatches on the first token: `confusius datasets ...` routes to the
  namespace, everything else falls through to the viewer. So
  `confusius fixed.nii moving.nii`, `--lazy`, and `--video` are unchanged.
- argparse can't combine the viewer's greedy `path` positional with real
  subparsers without either breaking multi-path launch or forcing a named `view`
  subcommand. To keep the viewer nameless while still listing `datasets` in
  `--help`, the namespace is advertised with a display-only pseudo-action (the
  same mechanism argparse uses for subcommand choices), so it is colored and
  aligned like a native help entry — including Python 3.14's colored headings,
  with automatic fallback under `NO_COLOR` / non-TTY — while staying invisible
  to argument parsing.

Fetch-from-CLI subcommands are intentionally left out — #232 defers them to
"the future".

## Tests

Unit tests cover the default viewer parser, `--list` parsing, `run_datasets` dispatching to `list_datasets`, and `main` routing to the namespace. All CLI tests pass; ruff, ty, and numpydoc are clean. Changelog and the datasets user-guide page updated.

Closes #232.
