### PR TITLE
fix(atlas,extract): disambiguate hemisphere masks by name, not raw id

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -62,13 +62,12 @@ Current development version for the next ConfUSIus release.
 ### :bug: Fixes
 
 - [`Atlas.get_masks`][confusius.atlas.Atlas.get_masks] now suffixes the `mask`
-  coordinate with `_L`/`_R` for `sides="left"`/`"right"`, so requesting the same
-  region on both hemispheres no longer produces duplicate `mask` values.
+  coordinate with `_L`/`_R` for `sides="left"`/`"right"`, so requesting the same region
+  on both hemispheres no longer produces duplicate `mask` values.
   [`extract_with_labels`][confusius.extract.extract_with_labels] no longer requires
-  unique region ids across stacked mask layers — a layer is already identified by its
-  position along `mask` — so `get_masks` output can be passed straight through
-  without manual relabeling
-  ([#249](https://github.com/confusius-tools/confusius/pull/249)).
+  unique region ids across stacked mask layers—a layer is already identified by its
+  position along `mask`—so `get_masks` output can be passed straight through without
+  manual relabeling ([#249](https://github.com/confusius-tools/confusius/pull/249)).
 - [`apply_affine`][confusius.xarray.apply_affine] now rescales the `voxdim` attribute
   of the spatial coordinates along with the coordinate values
   ([#245](https://github.com/confusius-tools/confusius/pull/245)).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -61,6 +61,14 @@ Current development version for the next ConfUSIus release.
 
 ### :bug: Fixes
 
+- [`Atlas.get_masks`][confusius.atlas.Atlas.get_masks] now suffixes the `mask`
+  coordinate with `_L`/`_R` for `sides="left"`/`"right"`, so requesting the same
+  region on both hemispheres no longer produces duplicate `mask` values.
+  [`extract_with_labels`][confusius.extract.extract_with_labels] no longer requires
+  unique region ids across stacked mask layers — a layer is already identified by its
+  position along `mask` — so `get_masks` output can be passed straight through
+  without manual relabeling
+  ([#249](https://github.com/confusius-tools/confusius/pull/249)).
 - [`apply_affine`][confusius.xarray.apply_affine] now rescales the `voxdim` attribute
   of the spatial coordinates along with the coordinate values
   ([#245](https://github.com/confusius-tools/confusius/pull/245)).

--- a/src/confusius/atlas/atlas.py
+++ b/src/confusius/atlas/atlas.py
@@ -352,7 +352,9 @@ class Atlas:
         -------
         xarray.DataArray
             Integer DataArray with dims `["mask", "z", "y", "x"]`. The
-            `mask` coordinate holds the region acronym for each layer.
+            `mask` coordinate holds the region acronym for each layer, suffixed with
+            `_L`/`_R` when the corresponding `side` is `"left"`/`"right"` (left/right
+            requests for the same region would otherwise share an acronym).
 
         Raises
         ------
@@ -368,6 +370,8 @@ class Atlas:
         >>> atlas.get_masks("VISp", sides="left")
         >>> atlas.get_masks(["VISp", "AUDp", "MOp"])
         >>> atlas.get_masks(["VISp", "AUDp"], sides=["left", "both"])
+        >>> atlas.get_masks(["VISp", "VISp"], sides=["left", "right"]).coords["mask"].values
+        array(['VISp_L', 'VISp_R'], dtype=object)
         """
         region_list: list[int | str] = (
             [regions] if isinstance(regions, (int, str)) else list(regions)
@@ -405,13 +409,16 @@ class Atlas:
             # faster at the cost of higher memory usage.
             layer[np.isin(annotation_np, descendant_ids, kind="table")] = rid
 
+            acronym = self._structures[rid]["acronym"]
             if s == "left":
                 layer[hemispheres_np != 1] = 0
+                acronym = f"{acronym}_L"
             elif s == "right":
                 layer[hemispheres_np != 2] = 0
+                acronym = f"{acronym}_R"
 
             layers.append(layer)
-            acronyms.append(self._structures[rid]["acronym"])
+            acronyms.append(acronym)
 
         stacked = np.stack(layers, axis=0)
 

--- a/src/confusius/extract/labels.py
+++ b/src/confusius/extract/labels.py
@@ -17,7 +17,7 @@ def _validate_stacked_mask_layers(labels: xr.DataArray) -> None:
 
     The layer's own non-zero value is never used to key the reduction (a fresh,
     per-layer id is assigned instead, see `extract_with_labels`), so layers may
-    reuse the same id across the `mask` dimension — a stacked mask layer is already
+    reuse the same id across the `mask` dimension—a stacked mask layer is already
     uniquely identified by its position along `mask`.
 
     Parameters

--- a/src/confusius/extract/labels.py
+++ b/src/confusius/extract/labels.py
@@ -12,26 +12,24 @@ _VALID_REDUCTIONS = frozenset({"mean", "sum", "median", "min", "max", "var", "st
 """Valid reduction names accepted by `extract_with_labels`."""
 
 
-def _get_stacked_mask_ids(labels: xr.DataArray) -> list[int]:
-    """Validate and return the unique non-zero ID from each stacked mask layer.
+def _validate_stacked_mask_layers(labels: xr.DataArray) -> None:
+    """Validate that each stacked mask layer has exactly one non-zero value.
+
+    The layer's own non-zero value is never used to key the reduction (a fresh,
+    per-layer id is assigned instead, see `extract_with_labels`), so layers may
+    reuse the same id across the `mask` dimension — a stacked mask layer is already
+    uniquely identified by its position along `mask`.
 
     Parameters
     ----------
     labels : xarray.DataArray
         Stacked mask array with a leading `mask` dimension.
 
-    Returns
-    -------
-    list[int]
-        Non-zero region ID for each mask layer, in mask-dimension order.
-
     Raises
     ------
     ValueError
-        If any layer has more or fewer than one non-zero value, or if IDs
-        are duplicated across layers.
+        If any layer has more or fewer than one unique non-zero value.
     """
-    per_mask_id: list[int] = []
     for i in range(labels.sizes["mask"]):
         layer_vals = np.unique(labels.isel(mask=i).values)
         layer_vals = layer_vals[layer_vals != 0]
@@ -40,16 +38,6 @@ def _get_stacked_mask_ids(labels: xr.DataArray) -> list[int]:
                 f"Stacked mask layer {i} must have exactly one unique non-zero "
                 f"value, got {len(layer_vals)}: {layer_vals.tolist()}."
             )
-        per_mask_id.append(int(layer_vals[0]))
-
-    duplicates = {v for v in per_mask_id if per_mask_id.count(v) > 1}
-    if duplicates:
-        raise ValueError(
-            f"Stacked mask layers have duplicate non-zero IDs: {duplicates}. "
-            "Each layer must carry a unique region ID."
-        )
-
-    return per_mask_id
 
 
 def _flox_reduce(
@@ -125,9 +113,12 @@ def extract_with_labels(
           non-overlapping region. The `region` coordinate of the output holds the
           integer label values.
         - **Stacked mask format**: Has a leading `mask` dimension followed by spatial
-          dims, e.g. `(mask, z, y, x)`. Each layer has values in `{0, region_id}`
-          and regions may overlap. The `region` coordinate of the output holds the
-          `mask` coordinate values (e.g., region label).
+          dims, e.g. `(mask, z, y, x)`. Each layer has exactly one non-zero value
+          identifying its own voxels, and regions may overlap; the non-zero value
+          itself is not used to identify the layer, so it may repeat across layers
+          (e.g. the same region id for left/right hemisphere layers). The `region`
+          coordinate of the output holds the `mask` coordinate values (e.g., region
+          label).
 
     reduction : {"mean", "sum", "median", "min", "max", "var", "std"}, default: "mean"
         Aggregation function applied across voxels in each region.
@@ -182,11 +173,12 @@ def extract_with_labels(
     >>> signals.coords["region"].values
     array([1, 2])
     >>>
-    >>> # Stacked mask format from Atlas.get_masks.
-    >>> mask = atlas_fusi.get_masks(["VISp", "AUDp"])
+    >>> # Stacked mask format from Atlas.get_masks. Left/right hemisphere layers
+    >>> # share the same region id, but each is disambiguated by its `mask` coord.
+    >>> mask = atlas_fusi.get_masks(["VISp", "VISp"], sides=["left", "right"])
     >>> signals = extract_with_labels(data, mask)
     >>> signals.coords["region"].values
-    array(['VISp', 'AUDp'], dtype=object)
+    array(['VISp_L', 'VISp_R'], dtype=object)
     """
     validate_labels(labels, data, "labels")
 
@@ -197,21 +189,29 @@ def extract_with_labels(
 
     if "mask" in labels.dims:
         spatial_dims = [d for d in labels.dims if d != "mask"]
-        per_mask_id = _get_stacked_mask_ids(labels)
-        id_to_name = dict(zip(per_mask_id, labels.coords["mask"].values))
+        _validate_stacked_mask_layers(labels)
+
+        # A stacked mask layer is already uniquely identified by its position along
+        # `mask`, so group by a fresh per-layer id instead of the layer's own
+        # (possibly repeated) non-zero value.
+        mask_names = labels.coords["mask"].values
+        layer_ids = xr.DataArray(np.arange(1, labels.sizes["mask"] + 1), dims="mask")
+        synthetic_labels = xr.where(labels != 0, layer_ids, 0)
 
         has_overlap = bool(((labels > 0).sum(dim="mask") > 1).any().values)
 
         if not has_overlap:
-            # Sum across mask dim: no-overlap guarantees each voxel keeps its original
-            # ID.
-            result = _flox_reduce(data, labels.sum(dim="mask"), spatial_dims, reduction)
+            # Sum across mask dim: no-overlap guarantees each voxel keeps its
+            # synthetic id.
+            result = _flox_reduce(
+                data, synthetic_labels.sum(dim="mask"), spatial_dims, reduction
+            )
         else:
             # Use flox's overlapping groups support.
             # See: https://flox.readthedocs.io/en/latest/user-stories/overlaps.html
-            result = _flox_reduce(data, labels, spatial_dims, reduction)
+            result = _flox_reduce(data, synthetic_labels, spatial_dims, reduction)
 
-        region_names = [id_to_name[int(r)] for r in result.coords["region"].values]
+        region_names = [mask_names[int(r) - 1] for r in result.coords["region"].values]
         return result.assign_coords(region=region_names)
     else:
         return _flox_reduce(data, labels, list(labels.dims), reduction)

--- a/tests/unit/test_atlas/test_atlas.py
+++ b/tests/unit/test_atlas/test_atlas.py
@@ -223,6 +223,16 @@ class TestGetMasks:
 
         np.testing.assert_array_equal((left > 0) | (right > 0), both > 0)
 
+    def test_per_region_sides_mask_coord_disambiguated(self, atlas: Atlas) -> None:
+        """Same region with different sides must not share a `mask` coord value."""
+        result = atlas.get_masks([10, 10], sides=["left", "right"])
+        np.testing.assert_array_equal(result.coords["mask"].values, ["ch_L", "ch_R"])
+
+    def test_both_side_mask_coord_is_bare_acronym(self, atlas: Atlas) -> None:
+        """`sides="both"` (the default) must not suffix the acronym."""
+        result = atlas.get_masks(10, sides="both")
+        np.testing.assert_array_equal(result.coords["mask"].values, ["ch"])
+
     def test_str_acronym_gives_same_result_as_integer_id(self, atlas: Atlas) -> None:
         by_id = atlas.get_masks(10).values[0]
         by_acronym = atlas.get_masks("ch").values[0]

--- a/tests/unit/test_extract/test_labels.py
+++ b/tests/unit/test_extract/test_labels.py
@@ -217,6 +217,95 @@ class TestWithLabels:
             sample_3dt_volume.values[:, 1:3, :, :].mean(axis=(-3, -2, -1)),
         )
 
+    def test_stacked_masks_duplicate_ids_non_overlapping(self, sample_3dt_volume):
+        """Non-overlapping layers sharing the same raw id must stay distinct regions.
+
+        Regression test: layer position along `mask`, not the layer's own non-zero
+        value, is what identifies a region — mirrors Atlas.get_masks reusing a
+        region's id across its left/right hemisphere layers.
+        """
+        _, nz, ny, nx = sample_3dt_volume.shape
+
+        mask_data = np.zeros((2, nz, ny, nx), dtype=int)
+        mask_data[0, 0, :, :] = 7  # Region "VISp_L": first z-slice, id 7.
+        mask_data[1, 1, :, :] = 7  # Region "VISp_R": second z-slice, same id 7.
+        labels = xr.DataArray(
+            mask_data,
+            dims=["mask", "z", "y", "x"],
+            coords={
+                "mask": ["VISp_L", "VISp_R"],
+                "z": sample_3dt_volume.coords["z"],
+                "y": sample_3dt_volume.coords["y"],
+                "x": sample_3dt_volume.coords["x"],
+            },
+        )
+
+        result = extract.extract_with_labels(sample_3dt_volume, labels)
+
+        np.testing.assert_array_equal(
+            result.coords["region"].values, ["VISp_L", "VISp_R"]
+        )
+        np.testing.assert_allclose(
+            result.sel(region="VISp_L").values,
+            sample_3dt_volume.values[:, 0, :, :].mean(axis=(-2, -1)),
+        )
+        np.testing.assert_allclose(
+            result.sel(region="VISp_R").values,
+            sample_3dt_volume.values[:, 1, :, :].mean(axis=(-2, -1)),
+        )
+
+    def test_stacked_masks_duplicate_ids_overlapping(self, sample_3dt_volume):
+        """Overlapping layers sharing the same raw id must stay distinct regions."""
+        _, nz, ny, nx = sample_3dt_volume.shape
+
+        mask_data = np.zeros((2, nz, ny, nx), dtype=int)
+        mask_data[0, 0:2, :, :] = 3  # Region "A": slices 0-1, id 3.
+        mask_data[1, 1:3, :, :] = 3  # Region "B": slices 1-2, same id 3.
+        labels = xr.DataArray(
+            mask_data,
+            dims=["mask", "z", "y", "x"],
+            coords={
+                "mask": ["A", "B"],
+                "z": sample_3dt_volume.coords["z"],
+                "y": sample_3dt_volume.coords["y"],
+                "x": sample_3dt_volume.coords["x"],
+            },
+        )
+
+        result = extract.extract_with_labels(sample_3dt_volume, labels)
+
+        np.testing.assert_array_equal(result.coords["region"].values, ["A", "B"])
+        np.testing.assert_allclose(
+            result.sel(region="A").values,
+            sample_3dt_volume.values[:, 0:2, :, :].mean(axis=(-3, -2, -1)),
+        )
+        np.testing.assert_allclose(
+            result.sel(region="B").values,
+            sample_3dt_volume.values[:, 1:3, :, :].mean(axis=(-3, -2, -1)),
+        )
+
+    def test_stacked_mask_layer_wrong_nonzero_count_raises(self, sample_3dt_volume):
+        """A layer with zero or multiple distinct non-zero values must raise."""
+        _, nz, ny, nx = sample_3dt_volume.shape
+
+        mask_data = np.zeros((2, nz, ny, nx), dtype=int)
+        mask_data[0, 0, :, :] = 1
+        mask_data[1, 1, : ny // 2, :] = 2  # Layer 1 has two distinct values below.
+        mask_data[1, 1, ny // 2 :, :] = 3
+        labels = xr.DataArray(
+            mask_data,
+            dims=["mask", "z", "y", "x"],
+            coords={
+                "mask": ["A", "B"],
+                "z": sample_3dt_volume.coords["z"],
+                "y": sample_3dt_volume.coords["y"],
+                "x": sample_3dt_volume.coords["x"],
+            },
+        )
+
+        with pytest.raises(ValueError, match="exactly one unique non-zero"):
+            extract.extract_with_labels(sample_3dt_volume, labels)
+
     def test_dask_spatial_chunks(self):
         """Test correctness when spatial dims are chunked in the Dask array."""
         rng = np.random.default_rng(42)


### PR DESCRIPTION
## Summary
- `Atlas.get_masks` now suffixes the `mask` coord acronym with `_L`/`_R` for `sides="left"`/`"right"` (bare acronym for `"both"`), so requesting the same region on both hemispheres no longer produces duplicate `mask` coord values.
- `extract_with_labels` no longer keys its flox reduction on a stacked mask layer's own non-zero value — it assigns a synthetic per-layer id from position along `mask` instead, so `get_masks` output with duplicate region ids across layers can be passed straight through without manual relabeling.

Closes #248.

## Test plan
- [x] `uv run pytest tests/unit/test_extract/test_labels.py tests/unit/test_atlas/test_atlas.py -q` (71 passed, includes new duplicate-id and side-suffix regression tests)
- [x] `just pre-commit` (ruff, ty, codespell, numpydoc-validation)