### PR TITLE
fix(signal): harden clean against boundary and non-finite inputs

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -57,6 +57,10 @@ Current development version for the next ConfUSIus release.
 
 ### :bug: Fixes
 
+- `signal.clean` now supports `ensure_finite=True` to repair non-finite `signals`
+  and `confounds` by interpolating along time, fills censored boundary samples from
+  the nearest kept sample before filtering, and accepts `interpolate_kwargs` for
+  pre-scrubbing interpolation ([#239](https://github.com/confusius-tools/confusius/pull/239)).
 - Image plotting functions now leave `alpha` unset by default (`None`), so a
   colormap's built-in alpha channel is respected
   ([#225](https://github.com/confusius-tools/confusius/pull/225)).

--- a/src/confusius/signal/censor.py
+++ b/src/confusius/signal/censor.py
@@ -174,9 +174,9 @@ def interpolate_samples(
 
     Control boundary behavior:
 
-    >>> # Default: extrapolate at boundaries.
+    >>> # Extrapolate at boundaries instead of leaving them as NaN.
     >>> interpolated = interpolate_samples(signals, sample_mask, fill_value="extrapolate")
-    >>> # Or fill with NaN outside kept range.
+    >>> # Or explicitly keep NaN outside the kept range.
     >>> interpolated_nan = interpolate_samples(signals, sample_mask, fill_value=np.nan)
     """
     if "time" not in signals.dims:

--- a/src/confusius/signal/core.py
+++ b/src/confusius/signal/core.py
@@ -19,7 +19,7 @@ def _interpolate_non_finite(data: xr.DataArray, *, name: str) -> xr.DataArray:
 
     Parameters
     ----------
-    data : xarray.DataArray
+    data : (time, ...) xarray.DataArray
         Data to sanitize.
     name : str
         Name used in error messages.
@@ -56,7 +56,7 @@ def _fill_interpolated_boundary_non_finite(
 
     Parameters
     ----------
-    signals : xarray.DataArray
+    signals : (time, ...) xarray.DataArray
         Interpolated signals.
     sample_mask : xarray.DataArray
         Boolean sample mask already validated by `interpolate_samples`.

--- a/src/confusius/signal/core.py
+++ b/src/confusius/signal/core.py
@@ -14,6 +14,91 @@ from confusius.signal.standardization import standardize
 from confusius.validation import validate_time_series
 
 
+def _interpolate_non_finite(data: xr.DataArray, *, name: str) -> xr.DataArray:
+    """Interpolate non-finite values along time and fill boundaries.
+
+    Parameters
+    ----------
+    data : xarray.DataArray
+        Data to sanitize.
+    name : str
+        Name used in error messages.
+
+    Returns
+    -------
+    xarray.DataArray
+        Data with non-finite values replaced by time interpolation, with leading and
+        trailing gaps filled from the nearest finite sample.
+
+    Raises
+    ------
+    ValueError
+        If any series remains entirely non-finite after interpolation.
+    """
+    finite = xr.apply_ufunc(np.isfinite, data, dask="allowed")
+    if not bool(finite.any(dim="time").all().compute().item()):
+        raise ValueError(
+            f"{name} contains a series with no finite values along time, so "
+            "ensure_finite=True cannot repair it."
+        )
+
+    repaired = data.where(finite)
+    repaired = repaired.interpolate_na(dim="time", method="linear")
+    repaired = repaired.ffill("time").bfill("time")
+
+    return repaired
+
+
+def _fill_interpolated_boundary_non_finite(
+    signals: xr.DataArray, sample_mask: xr.DataArray
+) -> xr.DataArray:
+    """Fill boundary non-finite values from the nearest kept sample.
+
+    Parameters
+    ----------
+    signals : xarray.DataArray
+        Interpolated signals.
+    sample_mask : xarray.DataArray
+        Boolean sample mask already validated by `interpolate_samples`.
+
+    Returns
+    -------
+    xarray.DataArray
+        Signals with any non-finite values left on censored boundaries replaced by the
+        nearest kept sample.
+    """
+    boolean_mask = np.asarray(sample_mask.values)
+    first_kept = int(np.argmax(boolean_mask))
+    last_kept = len(boolean_mask) - int(np.argmax(boolean_mask[::-1])) - 1
+    result = signals
+
+    if first_kept > 0:
+        left_boundary = xr.DataArray(
+            np.arange(signals.sizes["time"]) < first_kept,
+            dims=["time"],
+            coords={"time": signals.coords["time"]},
+        )
+        left_fill = signals.isel(time=first_kept).broadcast_like(signals)
+        left_missing = left_boundary & ~xr.apply_ufunc(
+            np.isfinite, result, dask="allowed"
+        )
+        result = xr.where(left_missing, left_fill, result)
+
+    if last_kept < signals.sizes["time"] - 1:
+        right_boundary = xr.DataArray(
+            np.arange(signals.sizes["time"]) > last_kept,
+            dims=["time"],
+            coords={"time": signals.coords["time"]},
+        )
+        right_fill = signals.isel(time=last_kept).broadcast_like(signals)
+        right_missing = right_boundary & ~xr.apply_ufunc(
+            np.isfinite, result, dask="allowed"
+        )
+        result = xr.where(right_missing, right_fill, result)
+
+    return result
+
+
 def clean(
     signals: xr.DataArray,
     *,
@@ -24,8 +109,10 @@ def clean(
     filter_butterworth_kwargs: dict | None = None,
     confounds: xr.DataArray | None = None,
     standardize_confounds: bool = True,
+    ensure_finite: bool = False,
     sample_mask: xr.DataArray | None = None,
     interpolate_method: InterpOptions = "linear",
+    interpolate_kwargs: dict | None = None,
 ) -> xr.DataArray:
     """Clean signals with detrending, filtering, confound regression, and scrubbing.
 
@@ -71,17 +158,19 @@ def clean(
         low-pass filter). If not provided, no low-pass filtering is applied.
     filter_butterworth_kwargs : dict, optional
         Extra keyword arguments passed to `confusius.signal.filter_butterworth`.
-    confounds : xarray.DataArray, optional
-        Confound regressors with shape `(time, n_confounds)`. When provided,
-        confounds are detrended and filtered along with signals and then removed via
-        regression.
     confounds : (time, n_confounds) xarray.DataArray, optional
         Confound regressors to remove. Can have shape `(time,)` for a single
-        confound. The time dimension and coordinates must match the signals exactly. If
-        not provided, no confound regression is applied.
+        confound. When provided, confounds are detrended and filtered along with
+        signals before regression. The time dimension and coordinates must match the
+        signals exactly. If not provided, no confound regression is applied.
     standardize_confounds : bool, default: True
         Whether to standardize confounds by their maximum absolute value before
         regression. This improves numerical stability while preserving constant terms.
+    ensure_finite : bool, default: False
+        Whether to repair non-finite values (`NaN`, `Inf`) in `signals` and
+        `confounds` before cleaning by interpolating each series along `time` and
+        filling boundary gaps from the nearest finite sample. If `False`, non-finite
+        values are left unchanged.
     sample_mask : (time,) xarray.DataArray, optional
         Boolean sample mask indicating which timepoints to keep (`True`) vs. remove
         (`False`). Must have a `time` dimension matching `signals`. If both
@@ -92,13 +181,19 @@ def clean(
             "akima", "makima"}, default: "linear"
         Interpolation method passed to `confusius.signal.interpolate_samples` when using
         pre-scrubbing interpolation. Ignored if `sample_mask` is not provided or if no
-        detrending or filtering is applied. DataArray.interp`. Common options:
+        detrending or filtering is applied. Common options:
 
         - `"nearest"`: Nearest-neighbor interpolation (fastest, least smooth).
         - `"linear"`: Linear interpolation (faster, less smooth).
         - `"cubic"`: Cubic spline interpolation (slower, smooth).
 
         See `xarray.DataArray.interp` for all available methods.
+    interpolate_kwargs : dict, optional
+        Extra keyword arguments forwarded to
+        `confusius.signal.interpolate_samples` during pre-scrubbing interpolation.
+        Ignored if `sample_mask` is not provided or if no detrending or filtering is
+        applied. Cannot contain `method`, which must be passed via
+        `interpolate_method`.
 
     Returns
     -------
@@ -131,11 +226,26 @@ def clean(
     else:
         filter_butterworth_kwargs = {}
 
+    if interpolate_kwargs is not None and not isinstance(interpolate_kwargs, dict):
+        raise TypeError("interpolate_kwargs must be a dict or None")
+
+    if interpolate_kwargs and "method" in interpolate_kwargs:
+        raise ValueError(
+            "Pass interpolate_method directly to clean, not in interpolate_kwargs."
+        )
+
+    interpolate_kwargs = {} if interpolate_kwargs is None else interpolate_kwargs.copy()
+
     filter_butterworth_kwargs.update(
         {"low_cutoff": low_cutoff, "high_cutoff": high_cutoff}
     )
 
     do_filter = low_cutoff is not None or high_cutoff is not None
+
+    if ensure_finite:
+        signals = _interpolate_non_finite(signals, name="signals")
+        if confounds is not None:
+            confounds = _interpolate_non_finite(confounds, name="confounds")
 
     original_mean = signals.mean(dim="time") if standardize_method == "psc" else None
 
@@ -144,12 +254,20 @@ def clean(
     # applied to the full time series without gaps.
     if sample_mask is not None and (detrend_order is not None or do_filter):
         signals = interpolate_samples(
-            signals, sample_mask=sample_mask, method=interpolate_method
+            signals,
+            sample_mask=sample_mask,
+            method=interpolate_method,
+            **interpolate_kwargs,
         )
+        signals = _fill_interpolated_boundary_non_finite(signals, sample_mask)
         if confounds is not None:
             confounds = interpolate_samples(
-                confounds, sample_mask=sample_mask, method=interpolate_method
+                confounds,
+                sample_mask=sample_mask,
+                method=interpolate_method,
+                **interpolate_kwargs,
             )
+            confounds = _fill_interpolated_boundary_non_finite(confounds, sample_mask)
 
     if detrend_order is not None:
         signals = detrend_signals(signals, order=detrend_order)

--- a/src/confusius/signal/filters.py
+++ b/src/confusius/signal/filters.py
@@ -105,13 +105,9 @@ def _butterworth_filter_wrapper(
     elif low_cutoff is not None:
         btype = "highpass"
         critical_freqs = low_cutoff
-    elif high_cutoff is not None:
+    else:
         btype = "lowpass"
         critical_freqs = high_cutoff
-    else:
-        if axis != 0:
-            data = np.moveaxis(data, 0, axis)
-        return data
 
     # Use second-order sections (SOS) for numerical stability.
     sos = scipy.signal.butter(

--- a/tests/unit/test_signal/test_censor.py
+++ b/tests/unit/test_signal/test_censor.py
@@ -124,12 +124,74 @@ def test_interpolate_all_kept_warning(sample_timeseries):
     assert_allclose(result.values, signals.values, rtol=1e-14)
 
 
+def test_interpolate_missing_time_dimension(sample_timeseries):
+    """Test error when signals have no time dimension."""
+    signals = sample_timeseries(n_time=100).rename({"time": "samples"})
+    sample_mask = xr.DataArray(np.ones(100, dtype=bool), dims=["time"])
+
+    with pytest.raises(ValueError, match="must have a 'time' dimension"):
+        interpolate_samples(signals, sample_mask)
+
+
 def test_interpolate_missing_time_coords(sample_timeseries):
     """Test error when signals have no time coordinates."""
     signals = sample_timeseries(n_time=100).drop_vars("time")
     sample_mask = xr.DataArray(np.ones(100, dtype=bool), dims=["time"])
 
     with pytest.raises(ValueError, match="must have 'time' coordinates"):
+        interpolate_samples(signals, sample_mask)
+
+
+def test_interpolate_rejects_non_dataarray_mask(sample_timeseries):
+    """Test sample_mask must be an xarray.DataArray."""
+    signals = sample_timeseries(n_time=100)
+
+    with pytest.raises(TypeError, match="sample_mask must be an xarray.DataArray"):
+        interpolate_samples(signals, np.ones(100, dtype=bool))  # type: ignore[arg-type]
+
+
+def test_interpolate_rejects_mask_without_time_dimension(sample_timeseries):
+    """Test sample_mask must have a time dimension."""
+    signals = sample_timeseries(n_time=100)
+    sample_mask = xr.DataArray(np.ones(100, dtype=bool), dims=["sample"])
+
+    with pytest.raises(ValueError, match="sample_mask must have a 'time' dimension"):
+        interpolate_samples(signals, sample_mask)
+
+
+def test_interpolate_rejects_non_boolean_mask(sample_timeseries):
+    """Test sample_mask must be boolean."""
+    signals = sample_timeseries(n_time=100)
+    sample_mask = xr.DataArray(
+        np.ones(100, dtype=int), dims=["time"], coords={"time": signals.coords["time"]}
+    )
+
+    with pytest.raises(ValueError, match="sample_mask must be boolean DataArray"):
+        interpolate_samples(signals, sample_mask)
+
+
+def test_interpolate_rejects_non_1d_mask(sample_timeseries):
+    """Test sample_mask must be 1D."""
+    signals = sample_timeseries(n_time=100)
+    sample_mask = xr.DataArray(
+        np.ones((100, 1), dtype=bool),
+        dims=["time", "extra"],
+        coords={"time": signals.coords["time"]},
+    )
+
+    with pytest.raises(ValueError, match="Boolean sample_mask must be 1D"):
+        interpolate_samples(signals, sample_mask)
+
+
+def test_interpolate_rejects_mask_with_wrong_length(sample_timeseries):
+    """Test sample_mask length must match the time dimension."""
+    signals = sample_timeseries(n_time=100)
+    sample_mask = xr.DataArray(
+        np.ones(99, dtype=bool),
+        dims=["time"],
+    )
+
+    with pytest.raises(ValueError, match=r"sample_mask length \(99\) must match"):
         interpolate_samples(signals, sample_mask)
 
 

--- a/tests/unit/test_signal/test_clean.py
+++ b/tests/unit/test_signal/test_clean.py
@@ -10,6 +10,7 @@ from confusius.signal import (
     clean,
     filter_butterworth,
     interpolate_samples,
+    standardize,
 )
 
 
@@ -130,6 +131,33 @@ def test_clean_filter_low_pass_matches_filter_butterworth(sample_timeseries):
     )
 
     assert_allclose(result.values, expected.values)
+
+
+def test_clean_rejects_non_dict_filter_kwargs(sample_timeseries):
+    """Test filter_butterworth_kwargs must be a dict."""
+    with pytest.raises(TypeError, match="filter_butterworth_kwargs must be a dict"):
+        clean(sample_timeseries(), filter_butterworth_kwargs=1)  # type: ignore[arg-type]
+
+
+def test_clean_rejects_cutoffs_inside_filter_kwargs(sample_timeseries):
+    """Test cutoffs must be passed directly to clean."""
+    with pytest.raises(ValueError, match="Pass low_pass/high_pass directly to clean"):
+        clean(sample_timeseries(), filter_butterworth_kwargs={"high_cutoff": 1.0})
+
+
+def test_clean_rejects_non_dict_interpolate_kwargs(sample_timeseries):
+    """Test interpolate_kwargs must be a dict."""
+    with pytest.raises(TypeError, match="interpolate_kwargs must be a dict"):
+        clean(sample_timeseries(), interpolate_kwargs=1)  # type: ignore[arg-type]
+
+
+def test_clean_rejects_method_inside_interpolate_kwargs(sample_timeseries):
+    """Test interpolate method must be passed directly to clean."""
+    with pytest.raises(
+        ValueError,
+        match="Pass interpolate_method directly to clean, not in interpolate_kwargs",
+    ):
+        clean(sample_timeseries(), interpolate_kwargs={"method": "nearest"})
 
 
 def test_clean_filter_with_boundary_censoring_and_confounds_stays_finite(
@@ -276,3 +304,18 @@ def test_clean_ensure_finite_raises_for_all_non_finite_series():
         match="signals contains a series with no finite values along time",
     ):
         clean(signals, ensure_finite=True)
+
+
+def test_clean_psc_restores_original_mean_after_highpass(sample_timeseries):
+    """Test PSC uses the original mean after mean-removing filtering."""
+    signals = sample_timeseries(n_time=200, n_voxels=3, sampling_rate=100.0) + 100.0
+
+    filtered = filter_butterworth(signals, low_cutoff=1.0)
+    expected = standardize(filtered + signals.mean(dim="time"), method="psc")
+    result = clean(
+        signals,
+        low_cutoff=1.0,
+        standardize_method="psc",
+    )
+
+    assert_allclose(result.values, expected.values)

--- a/tests/unit/test_signal/test_clean.py
+++ b/tests/unit/test_signal/test_clean.py
@@ -194,6 +194,31 @@ def test_clean_filter_with_boundary_censoring_and_confounds_stays_finite(
     assert np.all(np.isfinite(result.values))
 
 
+def test_clean_leaves_interior_non_finite_uncorrected_when_ensure_finite_false(
+    sample_timeseries,
+):
+    """Test an interior non-finite kept sample is not silently repaired."""
+    signals = sample_timeseries(n_time=100, n_voxels=1, sampling_rate=100.0)
+    signals.values[50, 0] = np.nan  # Interior value at a kept (non-censored) index.
+
+    mask_values = np.ones(signals.sizes["time"], dtype=bool)
+    mask_values[[0, -1]] = False  # Boundary censoring triggers the pre-scrub path.
+    sample_mask = xr.DataArray(
+        mask_values, dims=["time"], coords={"time": signals.coords["time"]}
+    )
+
+    result = clean(
+        signals,
+        detrend_order=None,
+        standardize_method=None,
+        high_cutoff=5.0,
+        sample_mask=sample_mask,
+        ensure_finite=False,
+    )
+
+    assert not np.any(np.isfinite(result.values))
+
+
 def test_clean_interpolate_kwargs_match_manual_pipeline(sample_timeseries):
     """Test interpolate_kwargs are forwarded to pre-scrubbing interpolation."""
     signals = sample_timeseries(n_time=100, sampling_rate=100.0)

--- a/tests/unit/test_signal/test_clean.py
+++ b/tests/unit/test_signal/test_clean.py
@@ -285,6 +285,37 @@ def test_clean_ensure_finite_matches_manual_interpolation(sample_timeseries):
     assert_allclose(result.values, expected.values)
 
 
+def test_clean_boundary_fill_uses_nearest_kept_sample(sample_timeseries):
+    """Test censored boundary samples are filled from the nearest kept sample."""
+    signals = sample_timeseries(n_time=100, n_voxels=3, sampling_rate=100.0)
+    mask_values = np.ones(signals.sizes["time"], dtype=bool)
+    mask_values[[0, 1, -2, -1]] = False  # Censor two samples at each boundary.
+    sample_mask = xr.DataArray(
+        mask_values, dims=["time"], coords={"time": signals.coords["time"]}
+    )
+
+    # Independent reference: interpolate, then clamp the out-of-range censored edges
+    # to the nearest kept sample by explicit indexing (not ffill/bfill).
+    interpolated = interpolate_samples(signals, sample_mask, method="linear")
+    filled = interpolated.copy()
+    first_kept, last_kept = 2, signals.sizes["time"] - 3
+    filled.values[:first_kept] = signals.values[first_kept]
+    filled.values[last_kept + 1 :] = signals.values[last_kept]
+    expected = censor_samples(filter_butterworth(filled, high_cutoff=5.0), sample_mask)
+
+    result = clean(signals, high_cutoff=5.0, sample_mask=sample_mask)
+
+    assert np.all(np.isfinite(result.values))
+    assert_allclose(result.values, expected.values)
+
+    # A wrong-but-finite fill (zeros) must NOT match, proving the value matters.
+    zero_filled = interpolated.fillna(0.0)
+    wrong = censor_samples(
+        filter_butterworth(zero_filled, high_cutoff=5.0), sample_mask
+    )
+    assert not np.allclose(result.values, wrong.values)
+
+
 def test_clean_ensure_finite_raises_for_all_non_finite_series():
     """Test ensure_finite=True fails when a whole series has no finite samples."""
     signals = xr.DataArray(

--- a/tests/unit/test_signal/test_clean.py
+++ b/tests/unit/test_signal/test_clean.py
@@ -1,10 +1,16 @@
 """Tests for the signal.clean pipeline."""
 
 import numpy as np
+import pytest
 import xarray as xr
 from numpy.testing import assert_allclose
 
-from confusius.signal import clean, filter_butterworth
+from confusius.signal import (
+    censor_samples,
+    clean,
+    filter_butterworth,
+    interpolate_samples,
+)
 
 
 def test_clean_no_processing_returns_original(sample_timeseries):
@@ -124,3 +130,149 @@ def test_clean_filter_low_pass_matches_filter_butterworth(sample_timeseries):
     )
 
     assert_allclose(result.values, expected.values)
+
+
+def test_clean_filter_with_boundary_censoring_and_confounds_stays_finite(
+    sample_timeseries,
+):
+    """Test boundary-censored samples do not poison filtered outputs."""
+    signals = sample_timeseries(n_time=100, n_voxels=3, sampling_rate=100.0)
+    confounds = xr.DataArray(
+        np.column_stack(
+            [
+                np.sin(2 * np.pi * signals.coords["time"].values),
+                np.cos(2 * np.pi * signals.coords["time"].values),
+            ]
+        ),
+        dims=["time", "confound"],
+        coords={"time": signals.coords["time"], "confound": [0, 1]},
+    )
+    mask_values = np.ones(signals.sizes["time"], dtype=bool)
+    mask_values[[0, -1]] = False
+    sample_mask = xr.DataArray(
+        mask_values, dims=["time"], coords={"time": signals.coords["time"]}
+    )
+
+    result = clean(
+        signals,
+        detrend_order=None,
+        standardize_method=None,
+        high_cutoff=5.0,
+        confounds=confounds,
+        sample_mask=sample_mask,
+    )
+
+    assert result.sizes["time"] == np.sum(mask_values)
+    assert np.all(np.isfinite(result.values))
+
+
+def test_clean_interpolate_kwargs_match_manual_pipeline(sample_timeseries):
+    """Test interpolate_kwargs are forwarded to pre-scrubbing interpolation."""
+    signals = sample_timeseries(n_time=100, sampling_rate=100.0)
+    mask_values = np.ones(signals.sizes["time"], dtype=bool)
+    mask_values[[0, -1]] = False
+    sample_mask = xr.DataArray(
+        mask_values, dims=["time"], coords={"time": signals.coords["time"]}
+    )
+
+    interpolated = interpolate_samples(
+        signals,
+        sample_mask,
+        fill_value="extrapolate",
+    )
+    expected = censor_samples(
+        filter_butterworth(interpolated, high_cutoff=5.0), sample_mask
+    )
+    result = clean(
+        signals,
+        detrend_order=None,
+        standardize_method=None,
+        high_cutoff=5.0,
+        sample_mask=sample_mask,
+        interpolate_kwargs={"fill_value": "extrapolate"},
+    )
+
+    assert_allclose(result.values, expected.values)
+
+
+def test_clean_noop_preserves_non_finite_when_ensure_finite_false(sample_timeseries):
+    """Test ensure_finite=False leaves non-finite values unchanged."""
+    signals = sample_timeseries()
+    signals.values[0, 0] = np.nan
+    signals.values[1, 1] = np.inf
+
+    result = clean(signals, ensure_finite=False)
+
+    assert np.isnan(result.values[0, 0])
+    assert np.isinf(result.values[1, 1])
+
+
+def test_clean_ensure_finite_matches_manual_interpolation(sample_timeseries):
+    """Test ensure_finite=True matches manual time interpolation."""
+    signals = sample_timeseries(n_time=200, n_voxels=3, sampling_rate=100.0)
+    confounds = xr.DataArray(
+        np.column_stack(
+            [
+                np.sin(2 * np.pi * signals.coords["time"].values),
+                np.cos(2 * np.pi * signals.coords["time"].values),
+            ]
+        ),
+        dims=["time", "confound"],
+        coords={"time": signals.coords["time"], "confound": [0, 1]},
+    )
+    signals_with_non_finite = signals.copy()
+    signals_with_non_finite.values[0, 0] = np.nan
+    signals_with_non_finite.values[1, 1] = np.inf
+    signals_with_non_finite.values[-1, 2] = np.nan
+    confounds_with_non_finite = confounds.copy()
+    confounds_with_non_finite.values[0, 0] = np.nan
+    confounds_with_non_finite.values[-1, 1] = np.inf
+
+    expected_signals = signals_with_non_finite.where(
+        np.isfinite(signals_with_non_finite)
+    )
+    expected_signals = expected_signals.interpolate_na(dim="time", method="linear")
+    expected_signals = expected_signals.ffill("time").bfill("time")
+    expected_confounds = confounds_with_non_finite.where(
+        np.isfinite(confounds_with_non_finite)
+    )
+    expected_confounds = expected_confounds.interpolate_na(dim="time", method="linear")
+    expected_confounds = expected_confounds.ffill("time").bfill("time")
+    expected = clean(
+        expected_signals,
+        detrend_order=1,
+        standardize_method=None,
+        high_cutoff=5.0,
+        confounds=expected_confounds,
+    )
+    result = clean(
+        signals_with_non_finite,
+        detrend_order=1,
+        standardize_method=None,
+        high_cutoff=5.0,
+        confounds=confounds_with_non_finite,
+        ensure_finite=True,
+    )
+
+    assert_allclose(result.values, expected.values)
+
+
+def test_clean_ensure_finite_raises_for_all_non_finite_series():
+    """Test ensure_finite=True fails when a whole series has no finite samples."""
+    signals = xr.DataArray(
+        np.array(
+            [
+                [np.nan, 0.0],
+                [np.nan, 1.0],
+                [np.nan, 2.0],
+            ]
+        ),
+        dims=["time", "space"],
+        coords={"time": [0.0, 1.0, 2.0]},
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="signals contains a series with no finite values along time",
+    ):
+        clean(signals, ensure_finite=True)

--- a/tests/unit/test_signal/test_compcor.py
+++ b/tests/unit/test_signal/test_compcor.py
@@ -1,5 +1,6 @@
 """Tests for CompCor functions."""
 
+import dask.array as da
 import numpy as np
 import pytest
 import xarray as xr
@@ -245,6 +246,27 @@ def test_compute_compcor_mask_shape_mismatch(sample_timeseries):
 
     with pytest.raises(ValueError, match="does not match"):
         compute_compcor_confounds(signals, noise_mask=noise_mask, n_components=5)
+
+
+def test_compute_compcor_mask_size_mismatch_after_flatten(sample_3dt_volume):
+    """Test error when a subset-dimension mask flattens to the wrong size."""
+    noise_mask = xr.DataArray(
+        np.ones(
+            (sample_3dt_volume.sizes["z"], sample_3dt_volume.sizes["y"]), dtype=bool
+        ),
+        dims=["z", "y"],
+        coords={
+            "z": sample_3dt_volume.coords["z"],
+            "y": sample_3dt_volume.coords["y"],
+        },
+    )
+
+    with pytest.raises(ValueError, match="Noise mask size"):
+        compute_compcor_confounds(
+            sample_3dt_volume,
+            noise_mask=noise_mask,
+            n_components=3,
+        )
 
 
 def test_compute_compcor_empty_mask(sample_timeseries):
@@ -508,6 +530,26 @@ def test_compute_compcor_time_chunked():
 
     with pytest.raises(ValueError, match="chunked along the 'time' dimension"):
         compute_compcor_confounds(signals, noise_mask=noise_mask, n_components=5)
+
+
+def test_compute_compcor_dask_path(sample_timeseries):
+    """Test CompCor uses the Dask SVD path when data are Dask-backed."""
+    signals = sample_timeseries(n_time=100, n_voxels=50).chunk(
+        {"time": -1, "space": 10}
+    )
+    noise_mask = _create_mask_like(signals.isel(time=0), np.ones(50, dtype=bool))
+
+    components = compute_compcor_confounds(
+        signals, noise_mask=noise_mask, n_components=5, detrend=False
+    )
+
+    assert isinstance(components.data, da.Array)
+    assert components.shape == (100, 5)
+    assert_allclose(
+        components.compute().values.T @ components.compute().values,
+        np.eye(5),
+        atol=1e-10,
+    )
 
 
 def test_compute_compcor_explained_variance_ratio():

--- a/tests/unit/test_signal/test_compcor.py
+++ b/tests/unit/test_signal/test_compcor.py
@@ -295,6 +295,53 @@ def test_compute_compcor_scaling_invariance(sample_timeseries):
         assert corr > 0.99
 
 
+def test_compute_compcor_ignores_zero_variance_voxels(sample_timeseries):
+    """Constant voxels are dropped before CompCor SVD."""
+    signals = sample_timeseries(n_time=100, n_voxels=10)
+    signals.values[:, :3] = 5.0
+
+    all_voxels_mask = _create_mask_like(
+        signals.isel(time=0), np.ones(signals.sizes["space"], dtype=bool)
+    )
+    varying_voxels = signals.isel(space=slice(3, None))
+    varying_mask = _create_mask_like(
+        varying_voxels.isel(time=0), np.ones(varying_voxels.sizes["space"], dtype=bool)
+    )
+
+    result = compute_compcor_confounds(
+        signals,
+        noise_mask=all_voxels_mask,
+        n_components=3,
+        detrend=False,
+    )
+    expected = compute_compcor_confounds(
+        varying_voxels,
+        noise_mask=varying_mask,
+        n_components=3,
+        detrend=False,
+    )
+
+    assert_allclose(np.abs(result.values), np.abs(expected.values))
+
+
+def test_compute_compcor_all_zero_variance_selected_voxels_error(sample_timeseries):
+    """CompCor fails when every selected voxel is constant."""
+    signals = sample_timeseries(n_time=100, n_voxels=10)
+    signals.values[:, :4] = 2.0
+
+    mask_values = np.zeros(signals.sizes["space"], dtype=bool)
+    mask_values[:4] = True
+    noise_mask = _create_mask_like(signals.isel(time=0), mask_values)
+
+    with pytest.raises(ValueError, match="All voxels have variance below tolerance"):
+        compute_compcor_confounds(
+            signals,
+            noise_mask=noise_mask,
+            n_components=2,
+            detrend=False,
+        )
+
+
 def test_compute_compcor_tcompcor_selects_high_variance(sample_timeseries, rng):
     """Test that tCompCor selects high-variance voxels."""
     n_time = 100

--- a/tests/unit/test_signal/test_confounds.py
+++ b/tests/unit/test_signal/test_confounds.py
@@ -203,6 +203,15 @@ def test_regress_confounds_invalid_type(sample_timeseries):
         regress_confounds(signals, "invalid")  # type: ignore[arg-type]
 
 
+def test_regress_confounds_confounds_missing_time_dimension(sample_timeseries):
+    """Test error when confounds have no time dimension."""
+    signals = sample_timeseries()
+    confounds = xr.DataArray(np.random.randn(10, 3), dims=["sample", "confound"])
+
+    with pytest.raises(ValueError, match="must have a 'time' dimension"):
+        regress_confounds(signals, confounds)
+
+
 def test_regress_confounds_wrong_dimensions(sample_timeseries):
     """Test error when confounds have wrong number of dimensions."""
     signals = sample_timeseries(n_time=100, n_voxels=50)
@@ -228,6 +237,17 @@ def test_regress_confounds_single_confound_1d(sample_timeseries):
     # Should work and be treated as single confound
     cleaned = regress_confounds(signals, confound)
     assert cleaned.shape == signals.shape
+
+
+def test_regress_confounds_mismatched_time_length_without_coordinates(
+    sample_timeseries,
+):
+    """Test shape mismatch path when confounds have no time coordinates."""
+    signals = sample_timeseries(n_time=100, n_voxels=50)
+    confounds = xr.DataArray(np.random.randn(50, 3), dims=["time", "confound"])
+
+    with pytest.raises(ValueError, match="does not match signals time dimension"):
+        regress_confounds(signals, confounds)
 
 
 def test_regress_confounds_xarray_confounds(sample_timeseries):
@@ -297,6 +317,22 @@ def test_regress_confounds_4d_imaging(sample_3dt_volume):
             cleaned.coords[dim].values,
             sample_3dt_volume.coords[dim].values,
         )
+
+
+def test_regress_confounds_nonleading_time_axis(sample_timeseries):
+    """Test confound regression when time is not the leading axis."""
+    signals = sample_timeseries(n_time=100, n_voxels=20)
+    confounds = xr.DataArray(
+        np.random.randn(100, 3),
+        dims=["time", "confound"],
+        coords={"time": signals.coords["time"]},
+    )
+
+    expected = regress_confounds(signals, confounds)
+    transposed = signals.transpose("space", "time")
+    result = regress_confounds(transposed, confounds).transpose("time", "space")
+
+    assert_allclose(result.values, expected.values)
 
 
 def test_regress_confounds_dask_compatibility(sample_timeseries):

--- a/tests/unit/test_signal/test_detrend.py
+++ b/tests/unit/test_signal/test_detrend.py
@@ -314,6 +314,22 @@ def test_detrend_polynomial_3dt(sample_3dt_volume):
     assert_allclose(result.values, naive_result, rtol=1e-8)
 
 
+def test_detrend_polynomial_with_nonleading_time_axis(sample_timeseries):
+    """Test polynomial detrending when time is not the first axis."""
+    signals = sample_timeseries(n_time=100, n_voxels=20).transpose("space", "time")
+    time = np.arange(signals.sizes["time"])
+    trended = signals + (time**2) * 0.05
+
+    result = detrend(trended, order=2)
+
+    assert result.dims == trended.dims
+    assert result.shape == trended.shape
+
+    naive_result = _naive_polynomial_detrend(trended.values, order=2, axis=1)
+    assert_allclose(result.values, naive_result, rtol=1e-7)
+
+
+
 def test_detrend_dask_compatibility(rng):
     """Test linear detrending works with Dask-backed arrays."""
     n_time = 100

--- a/tests/unit/test_signal/test_standardization.py
+++ b/tests/unit/test_signal/test_standardization.py
@@ -9,20 +9,6 @@ from numpy.testing import assert_allclose
 from confusius.signal import standardize
 
 
-@pytest.fixture
-def random_signals_dask(rng):
-    """Random 2D signals (time, voxels) with Dask backend."""
-    data = rng.normal(loc=10, scale=2, size=(100, 50))
-    return xr.DataArray(
-        da.from_array(data, chunks=(50, 25)),
-        dims=["time", "space"],
-        coords={
-            "time": np.arange(100) * 0.002,
-            "space": np.arange(50),
-        },
-    )
-
-
 def test_standardize_zscore(sample_timeseries):
     """Test z-score standardization produces mean=0, std=1."""
     random_signals = sample_timeseries(n_time=100, n_voxels=50)
@@ -116,10 +102,14 @@ def test_standardize_psc_near_zero_mean():
     assert np.all(np.isnan(result.values[:, 0]))
 
 
-def test_standardize_dask_compatibility(random_signals_dask):
+def test_standardize_dask_compatibility(sample_timeseries):
     """Test standardization works with Dask-backed arrays."""
+    signals = sample_timeseries(n_time=100, n_voxels=50).chunk(
+        {"time": 50, "space": 25}
+    )
+
     # Should work without computing.
-    result = standardize(random_signals_dask, method="zscore")
+    result = standardize(signals, method="zscore")
 
     # Result should still be Dask-backed.
     assert isinstance(result.data, da.Array)


### PR DESCRIPTION
## Summary
- add `ensure_finite` and `interpolate_kwargs` to `confusius.signal.clean`
- repair non-finite values with per-series time interpolation when `ensure_finite=True`, while leaving them untouched when `False`
- fill boundary-censored samples from the nearest kept sample before detrending/filtering
- fix the misleading `interpolate_samples` boundary doc example and add regression tests

Closes #238.
