### PR TITLE
fix(plotting): support non-numeric slice_mode coordinates

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -58,6 +58,14 @@ Current development version for the next ConfUSIus release.
   `data.fusi.affine.apply` accessor now accept a string naming a key in
   `attrs["affines"]`, instead of requiring the affine matrix itself
   ([#247](https://github.com/confusius-tools/confusius/pull/247)).
+- Plotting functions that slice along `slice_mode` (
+  [`plot_volume`][confusius.plotting.plot_volume],
+  [`plot_contours`][confusius.plotting.plot_contours],
+  [`plot_composite`][confusius.plotting.plot_composite], and the
+  [`VolumePlotter`][confusius.plotting.VolumePlotter] methods) now support non-numeric
+  coordinates (e.g. region/mask labels), so a single call can slice a stacked
+  connectivity or ROI map by label instead of looping over `.sel()` per panel
+  ([#250](https://github.com/confusius-tools/confusius/pull/250)).
 
 ### :bug: Fixes
 

--- a/src/confusius/plotting/image.py
+++ b/src/confusius/plotting/image.py
@@ -1,6 +1,8 @@
 """Image visualization utilities for fUSI data."""
 
+import numbers
 import warnings
+from collections.abc import Hashable
 from typing import TYPE_CHECKING, Any, Literal, Sequence
 
 import numpy as np
@@ -319,20 +321,49 @@ def _get_distinct_colors(n_colors: int) -> list[tuple[float, float, float]]:
     return [tuple(cmap(i % cmap.N)[:3]) for i in range(n_colors)]
 
 
+def _format_coord(coord: Hashable) -> str:
+    """Format a slice coordinate for display: `.3g` for numeric, `str` otherwise."""
+    if isinstance(coord, numbers.Real):
+        return f"{coord:.3g}"
+    return str(coord)
+
+
+def _coords_match(
+    stored_coord: Hashable, target_coord: Hashable, tolerance: float
+) -> bool:
+    """Compare two slice coordinates, using a tolerance for numeric values."""
+    if isinstance(stored_coord, numbers.Real) and isinstance(
+        target_coord, numbers.Real
+    ):
+        return abs(float(stored_coord) - float(target_coord)) < tolerance
+    return stored_coord == target_coord
+
+
 def _extract_slices(
-    data: xr.DataArray, slice_mode: str, slice_coords: Sequence[float]
-) -> tuple[list[xr.DataArray], list[float]]:
+    data: xr.DataArray, slice_mode: str, slice_coords: Sequence[Hashable]
+) -> tuple[list[xr.DataArray], list[Hashable]]:
     """Extract 2D slices from `data` along `slice_mode`.
+
+    Numeric coordinates are matched by nearest-neighbour lookup; non-numeric
+    coordinates (e.g. region labels) require an exact match.
 
     Returns the slices and their actual snapped coordinate values.
     """
     slices: list[xr.DataArray] = []
-    actual_coords: list[float] = []
+    actual_coords: list[Hashable] = []
     for coord in slice_coords:
         if slice_mode in data.coords:
-            slice_da = data.sel({slice_mode: coord}, method="nearest")
-            actual_coord = float(slice_da.coords[slice_mode].values)
+            is_numeric = np.issubdtype(data.coords[slice_mode].dtype, np.number)
+            slice_da = data.sel(
+                {slice_mode: coord}, method="nearest" if is_numeric else None
+            )
+            actual_coord = slice_da.coords[slice_mode].values.item()
         else:
+            if not isinstance(coord, numbers.Real):
+                raise ValueError(
+                    f"slice_mode '{slice_mode}' has no coordinates, so slice_coords "
+                    f"must be numeric positional indices, got {coord!r}."
+                )
             idx = int(round(coord))
             slice_da = data.isel({slice_mode: idx})
             actual_coord = float(coord)
@@ -414,7 +445,7 @@ class VolumePlotter:
         self._fg_color = fg_color
         self._yincrease = yincrease
         self._xincrease = xincrease
-        self._coord_to_axis: dict[float, int] = {}
+        self._coord_to_axis: dict[Hashable, int] = {}
         # Explicitly tracked axis data limits to avoid matplotlib's auto-margin.
         self._axis_xlims: dict[int, tuple[float, float]] = {}
         self._axis_ylims: dict[int, tuple[float, float]] = {}
@@ -479,7 +510,7 @@ class VolumePlotter:
             self._hover_manager.roi_labels.update(roi_labels)
 
     def _find_matching_axes(
-        self, actual_coords: list[float], tolerance: float = 1e-6
+        self, actual_coords: list[Hashable], tolerance: float = 1e-6
     ) -> list[tuple[int, int]]:
         """Find axis indices matching the target coordinates.
 
@@ -488,10 +519,12 @@ class VolumePlotter:
 
         Parameters
         ----------
-        actual_coords : list[float]
+        actual_coords : list[collections.abc.Hashable]
             The actual coordinate values of the slices being plotted.
         tolerance : float, default: 1e-6
-            Tolerance for matching coordinates, accounting for floating-point precision.
+            Tolerance for matching numeric coordinates, accounting for floating-point
+            precision. Non-numeric coordinates (e.g. region labels) are matched by
+            equality.
 
         Returns
         -------
@@ -501,7 +534,7 @@ class VolumePlotter:
         matched = []
         for slice_idx, target_coord in enumerate(actual_coords):
             for stored_coord, axis_idx in self._coord_to_axis.items():
-                if abs(stored_coord - target_coord) < tolerance:
+                if _coords_match(stored_coord, target_coord, tolerance):
                     matched.append((axis_idx, slice_idx))
                     break
         return matched
@@ -544,12 +577,12 @@ class VolumePlotter:
         store[axis_idx] = new_lim
         return new_lim
 
-    def _warn_unmatched(self, unmatched_slices: list[tuple[int, float]]) -> None:
+    def _warn_unmatched(self, unmatched_slices: list[tuple[int, Hashable]]) -> None:
         """Warn about slice coordinates that could not be matched to axes."""
         unmatched_str = ", ".join(
-            f"{self.slice_mode}={coord:.3g}" for _, coord in unmatched_slices
+            f"{self.slice_mode}={_format_coord(coord)}" for _, coord in unmatched_slices
         )
-        available_coords = [f"{c:.3g}" for c in self._coord_to_axis]
+        available_coords = [_format_coord(c) for c in self._coord_to_axis]
         warnings.warn(
             f"Could not find matching axes for slices: {unmatched_str}. "
             f"These slices will not be plotted. "
@@ -557,20 +590,20 @@ class VolumePlotter:
             stacklevel=find_stack_level(),
         )
 
-    def _build_slice_title(self, data: xr.DataArray, coord: float) -> str:
-        """Build a slice title such as `z = 0.001 mm`."""
+    def _build_slice_title(self, data: xr.DataArray, coord: Hashable) -> str:
+        """Build a slice title such as `z = 0.001 mm` or `region = LGN`."""
         units = (
             data.coords[self.slice_mode].attrs.get("units")
             if self.slice_mode in data.coords
             else None
         )
-        title = f"{self.slice_mode} = {coord:.3g}"
+        title = f"{self.slice_mode} = {_format_coord(coord)}"
         if units:
             title += f" {units}"
         return title
 
     def _init_sequential_layout(
-        self, actual_coords: list[float]
+        self, actual_coords: list[Hashable]
     ) -> list[tuple[int, int]]:
         """Initialise the coordinate-to-axis map and return sequential plot indices."""
         if not self._coord_to_axis:
@@ -603,7 +636,7 @@ class VolumePlotter:
         self,
         data: xr.DataArray,
         n_slices: int,
-        actual_coords: list[float],
+        actual_coords: list[Hashable],
         dim_row: str,
         dim_col: str,
         *,
@@ -663,7 +696,7 @@ class VolumePlotter:
         ax: "Axes",
         axis_idx: int,
         data: xr.DataArray,
-        coord: float,
+        coord: Hashable,
         dim_row: str,
         dim_col: str,
         x_edges: np.ndarray,
@@ -725,7 +758,7 @@ class VolumePlotter:
         self,
         data: xr.DataArray,
         *,
-        slice_coords: Sequence[float] | None = None,
+        slice_coords: Sequence[Hashable] | None = None,
         match_coordinates: bool = True,
         cmap: "str | Colormap | None" = None,
         norm: "Normalize | None" = None,
@@ -754,8 +787,10 @@ class VolumePlotter:
             3D volume data. Unitary dimensions (except `slice_mode`) are squeezed
             before processing. Complex-valued inputs are converted to magnitude
             (`abs(data)`) with a warning.
-        slice_coords : list[float], optional
-            Specific coordinates to plot. If None, uses all coordinates from data.
+        slice_coords : list[collections.abc.Hashable], optional
+            Specific coordinates to plot. Numeric coordinates are matched by
+            nearest-neighbour lookup; non-numeric coordinates (e.g. region labels)
+            require an exact match. If not provided, uses all coordinates from data.
         match_coordinates : bool, default: True
             If True, match slice coordinates to the stored coordinate mapping (for
             overlays). If False, plot sequentially on all axes (requires exact axis
@@ -968,7 +1003,7 @@ class VolumePlotter:
         rtol: float = 1e-5,
         atol: float = 1e-8,
         normalize_strategy: Literal["per_volume", "per_slice", "shared"] = "per_volume",
-        slice_coords: Sequence[float] | None = None,
+        slice_coords: Sequence[Hashable] | None = None,
         match_coordinates: bool = False,
         alpha: float | None = None,
         show_titles: bool = True,
@@ -1031,9 +1066,11 @@ class VolumePlotter:
               range. Preserves the absolute-intensity relationship between the
               two inputs, useful when comparing data acquired at the same
               dynamic range.
-        slice_coords : sequence of float, optional
-            Coordinate values along `slice_mode` at which to extract slices. If not
-            provided, all coordinate values from `data1` are used.
+        slice_coords : Sequence[collections.abc.Hashable], optional
+            Coordinate values along `slice_mode` at which to extract slices. Numeric
+            coordinates are matched by nearest-neighbour lookup; non-numeric
+            coordinates (e.g. region labels) require an exact match. If not provided,
+            all coordinate values from `data1` are used.
         match_coordinates : bool, default: False
             If True, match slice coordinates to the stored coordinate mapping of an
             existing figure (for use as an overlay). If False, plot sequentially on
@@ -1246,7 +1283,7 @@ class VolumePlotter:
         linewidths: float = 1.5,
         linestyles: str = "solid",
         match_coordinates: bool = True,
-        slice_coords: list[float] | None = None,
+        slice_coords: list[Hashable] | None = None,
         fontsize: float | None = None,
         roi_labels: dict[int, str] | None = None,
         **kwargs,
@@ -1283,10 +1320,11 @@ class VolumePlotter:
         match_coordinates : bool, default: True
             If `True`, overlay contours on axes whose slice coordinate matches the
             mask. If `False`, plot sequentially on all axes.
-        slice_coords : list[float], optional
+        slice_coords : list[collections.abc.Hashable], optional
             Coordinate values along the plotter's `slice_mode` at which to draw
-            contours. Slices are selected by nearest-neighbour lookup. If not
-            provided, all coordinate values along `slice_mode` are used.
+            contours. Numeric coordinates are matched by nearest-neighbour lookup;
+            non-numeric coordinates (e.g. region labels) require an exact match. If
+            not provided, all coordinate values along `slice_mode` are used.
         fontsize : float, optional
             Base font size for text elements when a standalone contour figure is created
             (`match_coordinates=False`). Subplot titles use `fontsize` directly;
@@ -1609,7 +1647,7 @@ def plot_contours(
     linewidths: float = 1.5,
     linestyles: str = "solid",
     slice_mode: str = "z",
-    slice_coords: list[float] | None = None,
+    slice_coords: list[Hashable] | None = None,
     fontsize: float | None = None,
     yincrease: bool = False,
     xincrease: bool = True,
@@ -1652,10 +1690,11 @@ def plot_contours(
     slice_mode : str, default: "z"
         Dimension along which to slice (e.g. `"x"`, `"y"`, `"z"`). After
         slicing, each panel must be 2D.
-    slice_coords : list[float], optional
-        Coordinate values along `slice_mode` at which to extract slices. Slices are
-        selected by nearest-neighbour lookup. If not provided, all coordinate values
-        along `slice_mode` are used.
+    slice_coords : list[collections.abc.Hashable], optional
+        Coordinate values along `slice_mode` at which to extract slices. Numeric
+        coordinates are matched by nearest-neighbour lookup; non-numeric
+        coordinates (e.g. region labels) require an exact match. If not provided,
+        all coordinate values along `slice_mode` are used.
     fontsize : float, optional
         Base font size for text elements. Subplot titles use `fontsize` directly; axis
         labels use `0.9 * fontsize`; tick labels use `0.85 * fontsize`. If not provided,
@@ -1751,7 +1790,7 @@ def plot_contours(
 def plot_volume(
     data: xr.DataArray,
     *,
-    slice_coords: list[float] | None = None,
+    slice_coords: list[Hashable] | None = None,
     slice_mode: str = "z",
     cmap: "str | Colormap | None" = None,
     norm: "Normalize | None" = None,
@@ -1789,10 +1828,11 @@ def plot_volume(
         Input data array. Unitary dimensions are squeezed before processing. After
         squeezing, data must be 3D. Complex-valued data is converted to magnitude
         before display.
-    slice_coords : list[float], optional
-        Coordinate values along `slice_mode` at which to extract slices. Slices are
-        selected by nearest-neighbour lookup. If not provided, all coordinate values
-        along `slice_mode` are used.
+    slice_coords : list[collections.abc.Hashable], optional
+        Coordinate values along `slice_mode` at which to extract slices. Numeric
+        coordinates are matched by nearest-neighbour lookup; non-numeric
+        coordinates (e.g. region labels) require an exact match. If not provided,
+        all coordinate values along `slice_mode` are used.
     slice_mode : str, default: "z"
         Dimension along which to slice (e.g., `"x"`, `"y"`, `"z"`,
         `"time"`). After slicing, each panel must be 2D.
@@ -1971,7 +2011,7 @@ def plot_composite(
     rtol: float = 1e-5,
     atol: float = 1e-8,
     normalize_strategy: Literal["per_volume", "per_slice", "shared"] = "per_volume",
-    slice_coords: Sequence[float] | None = None,
+    slice_coords: Sequence[Hashable] | None = None,
     slice_mode: str = "z",
     alpha: float | None = None,
     show_titles: bool = True,
@@ -2034,9 +2074,10 @@ def plot_composite(
         - `"shared"`: rescale both volumes together using a single shared
           `[min(data1.min(), data2.min()), max(data1.max(), data2.max())]` range.
           Preserves the absolute-intensity relationship between the two inputs.
-    slice_coords : sequence of float, optional
-        Coordinate values along `slice_mode` at which to extract slices. Slices are
-        selected by nearest-neighbour lookup. If not provided, all coordinate values
+    slice_coords : Sequence[collections.abc.Hashable], optional
+        Coordinate values along `slice_mode` at which to extract slices. Numeric
+        coordinates are matched by nearest-neighbour lookup; non-numeric
+        coordinates (e.g. region labels) require an exact match. If not provided,
         from `data1` are used.
     slice_mode : str, default: "z"
         Dimension along which to slice (e.g. `"x"`, `"y"`, `"z"`). After slicing, each

--- a/src/confusius/xarray/plotting.py
+++ b/src/confusius/xarray/plotting.py
@@ -1,5 +1,6 @@
 """Xarray accessor for plotting."""
 
+from collections.abc import Hashable
 from typing import TYPE_CHECKING, Any, Literal
 
 import xarray as xr
@@ -352,7 +353,7 @@ class FUSIPlotAccessor:
 
     def volume(
         self,
-        slice_coords: list[float] | None = None,
+        slice_coords: list[Hashable] | None = None,
         slice_mode: str = "z",
         nrows: int | None = None,
         ncols: int | None = None,
@@ -385,7 +386,7 @@ class FUSIPlotAccessor:
 
         Parameters
         ----------
-        slice_coords : list[float], optional
+        slice_coords : list[collections.abc.Hashable], optional
             Coordinate values along `slice_mode` at which to extract slices.
             Slices are selected by nearest-neighbour lookup. If not provided,
             all coordinate values along `slice_mode` are used.
@@ -531,7 +532,7 @@ class FUSIPlotAccessor:
         linewidths: float = 1.5,
         linestyles: str = "solid",
         slice_mode: str = "z",
-        slice_coords: list[float] | None = None,
+        slice_coords: list[Hashable] | None = None,
         fontsize: float | None = None,
         yincrease: bool = False,
         xincrease: bool = True,
@@ -562,7 +563,7 @@ class FUSIPlotAccessor:
         slice_mode : str, default: "z"
             Dimension along which to slice (e.g. `"x"`, `"y"`, `"z"`).
             After slicing, each panel must be 2D.
-        slice_coords : list[float], optional
+        slice_coords : list[collections.abc.Hashable], optional
             Coordinate values along `slice_mode` at which to extract slices.
             Slices are selected by nearest-neighbour lookup. If not provided, all
             coordinate values along `slice_mode` are used.
@@ -633,7 +634,7 @@ class FUSIPlotAccessor:
         rtol: float = 1e-5,
         atol: float = 1e-8,
         normalize_strategy: Literal["per_volume", "per_slice", "shared"] = "per_volume",
-        slice_coords: list[float] | None = None,
+        slice_coords: list[Hashable] | None = None,
         slice_mode: str = "z",
         alpha: float | None = None,
         show_titles: bool = True,
@@ -691,7 +692,7 @@ class FUSIPlotAccessor:
             - `"shared"`: rescale both volumes together using a shared
               `[min, max]` range, preserving the absolute-intensity
               relationship between the two inputs.
-        slice_coords : list[float], optional
+        slice_coords : list[collections.abc.Hashable], optional
             Coordinate values along `slice_mode` at which to extract slices.
             Slices are selected by nearest-neighbour lookup. If not provided,
             all coordinate values from this DataArray are used.

--- a/tests/unit/test_plotting/test_image.py
+++ b/tests/unit/test_plotting/test_image.py
@@ -474,6 +474,49 @@ class TestVolumePlotterAddVolume:
             )
 
 
+class TestNonNumericSliceMode:
+    """Tests for slicing along a non-numeric coordinate (e.g. region labels)."""
+
+    def test_string_coord_slice_mode_selects_exact_match(self, matplotlib_pyplot):
+        """plot_volume selects the slice matching a string coordinate exactly.
+
+        Regression test for a `TypeError` previously raised by the nearest-neighbour
+        lookup (`.sel(..., method="nearest")`) on non-numeric coordinates, and a
+        `ValueError` previously raised by the `.3g`-formatted slice title.
+        """
+        data = xr.DataArray(
+            np.arange(2 * 3 * 3, dtype=float).reshape(2, 3, 3),
+            name="r",
+            dims=["region", "y", "x"],
+            coords={"region": ["a", "b"], "y": np.arange(3.0), "x": np.arange(3.0)},
+        )
+        plotter = plot_volume(
+            data, slice_mode="region", slice_coords=["b"], show_colorbar=False
+        )
+
+        ax = plotter.axes[0, 0]
+        np.testing.assert_array_equal(
+            ax.collections[0].get_array().data, data.sel(region="b").values
+        )
+        assert ax.get_title() == "region = b"
+
+    def test_string_coord_mismatch_warns_with_label(self, matplotlib_pyplot):
+        """add_volume reports unmatched non-numeric coordinates by their label."""
+        data = xr.DataArray(
+            np.zeros((2, 3, 3)),
+            name="r",
+            dims=["region", "y", "x"],
+            coords={"region": ["a", "b"], "y": np.arange(3.0), "x": np.arange(3.0)},
+        )
+        plotter = plot_volume(
+            data, slice_mode="region", slice_coords=["a"], show_colorbar=False
+        )
+        other = data.assign_coords(region=["a", "c"]).sel(region=["c"])
+
+        with pytest.warns(UserWarning, match="region=c"):
+            plotter.add_volume(other, show_colorbar=False)
+
+
 class TestVolumePlotterUtilities:
     """Tests for VolumePlotter utility methods."""
 

--- a/tests/unit/test_plotting/test_image.py
+++ b/tests/unit/test_plotting/test_image.py
@@ -516,6 +516,14 @@ class TestNonNumericSliceMode:
         with pytest.warns(UserWarning, match="region=c"):
             plotter.add_volume(other, show_colorbar=False)
 
+    def test_non_numeric_slice_coords_without_coordinate_array_raises(
+        self, matplotlib_pyplot
+    ):
+        """A non-numeric slice_coords entry is rejected when slice_mode is coordless."""
+        data = xr.DataArray(np.zeros((2, 3, 3)), name="r", dims=["region", "y", "x"])
+        with pytest.raises(ValueError, match="must be numeric positional indices"):
+            plot_volume(data, slice_mode="region", slice_coords=["b"])
+
 
 class TestVolumePlotterUtilities:
     """Tests for VolumePlotter utility methods."""


### PR DESCRIPTION
## Summary
- `VolumePlotter` (and the `plot_volume`/`plot_contours`/`plot_composite` wrappers) always used `method="nearest"` for coordinate lookup and `.3g`-formatted panel titles/warnings, both of which crash on non-numeric `slice_mode` coordinates (e.g. a `region` label dimension from `SeedBasedMaps.maps_`).
- Numeric coordinates still use nearest-neighbour lookup; non-numeric coordinates now use exact matching, and titles/warnings format non-numeric values as plain strings instead of `.3g`.


Closes #250.