### PR TITLE
refactor(nifti): simplify pixdim writing on save

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -74,13 +74,21 @@ Current development version for the next ConfUSIus release.
   the coord does not start at 0 with regular spacing); otherwise the spacing is stored
   in `pixdim` and the coord is rebuilt as `step * arange(size)` on load. Attributes are
   preserved in `ConfUSIusDim{N}Attributes` entries.
-  ([#223](htttps://github.com/confusius-tools/confusius/pull/223)).
+  ([#223](https://github.com/confusius-tools/confusius/pull/223)).
 
 ### :books: Documentation
 
 - Add an [NMF example](examples/_built/decomposition/nmf_single_recording.md) to the
   gallery, demonstrating the z-score + absolute-value standardization that makes
   signed fUSI signals NMF-compatible.
+
+### :wrench: Maintenance
+
+- Simplified the NIfTI save path: time and extra-dimension voxel spacings are now
+  written directly to the header `pixdim` instead of through nibabel's `set_zooms` (that
+  was overwritten anyways), dropping a redundant spatial write that the qform
+  immediately overwrote. Behavior is unchanged.
+  ([#253](https://github.com/confusius-tools/confusius/pull/253)).
 
 ## 0.4.0
 

--- a/src/confusius/io/nifti.py
+++ b/src/confusius/io/nifti.py
@@ -2002,9 +2002,8 @@ def _create_nifti_image(
     nifti_version : {1, 2}
         NIfTI image version to instantiate.
     spacings : list[float]
-        Full NIfTI spacing vector, including temporal and extra-dimension entries when
-        present. Signed values are preserved in `pixdim` after calling nibabel's
-        `set_zooms` with their absolute values.
+        Full NIfTI signed spacing vector, including temporal and extra-dimension entries when
+        present.
     qform_affine : (4, 4) numpy.ndarray
         Resolved qform affine in NIfTI axis order.
     sform_affine : (4, 4) numpy.ndarray or None
@@ -2025,12 +2024,15 @@ def _create_nifti_image(
     constructor_affine = sform_affine if sform_affine is not None else qform_affine
     nifti_img = img_class(data, constructor_affine)
 
-    header_zooms = [abs(spacing) for spacing in spacings]
-    nifti_img.header.set_zooms(header_zooms)
-    for axis_index, spacing in enumerate(spacings, start=1):
-        if not np.isclose(spacing, header_zooms[axis_index - 1]):
-            nifti_img.header.structarr["pixdim"][axis_index] = np.float32(spacing)
+    # pixdim[4:] for temporal and extra dimensions are set independently of the qform.
+    for axis_index, spacing in enumerate(spacings[3:], start=4):
+        nifti_img.header.structarr["pixdim"][axis_index] = np.float32(spacing)
 
+    # Setting the qform also sets several parameters in the NIfTI header:
+    # the pixdim[1:4] (from zooms), qoffset_xyz (from translation), qfac (from
+    # determinant of the rotation block) and quatern_bcd (from the quaternion
+    # representation).
+    # obs.: qform is always valid at this point.
     nifti_img.header.set_qform(qform_affine, code=resolved_qform_code)
 
     if sform_affine is not None:


### PR DESCRIPTION
- Closes #252 

Simplifies how `save_nifti` writes voxel spacings into the NIfTI header `pixdim`.

Previously `_create_nifti_image` called nibabel's `set_zooms` (with absolute values, then a loop to restore signs) before `set_qform`. But `set_qform` rewrites the spatial zooms (`pixdim[1:4]`) and `qfac` (`pixdim[0]`), so the `set_zooms` spatial write was immediately overwritten and wasted.

Now only the axes `set_qform` never touches are written, directly into `pixdim[4:]`:

- `pixdim[4]` — temporal spacing (`tr_pixdim`)
- `pixdim[5:8]` — extra-dimension spacings (`dim4`/`dim5`/`dim6`)

Signs are preserved by writing the values directly (nibabel's `set_zooms` forces zooms positive), which the extra-dim loader relies on to reconstruct coordinates from a signed step.

## Behavior

No user-facing change. Verified that the produced header is **byte-identical** to the previous implementation across cases with negative spatial spacing, a temporal axis, and a negatively-spaced extra dimension.
