### PR TITLE
feat(xarray): accept string affine keys in apply_affine

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -54,6 +54,10 @@ Current development version for the next ConfUSIus release.
   downloading the Landemard et al. (2026) fUSI-BIDS dataset from OSF, with
   `datasets`, `subjects`, `acqs`, and `datatypes` filters
   ([#228](https://github.com/confusius-tools/confusius/pull/230)).
+- [`apply_affine`][confusius.xarray.affine.apply_affine] and the
+  `data.fusi.affine.apply` accessor now accept a string naming a key in
+  `attrs["affines"]`, instead of requiring the affine matrix itself
+  ([#247](https://github.com/confusius-tools/confusius/pull/247)).
 
 ### :bug: Fixes
 

--- a/src/confusius/xarray/affine.py
+++ b/src/confusius/xarray/affine.py
@@ -66,7 +66,7 @@ def affine_to(
 
 def apply_affine(
     da: xr.DataArray,
-    affine: "npt.NDArray[np.float64]",
+    affine: "npt.NDArray[np.float64] | str",
     inplace: bool = False,
 ) -> "tuple[xr.DataArray, npt.NDArray[np.float64]]":
     """Apply an affine to a DataArray's spatial coordinates.
@@ -94,8 +94,9 @@ def apply_affine(
     da : xarray.DataArray
         Input scan. Must have at least one of `"z"`, `"y"`, `"x"` as dimensions
         with associated 1D coordinates.
-    affine : numpy.ndarray, shape (4, 4)
-        Homogeneous affine matrix to apply.
+    affine : numpy.ndarray, shape (4, 4), or str
+        Homogeneous affine matrix to apply. If a string, it is looked up as a
+        key in `da.attrs["affines"]`.
     inplace : bool, default: False
         Whether to modify the DataArray in-place.
 
@@ -111,7 +112,10 @@ def apply_affine(
     Raises
     ------
     ValueError
-        If `affine` is not shape `(4, 4)`.
+        If `affine` is not shape `(4, 4)`, or if `affine` is a string and `da`
+        has no `"affines"` entry in `attrs`.
+    KeyError
+        If `affine` is a string not present in `da.attrs["affines"]`.
 
     Examples
     --------
@@ -129,6 +133,12 @@ def apply_affine(
     >>> float(result.coords["z"].values[0])
     10.0
     """
+    if isinstance(affine, str):
+        if "affines" not in da.attrs:
+            raise ValueError("da does not have an 'affines' entry in attrs.")
+        if affine not in da.attrs["affines"]:
+            raise KeyError(f"'{affine}' not found in da.attrs['affines'].")
+        affine = da.attrs["affines"][affine]
     affine = np.asarray(affine, dtype=np.float64)
     if affine.shape != (4, 4):
         raise ValueError(f"affine must have shape (4, 4), got {affine.shape}.")
@@ -267,7 +277,7 @@ class FUSIAffineAccessor:
 
     def apply(
         self,
-        affine: "npt.NDArray[np.float64]",
+        affine: "npt.NDArray[np.float64] | str",
         inplace: bool = False,
     ) -> "tuple[xr.DataArray, npt.NDArray[np.float64]]":
         """Apply an affine to the scan's spatial coordinates.
@@ -291,8 +301,9 @@ class FUSIAffineAccessor:
 
         Parameters
         ----------
-        affine : numpy.ndarray, shape (4, 4)
-            Homogeneous affine matrix to apply.
+        affine : numpy.ndarray, shape (4, 4), or str
+            Homogeneous affine matrix to apply. If a string, it is looked up
+            as a key in `self.attrs["affines"]`.
         inplace : bool, default: False
             Whether to modify the DataArray in-place.
 
@@ -308,7 +319,10 @@ class FUSIAffineAccessor:
         Raises
         ------
         ValueError
-            If `affine` shape is not `(4, 4)`.
+            If `affine` shape is not `(4, 4)`, or if `affine` is a string and
+            `self` has no `"affines"` entry in `attrs`.
+        KeyError
+            If `affine` is a string not present in `self.attrs["affines"]`.
 
         Examples
         --------

--- a/tests/unit/test_xarray/test_accessors.py
+++ b/tests/unit/test_xarray/test_accessors.py
@@ -533,6 +533,34 @@ class TestAffineApplyMethod:
         with pytest.raises(ValueError, match="shape"):
             da.fusi.affine.apply(np.eye(3))
 
+    def test_string_key_looks_up_stored_affine(self):
+        """A string `affine` is resolved from `attrs["affines"]` before applying."""
+        shift = np.eye(4)
+        shift[:3, 3] = [10.0, 5.0, -3.0]
+        da = self._make_scan(affines={"physical_to_lab": shift})
+        result, _ = da.fusi.affine.apply("physical_to_lab")
+        np.testing.assert_allclose(
+            result.coords["z"].values, da.coords["z"].values + 10.0
+        )
+        np.testing.assert_allclose(
+            result.coords["y"].values, da.coords["y"].values + 5.0
+        )
+        np.testing.assert_allclose(
+            result.coords["x"].values, da.coords["x"].values - 3.0
+        )
+
+    def test_string_key_missing_affines_attr_raises_value_error(self):
+        """A string `affine` raises ValueError when `da` has no `affines` attr."""
+        da = self._make_scan()
+        with pytest.raises(ValueError, match="does not have an 'affines' entry"):
+            da.fusi.affine.apply("physical_to_lab")
+
+    def test_string_key_not_found_raises_key_error(self):
+        """A string `affine` absent from `attrs["affines"]` raises KeyError."""
+        da = self._make_scan(affines={"physical_to_lab": np.eye(4)})
+        with pytest.raises(KeyError, match="physical_to_mri"):
+            da.fusi.affine.apply("physical_to_mri")
+
     def test_stored_affines_updated_single(self):
         """Stored (4, 4) affines are updated by M_new = M_old @ inv(affine)."""
         stored = np.array(


### PR DESCRIPTION
## Summary

- `apply_affine` / `data.fusi.affine.apply` now accept `affine: numpy.ndarray | str`. A string is resolved via `da.attrs["affines"][affine]`.
- Raises `ValueError` if `da` has no `"affines"` entry in `attrs`, `KeyError` if the key is missing.

Closes #246.

## Test plan
- [x] Added tests: successful string lookup, missing `affines` attr, missing key.
- [x] `uv run just pre-commit`
- [x] `uv run pytest tests/unit/test_xarray/test_accessors.py`