### PR TITLE
fix(nifti,napari): drop non-serializable sidecar attrs, fall back to gray colormap

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -72,9 +72,11 @@ Current development version for the next ConfUSIus release.
 - `save_nifti` now drops attrs that cannot be serialized to JSON as-is (e.g. matplotlib
   `ListedColormap`/`BoundaryNorm` objects) instead of writing their `str()` repr into the
   sidecar, which could corrupt fields such as `cmap` on reload. A warning lists the
-  dropped keys. **[Napari plugin]** The reader now falls back to the `"gray"` colormap
-  (with a napari warning) instead of crashing when a layer's `cmap` attr is not a valid
-  napari colormap name
+  dropped keys. [`confusius.load`][confusius.io.load] now rebuilds `cmap`/`norm` from
+  `rgb_lookup` when they are missing, so atlas-derived masks and annotations keep their
+  canonical colors after a save/load round-trip. **[Napari plugin]** The reader now
+  falls back to the `"gray"` colormap (with a napari warning) instead of crashing when a
+  layer's `cmap` attr is not a valid napari colormap name
   ([#255](https://github.com/confusius-tools/confusius/pull/255)).
 - [`Atlas.get_masks`][confusius.atlas.Atlas.get_masks] now suffixes the `mask`
   coordinate with `_L`/`_R` for `sides="left"`/`"right"`, so requesting the same region

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -69,6 +69,13 @@ Current development version for the next ConfUSIus release.
 
 ### :bug: Fixes
 
+- `save_nifti` now drops attrs that cannot be serialized to JSON as-is (e.g. matplotlib
+  `ListedColormap`/`BoundaryNorm` objects) instead of writing their `str()` repr into the
+  sidecar, which could corrupt fields such as `cmap` on reload. A warning lists the
+  dropped keys. **[Napari plugin]** The reader now falls back to the `"gray"` colormap
+  (with a napari warning) instead of crashing when a layer's `cmap` attr is not a valid
+  napari colormap name
+  ([#255](https://github.com/confusius-tools/confusius/pull/255)).
 - [`Atlas.get_masks`][confusius.atlas.Atlas.get_masks] now suffixes the `mask`
   coordinate with `_L`/`_R` for `sides="left"`/`"right"`, so requesting the same region
   on both hemispheres no longer produces duplicate `mask` values.

--- a/src/confusius/_napari/_io/_readers.py
+++ b/src/confusius/_napari/_io/_readers.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 
 from napari.layers.utils.layer_utils import calc_data_range
+from napari.utils.colormaps import ensure_colormap
 from napari.utils.notifications import show_warning
 
 from confusius._utils.coordinates import get_coordinate_spacings_best_effort
@@ -35,7 +36,9 @@ def _convert_dataarray_to_layer_data(da: xr.DataArray, name: str) -> FullLayerDa
       coordinates fall back to the median diff and a napari warning is shown.
     * Includes [`origin`][confusius.xarray.FUSIAccessor.origin] as `translate`
       so the layer is positioned correctly in physical space.
-    * Reads `"cmap"` from `da.attrs` for the colormap when present.
+    * Reads `"cmap"` from `da.attrs` for the colormap when present, falling back to
+      `"gray"` (with a napari warning) when the stored value is not a valid napari
+      colormap.
     * Passes `axis_labels` and `units` from the DataArray dimensions and coordinate
       attributes. These are stored on the layer but napari does not yet propagate them
       to `viewer.dims.axis_labels` when loading via a reader plugin.
@@ -63,12 +66,21 @@ def _convert_dataarray_to_layer_data(da: xr.DataArray, name: str) -> FullLayerDa
     # so it is fast even for large arrays.
     contrast_limits = calc_data_range(da.data)
 
+    colormap = da.attrs.get("cmap", "gray")
+    try:
+        ensure_colormap(colormap)
+    except (KeyError, TypeError):
+        show_warning(
+            f"{colormap!r} is not a valid napari colormap; falling back to 'gray'."
+        )
+        colormap = "gray"
+
     kwargs: dict[str, Any] = {
         "name": name,
         "scale": scale,
         "translate": translate,
         "axis_labels": all_dims,
-        "colormap": da.attrs.get("cmap", "gray"),
+        "colormap": colormap,
         "blending": "additive",
         "metadata": {"xarray": da},
         "contrast_limits": contrast_limits,

--- a/src/confusius/atlas/atlas.py
+++ b/src/confusius/atlas/atlas.py
@@ -70,7 +70,7 @@ def _build_dataset(bg_atlas: "BrainGlobeAtlas") -> xr.Dataset:
         dims=["z", "y", "x"],
         coords={d: xr.Variable(d, v, attrs=a) for d, (v, a) in coords.items()},
         # cmap and norm are non-serializable but are skipped automatically when saving
-        # to zarr; rgb_lookup is the serializable source of truth.
+        # to Zarr/NIfTI; rgb_lookup is the serializable source of truth.
         attrs={
             "rgb_lookup": rgb_lookup,
             "roi_labels": roi_labels,

--- a/src/confusius/io/loadsave.py
+++ b/src/confusius/io/loadsave.py
@@ -7,6 +7,7 @@ import xarray as xr
 
 import confusius.io.nifti as _nifti
 import confusius.io.scan as _scan
+from confusius._utils.atlas import build_atlas_cmap_and_norm
 from confusius.io.utils import check_path
 
 
@@ -20,6 +21,12 @@ def load(path: str | Path, variable: str | None = None, **kwargs: Any) -> xr.Dat
     - **Zarr** (`.zarr`): opened via [`xarray.open_zarr`][xarray.open_zarr] and a single
       variable is extracted. For loading the full dataset, use
       [`xarray.open_zarr`][xarray.open_zarr] directly.
+
+    If `attrs["rgb_lookup"]` is present but `attrs["cmap"]`/`attrs["norm"]` are missing
+    (as happens after a save/load round-trip, since matplotlib colormap/norm objects are
+    not JSON-serializable and are dropped on save), `cmap`/`norm` are rebuilt via
+    [`build_atlas_cmap_and_norm`][confusius._utils.atlas.build_atlas_cmap_and_norm] so
+    atlas-derived masks and annotations keep their canonical colors after reload.
 
     Parameters
     ----------
@@ -45,20 +52,44 @@ def load(path: str | Path, variable: str | None = None, **kwargs: Any) -> xr.Dat
     name = path.name
 
     if name.endswith(".nii") or name.endswith(".nii.gz"):
-        return _nifti.load_nifti(path, **kwargs)
-    if name.endswith(".scan"):
-        return _scan.load_scan(path, **kwargs)
-    if name.endswith(".zarr"):
+        data_array = _nifti.load_nifti(path, **kwargs)
+    elif name.endswith(".scan"):
+        data_array = _scan.load_scan(path, **kwargs)
+    elif name.endswith(".zarr"):
         ds = xr.open_zarr(path, **kwargs)
-        if variable is not None:
-            return ds[variable]
-        first_var = next(iter(ds.data_vars))
-        return ds[first_var]
+        data_array = (
+            ds[variable] if variable is not None else ds[next(iter(ds.data_vars))]
+        )
+    else:
+        raise ValueError(
+            f"Unsupported file extension in {name!r}. Supported"
+            " extensions are: .nii, .nii.gz, .scan, .zarr."
+        )
 
-    raise ValueError(
-        f"Unsupported file extension in {name!r}. Supported"
-        " extensions are: .nii, .nii.gz, .scan, .zarr."
-    )
+    _restore_atlas_cmap_and_norm(data_array)
+    return data_array
+
+
+def _restore_atlas_cmap_and_norm(data_array: xr.DataArray) -> None:
+    """Rebuild `cmap`/`norm` attrs from `rgb_lookup` in place, when missing.
+
+    Parameters
+    ----------
+    data_array : xarray.DataArray
+        DataArray to update in place.
+
+    Returns
+    -------
+    None
+        This function mutates `data_array.attrs` and returns nothing.
+    """
+    if "rgb_lookup" not in data_array.attrs:
+        return
+    if "cmap" in data_array.attrs and "norm" in data_array.attrs:
+        return
+    cmap, norm = build_atlas_cmap_and_norm(data_array.attrs["rgb_lookup"])
+    data_array.attrs["cmap"] = cmap
+    data_array.attrs["norm"] = norm
 
 
 def save(data_array: xr.DataArray, path: str | Path, **kwargs: Any) -> None:

--- a/src/confusius/io/nifti.py
+++ b/src/confusius/io/nifti.py
@@ -1977,7 +1977,40 @@ def _build_nifti_sidecar_metadata(
 
     sidecar_attrs.update(_build_extra_dim_sidecar_metadata(data_array))
     sidecar_attrs.update(timing_metadata)
-    return sidecar_attrs
+    return _drop_non_json_serializable_attrs(sidecar_attrs)
+
+
+def _drop_non_json_serializable_attrs(attrs: dict[str, Any]) -> dict[str, Any]:
+    """Drop attrs whose values cannot be serialized to JSON as-is.
+
+    Parameters
+    ----------
+    attrs : dict[str, Any]
+        Attributes to filter.
+
+    Returns
+    -------
+    dict[str, Any]
+        Copy of `attrs` containing only entries whose value round-trips through
+        `json.dumps` without coercion.
+    """
+    serializable_attrs = {}
+    dropped_keys = []
+    for key, value in attrs.items():
+        try:
+            json.dumps(value)
+        except TypeError:
+            dropped_keys.append(key)
+        else:
+            serializable_attrs[key] = value
+
+    if dropped_keys:
+        warnings.warn(
+            f"Dropping non-JSON-serializable attrs from NIfTI sidecar: {dropped_keys}.",
+            stacklevel=find_stack_level(),
+        )
+
+    return serializable_attrs
 
 
 def _create_nifti_image(
@@ -2205,4 +2238,4 @@ def save_nifti(
             )
 
     with open(sidecar_path, "w") as f:
-        json.dump(bids_attrs, f, indent=2, default=str)
+        json.dump(bids_attrs, f, indent=2)

--- a/tests/unit/test_io/test_loadsave.py
+++ b/tests/unit/test_io/test_loadsave.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock, call, patch
 
 import numpy as np
+import numpy.testing as npt
 import pytest
 import xarray as xr
 
@@ -165,3 +166,55 @@ class TestLoadZarr:
         result = load(multi_var_zarr, variable="iq")
         assert isinstance(result, xr.DataArray)
         assert result.name == "iq"
+
+
+class TestLoadRestoresAtlasCmapAndNorm:
+    """cmap/norm are rebuilt from rgb_lookup when missing after a round-trip."""
+
+    RGB_LOOKUP = {1: [255, 0, 0], 2: [0, 255, 0]}
+
+    @pytest.fixture
+    def atlas_like_zarr(self, tmp_path):
+        """Zarr store mimicking an Atlas annotation: rgb_lookup present, no cmap/norm."""
+        da = xr.DataArray(
+            np.array([[0, 1], [2, 1]], dtype=np.int32),
+            attrs={"rgb_lookup": self.RGB_LOOKUP},
+        )
+        path = tmp_path / "annotation.zarr"
+        xr.Dataset({"annotation": da}).to_zarr(path, zarr_format=2)
+        return path
+
+    def test_rebuilds_cmap_and_norm_from_rgb_lookup(self, atlas_like_zarr):
+        """cmap/norm reproduce the exact rgb_lookup colors, not just the right types."""
+        result = load(atlas_like_zarr)
+
+        cmap = result.attrs["cmap"]
+        norm = result.attrs["norm"]
+        for label_id, expected_rgb in self.RGB_LOOKUP.items():
+            expected_rgba = tuple(c / 255 for c in expected_rgb) + (1.0,)
+            npt.assert_allclose(cmap(norm(label_id)), expected_rgba)
+
+    def test_does_not_override_existing_cmap_and_norm(self, tmp_path):
+        """Existing cmap/norm attrs are left untouched."""
+        mock_da = MagicMock(spec=xr.DataArray)
+        mock_da.attrs = {
+            "rgb_lookup": {1: [255, 0, 0]},
+            "cmap": "sentinel_cmap",
+            "norm": "sentinel_norm",
+        }
+        path = tmp_path / "data.nii.gz"
+        with patch("confusius.io.nifti.load_nifti", return_value=mock_da):
+            result = load(path)
+
+        assert result.attrs["cmap"] == "sentinel_cmap"
+        assert result.attrs["norm"] == "sentinel_norm"
+
+    def test_no_rgb_lookup_leaves_attrs_untouched(self, tmp_path):
+        """DataArrays without rgb_lookup are returned unmodified."""
+        mock_da = MagicMock(spec=xr.DataArray)
+        mock_da.attrs = {"task_name": "test"}
+        path = tmp_path / "data.nii.gz"
+        with patch("confusius.io.nifti.load_nifti", return_value=mock_da):
+            result = load(path)
+
+        assert result.attrs == {"task_name": "test"}

--- a/tests/unit/test_io/test_nifti.py
+++ b/tests/unit/test_io/test_nifti.py
@@ -1452,6 +1452,29 @@ class TestSaveNifti:
         assert sidecar["custom"] == "value"
         assert "RepetitionTime" not in sidecar
 
+    def test_save_drops_non_json_serializable_attrs(
+        self, tmp_path, sample_3d_volume
+    ) -> None:
+        """Non-JSON-serializable attrs (e.g. matplotlib colormaps) are dropped, not
+        stringified, and do not prevent the sidecar from being written."""
+        from matplotlib.colors import ListedColormap
+
+        da = sample_3d_volume.drop_vars("time").copy()
+        da.attrs["cmap"] = ListedColormap(["red", "blue"])
+        da.attrs["task_name"] = "test"
+
+        output_path = tmp_path / "non_serializable.nii.gz"
+        with pytest.warns(UserWarning, match="non-JSON-serializable"):
+            save_nifti(da, output_path)
+
+        sidecar_path = tmp_path / "non_serializable.json"
+        with open(sidecar_path) as f:
+            sidecar = json.load(f)
+
+        assert "ConfUSIusCmap" not in sidecar
+        assert "cmap" not in sidecar
+        assert sidecar["TaskName"] == "test"
+
     def test_save_maps_processing_metadata_to_sidecar_fields(
         self, tmp_path, sample_3dt_volume
     ) -> None:

--- a/tests/unit/test_napari/test_readers.py
+++ b/tests/unit/test_napari/test_readers.py
@@ -215,6 +215,38 @@ class TestReaderLayerData:
 
         assert kwargs["colormap"] == "viridis"
 
+    def test_invalid_colormap_falls_back_to_gray(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An unrecognized `cmap` attr (e.g. a stringified colormap object from a
+        pre-fix sidecar) falls back to 'gray' with a warning instead of crashing."""
+        import confusius._napari._io._readers as readers_module
+
+        warnings_seen: list[str] = []
+        monkeypatch.setattr(
+            readers_module, "show_warning", warnings_seen.append
+        )
+
+        da = xr.DataArray(
+            np.zeros((4, 6), dtype=np.float32),
+            dims=["z", "x"],
+            coords={
+                "z": np.arange(4) * 0.1,
+                "x": np.arange(6) * 0.05,
+            },
+            attrs={"cmap": "<matplotlib.colors.ListedColormap object at 0x0>"},
+        )
+        path = tmp_path / "invalid_cmap.zarr"
+        xr.Dataset({"data": da}).to_zarr(path, zarr_format=2)
+
+        reader = read_zarr(str(path))
+        assert reader is not None
+        _, kwargs, _ = reader(str(path))[0]
+
+        assert kwargs["colormap"] == "gray"
+        assert len(warnings_seen) == 1
+        assert "not a valid napari colormap" in warnings_seen[0]
+
     def test_xarray_stored_in_metadata(self, zarr_3d_path: Path) -> None:
         """The original DataArray is stored in metadata for downstream access."""
         reader = read_zarr(str(zarr_3d_path))


### PR DESCRIPTION
## Summary
- `save_nifti` now drops attrs that aren't JSON-serializable as-is instead of stringifying them via `default=str`, which could corrupt fields like `cmap` on reload.
- The napari zarr/NIfTI reader now falls back to the `gray` colormap (with a warning) instead of crashing when a layer's `cmap` attr isn't a valid napari colormap.

Fixes #254.