### PR TITLE
fix(plotting): raise clear error for non-finite vmin/vmax

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -94,6 +94,11 @@ Current development version for the next ConfUSIus release.
 
 ### :bug: Fixes
 
+- [`plot_volume`][confusius.plotting.plot_volume] and other image plotting functions now
+  raise a clear `ValueError` when `vmin`/`vmax` (or a passed-in `norm`) resolve to a
+  non-finite value, instead of crashing deep inside
+  `matplotlib.colors.LinearSegmentedColormap.from_list` with an opaque `IndexError`
+  ([#258](https://github.com/confusius-tools/confusius/issues/258)).
 - `save_nifti` now drops attrs that cannot be serialized to JSON as-is (e.g. matplotlib
   `ListedColormap`/`BoundaryNorm` objects) instead of writing their `str()` repr into the
   sidecar, which could corrupt fields such as `cmap` on reload. A warning lists the

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -98,7 +98,7 @@ Current development version for the next ConfUSIus release.
   raise a clear `ValueError` when `vmin`/`vmax` (or a passed-in `norm`) resolve to a
   non-finite value, instead of crashing deep inside
   `matplotlib.colors.LinearSegmentedColormap.from_list` with an opaque `IndexError`
-  ([#258](https://github.com/confusius-tools/confusius/issues/258)).
+  ([#259](https://github.com/confusius-tools/confusius/pull/259)).
 - `save_nifti` now drops attrs that cannot be serialized to JSON as-is (e.g. matplotlib
   `ListedColormap`/`BoundaryNorm` objects) instead of writing their `str()` repr into the
   sidecar, which could corrupt fields such as `cmap` on reload. A warning lists the

--- a/src/confusius/plotting/image.py
+++ b/src/confusius/plotting/image.py
@@ -1,5 +1,6 @@
 """Image visualization utilities for fUSI data."""
 
+import math
 import numbers
 import warnings
 from collections.abc import Hashable
@@ -252,9 +253,25 @@ def _resolve_cmap(
 
     For `threshold_mode='lower'`: gray between `[-threshold, threshold]`.
     For `threshold_mode='upper'`: gray outside `[-threshold, threshold]`.
+
+    Raises
+    ------
+    ValueError
+        If `norm.vmin` or `norm.vmax` is not finite.
     """
     import matplotlib.colors as mcolors
     import matplotlib.pyplot as plt
+
+    if (
+        norm.vmin is None
+        or norm.vmax is None
+        or not math.isfinite(norm.vmin)
+        or not math.isfinite(norm.vmax)
+    ):
+        raise ValueError(
+            "norm.vmin and norm.vmax must be finite, got "
+            f"vmin={norm.vmin!r}, vmax={norm.vmax!r}."
+        )
 
     cmap = (
         cmap

--- a/tests/unit/test_plotting/test_image.py
+++ b/tests/unit/test_plotting/test_image.py
@@ -25,6 +25,27 @@ class TestPlotVolume:
         with pytest.raises(ValueError, match="slice_mode"):
             plot_volume(sample_3d_volume, slice_mode="t", slice_coords=[0.0])
 
+    @pytest.mark.parametrize("bad_value", [np.nan, np.inf, -np.inf])
+    @pytest.mark.parametrize("bad_arg", ["vmin", "vmax"])
+    def test_nonfinite_vmin_vmax_raises(
+        self, sample_3d_volume, matplotlib_pyplot, bad_arg, bad_value
+    ):
+        """plot_volume raises a clear ValueError for non-finite vmin/vmax.
+
+        Regression test for #258: non-finite bounds used to produce an empty
+        colormap color list and crash deep inside
+        `matplotlib.colors.LinearSegmentedColormap.from_list` with an opaque
+        `IndexError`.
+        """
+        z_coord = sample_3d_volume.coords["z"].values[0]
+        with pytest.raises(ValueError, match="finite"):
+            plot_volume(
+                sample_3d_volume,
+                slice_mode="z",
+                slice_coords=[z_coord],
+                **{bad_arg: bad_value},
+            )
+
     def test_non_3d_data_raises(self):
         """plot_volume raises ValueError for 4D data with no unitary dimensions."""
         data = xr.DataArray(


### PR DESCRIPTION
## Summary
- `_resolve_cmap` now validates `norm.vmin`/`norm.vmax` are finite and raises `ValueError` instead of crashing deep in `LinearSegmentedColormap.from_list` with an opaque `IndexError`.

Fixes #258.