### PR TITLE
feat(napari): open integer-dtype CLI files as labels layers

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,6 +24,10 @@ Current development version for the next ConfUSIus release.
 
 ### :sparkles: Enhancements
 
+- **[Napari plugin]** `confusius PATH...` now opens integer-dtype files (e.g. atlas
+  annotations, ROI masks) as a `Labels` layer with per-label colors, instead of an
+  `Image` layer with the wrong colormap
+  ([#257](https://github.com/confusius-tools/confusius/pull/257)).
 - **[Napari plugin]** Added **Events** panel to annotate temporal events within Napari.
   Events shade the signal plot; active event names appear in the time overlay; load
   from / save to a BIDS `.tsv`

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,8 +24,9 @@ Current development version for the next ConfUSIus release.
 
 ### :sparkles: Enhancements
 
-- **[Napari plugin]** `confusius PATH...` now opens integer-dtype files (e.g. atlas
-  annotations, ROI masks) as a `Labels` layer with per-label colors, instead of an
+- **[Napari plugin]** Integer-dtype files (e.g. atlas annotations, ROI masks) opened via
+  the `confusius` CLI, the Data Panel, or the native napari file readers (drag-and-drop /
+  **File > Open**) are now added as a `Labels` layer with per-label colors, instead of an
   `Image` layer with the wrong colormap
   ([#257](https://github.com/confusius-tools/confusius/pull/257)).
 - **[Napari plugin]** Added **Events** panel to annotate temporal events within Napari.
@@ -92,28 +93,29 @@ Current development version for the next ConfUSIus release.
 - [`apply_affine`][confusius.xarray.apply_affine] now rescales the `voxdim` attribute
   of the spatial coordinates along with the coordinate values
   ([#245](https://github.com/confusius-tools/confusius/pull/245)).
-- `signal.clean` now supports `ensure_finite=True` to repair non-finite `signals`
-  and `confounds` by interpolating along time, fills censored boundary samples from
-  the nearest kept sample before filtering, and accepts `interpolate_kwargs` for
-  pre-scrubbing interpolation ([#239](https://github.com/confusius-tools/confusius/pull/239)).
+- [`clean`][confusius.signal.clean] now supports `ensure_finite=True` to repair
+  non-finite `signals` and `confounds` by interpolating along time, fills censored
+  boundary samples from the nearest kept sample before filtering, and accepts
+  `interpolate_kwargs` for pre-scrubbing interpolation
+  ([#239](https://github.com/confusius-tools/confusius/pull/239)).
 - Image plotting functions now leave `alpha` unset by default (`None`), so a
   colormap's built-in alpha channel is respected
   ([#225](https://github.com/confusius-tools/confusius/pull/225)).
-- `load_nifti` no longer drops affines loaded from the JSON sidecar (e.g.
-  `bspline_initialization` written by the registration pipeline) when merging in the
-  NIfTI qform/sform affines
+- [`load_nifti`][confusius.io.load_nifti] no longer drops affines loaded from the JSON
+  sidecar (e.g. `bspline_initialization` written by the registration pipeline) when
+  merging in the NIfTI qform/sform affines
   ([#222](https://github.com/confusius-tools/confusius/pull/222)).
-- `save_nifti` no longer maps non-time additional axes to the NIfTI 4th slot. When
-  additional axes are present in the DataArray, a degenerate length-1 `time` axis is
-  inserted at NIfTI axis 4 (NIfTI's conventional time slot) so non-time additional axes
-  always land at NIfTI axes 5, 6, 7. The original dim name for each additional axis is
-  always written to the sidecar as `ConfUSIusDim{N}Name` (with `N` in 4, 5, 6, matching
-  the 0-based NIfTI axis of the extra dim). The matching `ConfUSIusDim{N}Coordinates`
-  entry is only written when the coord cannot be reconstructed from `pixdim` (i.e. when
-  the coord does not start at 0 with regular spacing); otherwise the spacing is stored
-  in `pixdim` and the coord is rebuilt as `step * arange(size)` on load. Attributes are
-  preserved in `ConfUSIusDim{N}Attributes` entries.
-  ([#223](https://github.com/confusius-tools/confusius/pull/223)).
+- [`save_nifti`][confusius.io.save_nifti] no longer maps non-time additional axes to the
+  NIfTI 4th slot. When additional axes are present in the DataArray, a degenerate
+  length-1 `time` axis is inserted at NIfTI axis 4 (NIfTI's conventional time slot) so
+  non-time additional axes always land at NIfTI axes 5, 6, 7. The original dim name for
+  each additional axis is always written to the sidecar as `ConfUSIusDim{N}Name` (with
+  `N` in 4, 5, 6, matching the 0-based NIfTI axis of the extra dim). The matching
+  `ConfUSIusDim{N}Coordinates` entry is only written when the coord cannot be
+  reconstructed from `pixdim` (i.e. when the coord does not start at 0 with regular
+  spacing); otherwise the spacing is stored in `pixdim` and the coord is rebuilt as
+  `step * arange(size)` on load. Attributes are preserved in `ConfUSIusDim{N}Attributes`
+  entries. ([#223](https://github.com/confusius-tools/confusius/pull/223)).
 
 ### :books: Documentation
 

--- a/docs/gui/overview.md
+++ b/docs/gui/overview.md
@@ -71,7 +71,9 @@ confusius path/to/data.zarr path/to/other/data.zarr
 Both routes use [`confusius.load()`][confusius.load] under the hood, which produces a
 fully-labeled DataArray with named dimensions, physical coordinates, and all file
 metadata preserved. The DataArray is attached to the layer and used automatically by the
-Signals and QC panels. By default the full array is loaded into memory for
+Signals and QC panels. Integer-dtype files (e.g. atlas annotations, ROI masks) are added
+as a `Labels` layer with per-label colors instead of a continuous colormap; all other
+dtypes are added as an `Image` layer. By default the full array is loaded into memory for
 responsive time scrubbing. For files that don't fit in RAM, lazy loading keeps the array
 Dask-backed—the layer appears instantly and slices are read from disk on demand. Enable
 it via the **Load lazily** checkbox in the Data Panel, or with the `--lazy` flag on the
@@ -85,7 +87,8 @@ confusius --lazy path/to/data.zarr
 
 ConfUSIus also registers native napari file readers for NIfTI, Iconeus SCAN, and Zarr
 files. These let you open files by dragging them onto the canvas or using **File >
-Open** (++ctrl+o++) without switching to the Data Panel.
+Open** (++ctrl+o++) without switching to the Data Panel. Like the Data Panel and CLI,
+integer-dtype files are added as a `Labels` layer.
 
 !!! warning "Axis labels are not propagated to the viewer"
     Due to a current napari limitation, files opened through the native readers have

--- a/src/confusius/_cli.py
+++ b/src/confusius/_cli.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import argparse
 from importlib import metadata
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     import napari
@@ -164,9 +164,10 @@ def run(args: argparse.Namespace, viewer: napari.Viewer | None = None) -> napari
     -------
     napari.Viewer
         The viewer with the ConfUSIus widget docked and the requested data
-        files added as image layers (one layer per file, in the same order as
-        `args.path`). The first loaded layer is paired with `args.video`
-        if it is also set.
+        files added as layers (one layer per file, in the same order as
+        `args.path`; see [`_open_paths`][confusius._cli._open_paths] for how
+        the layer type is chosen). The first loaded layer is paired with
+        `args.video` if it is also set.
     """
     import napari
 
@@ -215,35 +216,38 @@ def _open_paths(
     paths: list[Path],
     *,
     lazy: bool,
-) -> list[napari.layers.Image]:
-    """Load each path and add it to the viewer as a ConfUSIus image layer.
+) -> list[napari.layers.Image | napari.layers.Labels]:
+    """Load each path and add it to the viewer as an image or labels layer.
 
     Parameters
     ----------
     viewer : napari.Viewer
         Active napari viewer to add the loaded layers to.
     paths : list of pathlib.Path
-        One path per fUSI data file. Each becomes its own image layer named
-        after the file's basename.
+        One path per fUSI data file. Each becomes its own layer named after
+        the file's basename.
     lazy : bool
         Whether to keep the data Dask-backed (`True`) or materialise it into
         memory before plotting (`False`).
 
     Returns
     -------
-    list of napari.layers.Image
-        The layers added to the viewer, in the same order as `paths`.
+    list of napari.layers.Image or napari.layers.Labels
+        The layers added to the viewer, in the same order as `paths`. Files
+        with an integer dtype (e.g. atlas annotations, ROI masks) are added
+        as `Labels` layers; all others are added as `Image` layers.
     """
+    import numpy as np
+
     from confusius.io import load
     from confusius.plotting.napari import plot_napari
 
-    layers: list[napari.layers.Image] = []
+    layers: list[napari.layers.Image | napari.layers.Labels] = []
     for path in paths:
         da = load(path)
         if not lazy:
             da = da.compute()
-        _, layer = plot_napari(da, viewer=viewer, name=path.name)
-        # `plot_napari` returns Image | Labels; the CLI only loads image
-        # data files, so the resulting layer is always an Image.
-        layers.append(cast("napari.layers.Image", layer))
+        layer_type = "labels" if np.issubdtype(da.dtype, np.integer) else "image"
+        _, layer = plot_napari(da, viewer=viewer, name=path.name, layer_type=layer_type)
+        layers.append(layer)
     return layers

--- a/src/confusius/_cli.py
+++ b/src/confusius/_cli.py
@@ -237,8 +237,7 @@ def _open_paths(
         with an integer dtype (e.g. atlas annotations, ROI masks) are added
         as `Labels` layers; all others are added as `Image` layers.
     """
-    import numpy as np
-
+    from confusius._utils.napari import infer_layer_type
     from confusius.io import load
     from confusius.plotting.napari import plot_napari
 
@@ -247,7 +246,7 @@ def _open_paths(
         da = load(path)
         if not lazy:
             da = da.compute()
-        layer_type = "labels" if np.issubdtype(da.dtype, np.integer) else "image"
+        layer_type = infer_layer_type(da.dtype)
         _, layer = plot_napari(da, viewer=viewer, name=path.name, layer_type=layer_type)
         layers.append(layer)
     return layers

--- a/src/confusius/_napari/_data/_load_panel.py
+++ b/src/confusius/_napari/_data/_load_panel.py
@@ -23,6 +23,7 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
+from confusius._utils.napari import infer_layer_type
 from confusius.io import load
 from confusius.plotting.napari import plot_napari
 
@@ -199,7 +200,9 @@ class DataPanel(QWidget):
             # them as napari notifications so they appear in the UI.
             with warnings.catch_warnings(record=True) as caught:
                 warnings.simplefilter("always")
-                _viewer, layer = plot_napari(da, viewer=self.viewer)
+                _viewer, layer = plot_napari(
+                    da, viewer=self.viewer, layer_type=infer_layer_type(da.dtype)
+                )
             for w in caught:
                 if issubclass(w.category, UserWarning):
                     show_warning(str(w.message))

--- a/src/confusius/_napari/_io/_readers.py
+++ b/src/confusius/_napari/_io/_readers.py
@@ -18,6 +18,11 @@ from napari.utils.colormaps import ensure_colormap
 from napari.utils.notifications import show_warning
 
 from confusius._utils.coordinates import get_coordinate_spacings_best_effort
+from confusius._utils.napari import (
+    build_direct_label_colormap,
+    build_roi_labels_features,
+    infer_layer_type,
+)
 from confusius.io import load
 
 if TYPE_CHECKING:
@@ -36,12 +41,14 @@ def _convert_dataarray_to_layer_data(da: xr.DataArray, name: str) -> FullLayerDa
       coordinates fall back to the median diff and a napari warning is shown.
     * Includes [`origin`][confusius.xarray.FUSIAccessor.origin] as `translate`
       so the layer is positioned correctly in physical space.
-    * Reads `"cmap"` from `da.attrs` for the colormap when present, falling back to
-      `"gray"` (with a napari warning) when the stored value is not a valid napari
-      colormap.
     * Passes `axis_labels` and `units` from the DataArray dimensions and coordinate
       attributes. These are stored on the layer but napari does not yet propagate them
       to `viewer.dims.axis_labels` when loading via a reader plugin.
+    * Integer-dtype arrays (e.g. atlas annotations, ROI masks) are returned as a
+      `"labels"` layer, with a per-label `DirectLabelColormap` built from `da.attrs`
+      when available. All other dtypes are returned as an `"image"` layer, reading
+      `"cmap"` from `da.attrs` for the colormap when present, falling back to `"gray"`
+      (with a napari warning) when the stored value is not a valid napari colormap.
     """
 
     all_dims = list(da.dims)
@@ -60,35 +67,41 @@ def _convert_dataarray_to_layer_data(da: xr.DataArray, name: str) -> FullLayerDa
         da.coords[d].attrs.get("units") if d in da.coords else None for d in all_dims
     ]
 
-    # Pre-compute contrast limits so napari displays the image correctly on load. In
-    # napari 0.6.6+ the deferred _should_calc_clims mechanism does not fire reliably for
-    # non-numpy data during the insertion event. calc_data_range samples a few planes,
-    # so it is fast even for large arrays.
-    contrast_limits = calc_data_range(da.data)
-
-    colormap = da.attrs.get("cmap", "gray")
-    try:
-        ensure_colormap(colormap)
-    except (KeyError, TypeError):
-        show_warning(
-            f"{colormap!r} is not a valid napari colormap; falling back to 'gray'."
-        )
-        colormap = "gray"
-
     kwargs: dict[str, Any] = {
         "name": name,
         "scale": scale,
         "translate": translate,
         "axis_labels": all_dims,
-        "colormap": colormap,
-        "blending": "additive",
         "metadata": {"xarray": da},
-        "contrast_limits": contrast_limits,
     }
     if any(u is not None for u in all_units):
         kwargs["units"] = all_units
 
-    return da.data, kwargs, "image"
+    layer_type = infer_layer_type(da.dtype)
+    if layer_type == "labels":
+        colormap = build_direct_label_colormap(da)
+        if colormap is not None:
+            kwargs["colormap"] = colormap
+        if (roi_labels := da.attrs.get("roi_labels")) is not None:
+            kwargs["features"] = build_roi_labels_features(roi_labels)
+    else:
+        # Pre-compute contrast limits so napari displays the image correctly on load.
+        # In napari 0.6.6+ the deferred _should_calc_clims mechanism does not fire
+        # reliably for non-numpy data during the insertion event. calc_data_range
+        # samples a few planes, so it is fast even for large arrays.
+        colormap = da.attrs.get("cmap", "gray")
+        try:
+            ensure_colormap(colormap)
+        except (KeyError, TypeError):
+            show_warning(
+                f"{colormap!r} is not a valid napari colormap; falling back to 'gray'."
+            )
+            colormap = "gray"
+        kwargs["colormap"] = colormap
+        kwargs["blending"] = "additive"
+        kwargs["contrast_limits"] = calc_data_range(da.data)
+
+    return da.data, kwargs, layer_type
 
 
 def _make_reader(path: str | Path) -> Callable[[PathOrPaths], list[FullLayerData]]:

--- a/src/confusius/_utils/napari.py
+++ b/src/confusius/_utils/napari.py
@@ -1,0 +1,97 @@
+"""Napari layer-construction helpers shared by the CLI, GUI panels, and file readers."""
+
+from collections import defaultdict
+from typing import Literal
+
+import numpy as np
+import numpy.typing as npt
+import pandas as pd
+import xarray as xr
+from napari.utils.colormaps import DirectLabelColormap
+
+from confusius._utils.atlas import build_atlas_cmap_and_norm
+
+
+def infer_layer_type(dtype: npt.DTypeLike) -> Literal["image", "labels"]:
+    """Infer the napari layer type to use for an array's dtype.
+
+    Parameters
+    ----------
+    dtype : numpy.typing.DTypeLike
+        Dtype of the array to be displayed.
+
+    Returns
+    -------
+    {"image", "labels"}
+        `"labels"` for integer dtypes (e.g. atlas annotations, ROI masks), which
+        should render with per-label colors rather than a continuous colormap.
+        `"image"` for all other dtypes.
+    """
+    return "labels" if np.issubdtype(np.dtype(dtype), np.integer) else "image"
+
+
+def build_direct_label_colormap(data: xr.DataArray) -> DirectLabelColormap | None:
+    """Build a per-label `DirectLabelColormap` from a labels DataArray's attrs.
+
+    Parameters
+    ----------
+    data : xarray.DataArray
+        Labels array. Uses `data.attrs["cmap"]` / `data.attrs["norm"]` when present
+        (as set by atlas functions), or reconstructs them from
+        `data.attrs["rgb_lookup"]` when `cmap`/`norm` are absent (e.g. after a
+        Zarr round-trip, since they are not serializable).
+
+    Returns
+    -------
+    napari.utils.colormaps.DirectLabelColormap or None
+        Colormap mapping each unique non-zero label in `data` to its atlas color,
+        with unknown/background labels transparent. `None` if `data.attrs` carries
+        neither a `cmap`/`norm` pair nor `rgb_lookup`.
+    """
+    cmap_attr = data.attrs.get("cmap")
+    norm_attr = data.attrs.get("norm")
+    if (cmap_attr is None or norm_attr is None) and "rgb_lookup" in data.attrs:
+        cmap_attr, norm_attr = build_atlas_cmap_and_norm(data.attrs["rgb_lookup"])
+    if cmap_attr is None or norm_attr is None:
+        return None
+
+    color_dict: defaultdict[int | None, np.ndarray] = defaultdict(
+        lambda: np.zeros(4, dtype=np.float32)  # unknown labels → transparent.
+    )
+    for label in np.unique(data.values):
+        if label == 0:
+            continue  # background_value=0 is always transparent.
+        color_dict[int(label)] = np.array(
+            cmap_attr(norm_attr(int(label))), dtype=np.float32
+        )
+    return DirectLabelColormap(color_dict=color_dict, background_value=0)
+
+
+def build_roi_labels_features(roi_labels: dict[int, str]) -> pd.DataFrame:
+    """Build a napari `features` table reporting ROI names in the status bar.
+
+    Parameters
+    ----------
+    roi_labels : dict[int, str]
+        Mapping from integer ROI id to display name, as stored in
+        `data.attrs["roi_labels"]`.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Table with `"index"` and `"name"` columns, suitable for a
+        `napari.layers.Labels.features` assignment (or the `features` constructor
+        argument). Napari's built-in `Labels.get_status` then appends `name: <roi
+        name>` to the status bar (and cursor tooltip) whenever the cursor is over a
+        labelled voxel. A row for label `0` is included with a NaN name so
+        background hovers do not show napari's default `[No Properties]`
+        placeholder.
+    """
+    ids: list[int] = [0]
+    names: list[float | str] = [float("nan")]
+    for sid, name in roi_labels.items():
+        sid_int = int(sid)
+        if sid_int != 0:
+            ids.append(sid_int)
+            names.append(str(name))
+    return pd.DataFrame({"index": ids, "name": names})

--- a/src/confusius/plotting/napari.py
+++ b/src/confusius/plotting/napari.py
@@ -1,16 +1,17 @@
 """Napari-based visualization utilities for fUSI data."""
 
 import warnings
-from collections import defaultdict
 from typing import TYPE_CHECKING, Literal, cast
 
 import napari
 import numpy as np
 import xarray as xr
-from napari.utils.colormaps import DirectLabelColormap
 
-from confusius._utils.atlas import build_atlas_cmap_and_norm
 from confusius._utils.coordinates import get_coordinate_spacings_best_effort
+from confusius._utils.napari import (
+    build_direct_label_colormap,
+    build_roi_labels_features,
+)
 from confusius._utils.stack import find_stack_level
 from confusius.plotting._utils import (
     coerce_complex_to_magnitude,
@@ -222,31 +223,12 @@ def plot_napari(
             values = values.astype(np.int32)
 
         # Build a DirectLabelColormap from attrs when the caller has not already
-        # supplied one.  This lets atlas annotations and masks carry their colormap
-        # automatically into the viewer.  cmap/norm are not serializable, so they
-        # may be absent after a Zarr round-trip; fall back to reconstructing them
-        # from rgb_lookup when that is present.
-        cmap_attr = data.attrs.get("cmap")
-        norm_attr = data.attrs.get("norm")
-        if (cmap_attr is None or norm_attr is None) and "rgb_lookup" in data.attrs:
-            cmap_attr, norm_attr = build_atlas_cmap_and_norm(data.attrs["rgb_lookup"])
-        if (
-            cmap_attr is not None
-            and norm_attr is not None
-            and "colormap" not in layer_kwargs
-        ):
-            color_dict: defaultdict[int | None, np.ndarray] = defaultdict(
-                lambda: np.zeros(4, dtype=np.float32)  # unknown labels → transparent.
-            )
-            for label in np.unique(values):
-                if label == 0:
-                    continue  # background_value=0 is always transparent.
-                color_dict[int(label)] = np.array(
-                    cmap_attr(norm_attr(int(label))), dtype=np.float32
-                )
-            layer_kwargs["colormap"] = DirectLabelColormap(
-                color_dict=color_dict, background_value=0
-            )
+        # supplied one. This lets atlas annotations and masks carry their colormap
+        # automatically into the viewer.
+        if "colormap" not in layer_kwargs:
+            colormap = build_direct_label_colormap(data)
+            if colormap is not None:
+                layer_kwargs["colormap"] = colormap
 
         layer = viewer.add_labels(
             values,
@@ -255,7 +237,7 @@ def plot_napari(
         )
 
         if (roi_labels := data.attrs.get("roi_labels")) is not None:
-            _attach_roi_labels_to_napari(layer, roi_labels)
+            layer.features = build_roi_labels_features(roi_labels)
 
     else:
         raise ValueError(
@@ -271,36 +253,6 @@ def plot_napari(
         viewer.scale_bar.unit = scale_bar_unit
 
     return viewer, layer
-
-
-def _attach_roi_labels_to_napari(layer: "Labels", roi_labels: dict[int, str]) -> None:
-    """Make a napari Labels layer report the ROI name in the status bar.
-
-    Sets `layer.features` so that napari's built-in
-    `napari.layers.Labels.get_status` appends `name: <roi name>` to the status
-    bar (and the cursor tooltip when `viewer.tooltip.visible` is `True`)
-    whenever the cursor is over a labelled voxel.
-
-    A row for label `0` is included with a NaN name so background hovers do not
-    show napari's default `[No Properties]` placeholder.
-
-    Parameters
-    ----------
-    layer : napari.layers.Labels
-        Layer whose `features` table will be replaced.
-    roi_labels : dict[int, str]
-        Mapping from integer ROI id to display name.
-    """
-    import pandas as pd
-
-    ids: list[int] = [0]
-    names: list[float | str] = [float("nan")]
-    for sid, name in roi_labels.items():
-        sid_int = int(sid)
-        if sid_int != 0:
-            ids.append(sid_int)
-            names.append(str(name))
-    layer.features = pd.DataFrame({"index": ids, "name": names})
 
 
 def draw_napari_labels(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -780,6 +780,37 @@ def sample_roi_labels():
 
 
 @pytest.fixture
+def integer_nifti_path(tmp_path: Path, sample_roi_labels: xr.DataArray) -> Path:
+    """`sample_roi_labels` written to a NIfTI file.
+
+    Shared by tests covering integer-dtype file loading (CLI, native readers, GUI
+    panels) so they all exercise the exact same on-disk data.
+    """
+    from confusius.io import save_nifti
+
+    path = tmp_path / "roi_labels.nii.gz"
+    save_nifti(sample_roi_labels, path)
+    return path
+
+
+@pytest.fixture
+def float_nifti_path(tmp_path: Path, sample_3d_volume: xr.DataArray) -> Path:
+    """`sample_3d_volume` written to a NIfTI file.
+
+    Shared by tests covering float-dtype file loading (CLI, native readers, GUI
+    panels) so they all exercise the exact same on-disk data.
+    """
+    from confusius.io import save_nifti
+
+    path = tmp_path / "power_doppler.nii.gz"
+    # sample_3d_volume's scalar `time` coord has no FrameAcquisitionDuration, which
+    # save_nifti's BIDS sidecar validation requires once VolumeTiming is written;
+    # this fixture only needs a plain spatial volume, so drop it before saving.
+    save_nifti(sample_3d_volume.drop_vars("time"), path)
+    return path
+
+
+@pytest.fixture
 def matplotlib_pyplot():
     """Set up and teardown fixture for matplotlib.
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -4,31 +4,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import nibabel as nib
-import numpy as np
-import pytest
-
-
-@pytest.fixture
-def integer_nifti_path(tmp_path: Path) -> Path:
-    """3D NIfTI file with an integer dtype, as produced by atlas annotations."""
-    data = np.zeros((4, 6, 8), dtype=np.int16)
-    data[1:3, 2:4, 3:5] = 7
-    img = nib.Nifti1Image(data, np.eye(4))
-    path = tmp_path / "labels.nii.gz"
-    img.to_filename(path)
-    return path
-
-
-@pytest.fixture
-def float_nifti_path(tmp_path: Path) -> Path:
-    """3D NIfTI file with a float dtype, as produced by fUSI power Doppler data."""
-    data = np.random.default_rng(0).random((4, 6, 8)).astype(np.float32)
-    img = nib.Nifti1Image(data, np.eye(4))
-    path = tmp_path / "power_doppler.nii.gz"
-    img.to_filename(path)
-    return path
-
 
 class TestBuildParser:
     """The default parser accepts zero, one, or many positional paths."""

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -4,6 +4,31 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import nibabel as nib
+import numpy as np
+import pytest
+
+
+@pytest.fixture
+def integer_nifti_path(tmp_path: Path) -> Path:
+    """3D NIfTI file with an integer dtype, as produced by atlas annotations."""
+    data = np.zeros((4, 6, 8), dtype=np.int16)
+    data[1:3, 2:4, 3:5] = 7
+    img = nib.Nifti1Image(data, np.eye(4))
+    path = tmp_path / "labels.nii.gz"
+    img.to_filename(path)
+    return path
+
+
+@pytest.fixture
+def float_nifti_path(tmp_path: Path) -> Path:
+    """3D NIfTI file with a float dtype, as produced by fUSI power Doppler data."""
+    data = np.random.default_rng(0).random((4, 6, 8)).astype(np.float32)
+    img = nib.Nifti1Image(data, np.eye(4))
+    path = tmp_path / "power_doppler.nii.gz"
+    img.to_filename(path)
+    return path
+
 
 class TestBuildParser:
     """The default parser accepts zero, one, or many positional paths."""
@@ -149,3 +174,31 @@ class TestRun:
         viewer = make_napari_viewer()
         with pytest.raises(SystemExit):
             run(args, viewer=viewer)
+
+    def test_integer_nifti_opens_as_labels_layer(
+        self, make_napari_viewer, integer_nifti_path: Path
+    ) -> None:
+        from napari.layers import Labels
+
+        from confusius._cli import build_parser, run
+
+        args = build_parser().parse_args([str(integer_nifti_path)])
+        viewer = make_napari_viewer()
+        run(args, viewer=viewer)
+
+        layer = viewer.layers[integer_nifti_path.name]
+        assert isinstance(layer, Labels)
+
+    def test_float_nifti_opens_as_image_layer(
+        self, make_napari_viewer, float_nifti_path: Path
+    ) -> None:
+        from napari.layers import Image
+
+        from confusius._cli import build_parser, run
+
+        args = build_parser().parse_args([str(float_nifti_path)])
+        viewer = make_napari_viewer()
+        run(args, viewer=viewer)
+
+        layer = viewer.layers[float_nifti_path.name]
+        assert isinstance(layer, Image)

--- a/tests/unit/test_napari/test_load_panel.py
+++ b/tests/unit/test_napari/test_load_panel.py
@@ -1,0 +1,45 @@
+"""Unit tests for the DataPanel widget.
+
+`_on_load_returned` is exercised directly with a pre-built DataArray so tests don't
+depend on the background `thread_worker` machinery used by the real load path.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from confusius._napari._data._load_panel import DataPanel
+
+
+@pytest.fixture
+def viewer(make_napari_viewer):
+    return make_napari_viewer()
+
+
+@pytest.fixture
+def data_panel(viewer):
+    return DataPanel(viewer)
+
+
+class TestOnLoadReturned:
+    """Loaded DataArrays are added to the viewer as the expected layer type."""
+
+    def test_integer_dtype_adds_labels_layer(
+        self, data_panel, viewer, sample_roi_labels
+    ) -> None:
+        from napari.layers import Labels
+
+        data_panel._on_load_returned(sample_roi_labels)
+
+        assert len(viewer.layers) == 1
+        assert isinstance(viewer.layers[0], Labels)
+
+    def test_float_dtype_adds_image_layer(
+        self, data_panel, viewer, sample_3d_volume
+    ) -> None:
+        from napari.layers import Image
+
+        data_panel._on_load_returned(sample_3d_volume)
+
+        assert len(viewer.layers) == 1
+        assert isinstance(viewer.layers[0], Image)

--- a/tests/unit/test_napari/test_readers.py
+++ b/tests/unit/test_napari/test_readers.py
@@ -54,6 +54,17 @@ def zarr_4d_path(tmp_path: Path, sample_3dt_volume: xr.DataArray) -> Path:
     return path
 
 
+@pytest.fixture
+def integer_zarr_path(tmp_path: Path, sample_roi_labels: xr.DataArray) -> Path:
+    """Zarr store built from the shared sample_roi_labels fixture.
+
+    Carries `roi_labels` and `rgb_lookup` attrs, like a real atlas mask.
+    """
+    path = tmp_path / "labels.zarr"
+    xr.Dataset({"data": sample_roi_labels}).to_zarr(path, zarr_format=2)
+    return path
+
+
 # ---------------------------------------------------------------------------
 # Gate logic: None vs callable
 # ---------------------------------------------------------------------------
@@ -254,3 +265,27 @@ class TestReaderLayerData:
         _, kwargs, _ = reader(str(zarr_3d_path))[0]
 
         assert isinstance(kwargs["metadata"]["xarray"], xr.DataArray)
+
+    def test_integer_dtype_is_labels_layer(self, integer_zarr_path: Path) -> None:
+        """Integer-dtype arrays are returned as a 'labels' layer, not 'image'."""
+        from napari.utils.colormaps import DirectLabelColormap
+
+        reader = read_zarr(str(integer_zarr_path))
+        assert reader is not None
+        data, kwargs, layer_type = reader(str(integer_zarr_path))[0]
+
+        assert layer_type == "labels"
+        assert np.issubdtype(data.dtype, np.integer)
+        # Image-only kwargs must not leak into the labels layer construction.
+        assert "blending" not in kwargs
+        assert "contrast_limits" not in kwargs
+
+        # sample_roi_labels' rgb_lookup: 3 -> blue, 7 -> red, 42 -> green.
+        colormap = kwargs["colormap"]
+        assert isinstance(colormap, DirectLabelColormap)
+        npt.assert_allclose(colormap.map(np.array([7])), [[1.0, 0.0, 0.0, 1.0]])
+        npt.assert_allclose(colormap.map(np.array([0])), [[0.0, 0.0, 0.0, 0.0]])
+
+        # sample_roi_labels' roi_labels attr should populate hover-status features.
+        features = kwargs["features"]
+        assert dict(zip(features["index"], features["name"]))[7] == "somatosensory"

--- a/tests/unit/test_napari/test_readers.py
+++ b/tests/unit/test_napari/test_readers.py
@@ -234,9 +234,7 @@ class TestReaderLayerData:
         import confusius._napari._io._readers as readers_module
 
         warnings_seen: list[str] = []
-        monkeypatch.setattr(
-            readers_module, "show_warning", warnings_seen.append
-        )
+        monkeypatch.setattr(readers_module, "show_warning", warnings_seen.append)
 
         da = xr.DataArray(
             np.zeros((4, 6), dtype=np.float32),


### PR DESCRIPTION
## Summary
- `_open_paths` (CLI), `DataPanel._on_load_returned` (Data I/O Panel), and the native napari file readers (drag-and-drop / File > Open) all detect integer dtype and now use a `Labels` layer instead of an `Image` layer, so atlas annotations / ROI masks get per-label colors everywhere they can be opened.
- Extracted the shared layer-type inference and `DirectLabelColormap`/`features` construction into `confusius._utils.napari`, used by all four call sites (`_cli.py`, `plotting/napari.py`, `_load_panel.py`, `_readers.py`).
- Added shared `integer_nifti_path` / `float_nifti_path` fixtures (built from the existing `sample_roi_labels` / `sample_3d_volume` fixtures) so CLI, reader, and panel tests exercise the same on-disk data.

Fixes #256.

## Test plan
- [x] `uv run pytest tests/unit/test_cli.py tests/unit/test_napari/test_readers.py tests/unit/test_napari/test_load_panel.py -v`
- [x] `just test` (full suite, 1861 passed)
- [x] `just pre-commit`