### PR TITLE
fix(xarray): scale voxdim with applied affine

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -57,6 +57,9 @@ Current development version for the next ConfUSIus release.
 
 ### :bug: Fixes
 
+- [`apply_affine`][confusius.xarray.apply_affine] now rescales the `voxdim` attribute
+  of the spatial coordinates along with the coordinate values
+  ([#245](https://github.com/confusius-tools/confusius/pull/245)).
 - `signal.clean` now supports `ensure_finite=True` to repair non-finite `signals`
   and `confounds` by interpolating along time, fills censored boundary samples from
   the nearest kept sample before filtering, and accepts `interpolate_kwargs` for

--- a/src/confusius/xarray/affine.py
+++ b/src/confusius/xarray/affine.py
@@ -178,6 +178,10 @@ def apply_affine(
             dims=[dim],
             attrs=da.coords[dim].attrs,
         )
+        if "voxdim" in new_coords[dim].attrs:
+            # `voxdim` records the physical voxel size along this axis, so it must scale
+            # together with the coordinates it describes.
+            new_coords[dim].attrs["voxdim"] *= np.abs(zoom[axis])
 
     # Re-express every stored affine against the new axis-aligned physical frame
     # so it stays valid: M_new = M_old @ inv(axis_aligned(translation, zoom)).

--- a/tests/unit/test_io/test_nifti.py
+++ b/tests/unit/test_io/test_nifti.py
@@ -11,6 +11,7 @@ import pytest
 import xarray as xr
 
 from confusius.io.nifti import load_nifti, save_nifti
+from confusius.xarray.affine import apply_affine
 
 
 @pytest.fixture
@@ -1211,9 +1212,7 @@ class TestSaveNifti:
         roundtripped = load_nifti(output_path)
         assert roundtripped.dims == ("component", "z", "y", "x")
         assert roundtripped.sizes["component"] == 1
-        np.testing.assert_array_equal(
-            roundtripped.coords["component"].values, [0.0]
-        )
+        np.testing.assert_array_equal(roundtripped.coords["component"].values, [0.0])
 
     def test_save_empty_extra_coord_roundtrips(self, tmp_path) -> None:
         """An empty extra-dim coord is vacuously regular; the save writes an empty-axis NIfTI.
@@ -2454,6 +2453,39 @@ class TestRoundtrip:
         )
         np.testing.assert_allclose(
             reloaded.header.get_qform(coded=True)[0], qform, atol=1e-4
+        )
+
+    def test_roundtrip_qform_after_apply_affine_with_singleton_dim(self, tmp_path):
+        """Applying `physical_to_qform` before saving still round-trips the qform.
+
+        Regression (#244): the scan has a singleton spatial axis, whose saved
+        spacing cannot come from coordinate steps and falls back to the
+        `voxdim` coordinate attribute. `apply_affine` must rescale `voxdim`
+        along with the coordinates, otherwise the saved qform carries the
+        stale voxel size on that axis.
+        """
+        sform = np.diag([2.0, 3.0, 4.0, 1.0])
+        sform[:3, 3] = [10.0, -5.0, 2.0]
+        qform = np.diag([0.5, 1.5, 2.5, 1.0])
+        qform[:3, 3] = [5.0, 6.0, 7.0]
+        # NIfTI shape (x, y, z): z is the singleton axis.
+        img = nib.Nifti1Image(np.zeros((4, 3, 1), dtype=np.float32), sform)
+        img.header.set_sform(sform, code=1)
+        img.header.set_qform(qform, code=1)
+        in_path = tmp_path / "in.nii.gz"
+        img.to_filename(in_path)
+
+        da = load_nifti(in_path)
+        da, _ = apply_affine(da, da.attrs["affines"]["physical_to_qform"])
+        out_path = tmp_path / "out.nii.gz"
+        save_nifti(da, out_path)
+        reloaded = nib.load(out_path)
+
+        np.testing.assert_allclose(
+            reloaded.header.get_qform(coded=True)[0], qform, atol=1e-4
+        )
+        np.testing.assert_allclose(
+            reloaded.header.get_sform(coded=True)[0], sform, atol=1e-4
         )
 
     def test_roundtrip_3d(self, tmp_path, sample_3d_volume):

--- a/tests/unit/test_xarray/test_accessors.py
+++ b/tests/unit/test_xarray/test_accessors.py
@@ -507,6 +507,26 @@ class TestAffineApplyMethod:
         np.testing.assert_allclose(result.coords["x"].values, da.coords["x"].values)
         np.testing.assert_allclose(orientation, np.eye(4))
 
+    def test_scaling_updates_voxdim_attrs(self):
+        """A scaling affine rescales each coord's `voxdim` by the absolute zoom.
+
+        Regression: `voxdim` used to be copied verbatim, leaving a stale voxel
+        size after any zooming affine (and hence a wrong pixdim/qform when the
+        scan is saved to NIfTI).
+        """
+        da = self._make_scan()
+        voxdims = {"z": 0.1, "y": 0.2, "x": 0.3}
+        for dim, voxdim in voxdims.items():
+            da.coords[dim].attrs["voxdim"] = voxdim
+        scale = np.diag([2.0, 3.0, -0.5, 1.0])
+        result, _ = da.fusi.affine.apply(scale)
+        for dim, zoom in zip(("z", "y", "x"), (2.0, 3.0, 0.5)):
+            assert result.coords[dim].attrs["voxdim"] == pytest.approx(
+                voxdims[dim] * zoom
+            )
+            # The input scan's voxdim must not be mutated.
+            assert da.coords[dim].attrs["voxdim"] == voxdims[dim]
+
     def test_wrong_shape_raises_value_error(self):
         """Affines with shape other than (4, 4) raise ValueError."""
         da = self._make_scan()


### PR DESCRIPTION
## Summary
- `apply_affine` now rescales each spatial coordinate's `voxdim` attribute by the absolute per-axis zoom, keeping the stored voxel size in sync with the rescaled coordinate values
- add a regression test asserting `voxdim` scales with the applied zoom (and that the input array is not mutated)
- add a NIfTI round-trip regression test: a file with sform + qform and a singleton spatial axis, loaded, transformed with `physical_to_qform`, and saved must keep its original qform — the singleton axis has no coordinate steps, so the saved spacing relies entirely on `voxdim`
- add changelog entry

Closes #244.