### PR TITLE
feat(datasets): re-download files with changed upstream md5 on refresh

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -30,7 +30,7 @@ Current development version for the next ConfUSIus release.
   MD5. Affects [`fetch_cybis_pereira_2026`][confusius.datasets.fetch_cybis_pereira_2026],
   [`fetch_nunez_elizalde_2022`][confusius.datasets.fetch_nunez_elizalde_2022], and
   [`fetch_landemard_2026`][confusius.datasets.fetch_landemard_2026]
-  ([#PR](https://github.com/confusius-tools/confusius/pull/PR)).
+  ([#261](https://github.com/confusius-tools/confusius/pull/261)).
 - Added [`plot_matrix`][confusius.plotting.plot_matrix] for plotting 2D matrices
   (e.g. connectivity or correlation matrices), with optional lower/diagonal triangle
   masking, grid lines, and a `groups` parameter that annotates contiguous label runs

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,7 +15,9 @@ Current development version for the next ConfUSIus release.
 - Dataset fetchers called with `refresh=True` now re-download cached files whose upstream
   MD5 changed, comparing the cached dataset index against the freshly fetched one instead
   of only checking whether the file exists; downloads are additionally verified against
-  the index MD5. Affects
+  the index MD5. A locally cached dataset whose `dataset_index.json` predates this format
+  is detected on fetch and reported with a clear error naming the directory to delete and
+  re-fetch, rather than being silently mishandled. Affects
   [`fetch_cybis_pereira_2026`][confusius.datasets.fetch_cybis_pereira_2026],
   [`fetch_nunez_elizalde_2022`][confusius.datasets.fetch_nunez_elizalde_2022], and
   [`fetch_landemard_2026`][confusius.datasets.fetch_landemard_2026]

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,6 +24,13 @@ Current development version for the next ConfUSIus release.
 
 ### :sparkles: Enhancements
 
+- Dataset fetchers called with `refresh=True` now re-download cached files whose upstream
+  content changed, comparing each file's MD5 against the dataset index instead of only
+  checking whether the file exists; downloads are additionally verified against the index
+  MD5. Affects [`fetch_cybis_pereira_2026`][confusius.datasets.fetch_cybis_pereira_2026],
+  [`fetch_nunez_elizalde_2022`][confusius.datasets.fetch_nunez_elizalde_2022], and
+  [`fetch_landemard_2026`][confusius.datasets.fetch_landemard_2026]
+  ([#PR](https://github.com/confusius-tools/confusius/pull/PR)).
 - Added [`plot_matrix`][confusius.plotting.plot_matrix] for plotting 2D matrices
   (e.g. connectivity or correlation matrices), with optional lower/diagonal triangle
   masking, grid lines, and a `groups` parameter that annotates contiguous label runs

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -25,9 +25,10 @@ Current development version for the next ConfUSIus release.
 ### :sparkles: Enhancements
 
 - Dataset fetchers called with `refresh=True` now re-download cached files whose upstream
-  content changed, comparing each file's MD5 against the dataset index instead of only
-  checking whether the file exists; downloads are additionally verified against the index
-  MD5. Affects [`fetch_cybis_pereira_2026`][confusius.datasets.fetch_cybis_pereira_2026],
+  MD5 changed, comparing the cached dataset index against the freshly fetched one instead
+  of only checking whether the file exists; downloads are additionally verified against
+  the index MD5. Affects
+  [`fetch_cybis_pereira_2026`][confusius.datasets.fetch_cybis_pereira_2026],
   [`fetch_nunez_elizalde_2022`][confusius.datasets.fetch_nunez_elizalde_2022], and
   [`fetch_landemard_2026`][confusius.datasets.fetch_landemard_2026]
   ([#261](https://github.com/confusius-tools/confusius/pull/261)).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,17 @@ icon: lucide/history
 
 Current development version for the next ConfUSIus release.
 
+### :sparkles: Enhancements
+
+- Dataset fetchers called with `refresh=True` now re-download cached files whose upstream
+  MD5 changed, comparing the cached dataset index against the freshly fetched one instead
+  of only checking whether the file exists; downloads are additionally verified against
+  the index MD5. Affects
+  [`fetch_cybis_pereira_2026`][confusius.datasets.fetch_cybis_pereira_2026],
+  [`fetch_nunez_elizalde_2022`][confusius.datasets.fetch_nunez_elizalde_2022], and
+  [`fetch_landemard_2026`][confusius.datasets.fetch_landemard_2026]
+  ([#261](https://github.com/confusius-tools/confusius/pull/261)).
+
 ## 0.5.0
 
 Released 2026-07-07.
@@ -27,14 +38,6 @@ Released 2026-07-07.
 
 ### :sparkles: Enhancements
 
-- Dataset fetchers called with `refresh=True` now re-download cached files whose upstream
-  MD5 changed, comparing the cached dataset index against the freshly fetched one instead
-  of only checking whether the file exists; downloads are additionally verified against
-  the index MD5. Affects
-  [`fetch_cybis_pereira_2026`][confusius.datasets.fetch_cybis_pereira_2026],
-  [`fetch_nunez_elizalde_2022`][confusius.datasets.fetch_nunez_elizalde_2022], and
-  [`fetch_landemard_2026`][confusius.datasets.fetch_landemard_2026]
-  ([#261](https://github.com/confusius-tools/confusius/pull/261)).
 - Added [`plot_matrix`][confusius.plotting.plot_matrix] for plotting 2D matrices
   (e.g. connectivity or correlation matrices), with optional lower/diagonal triangle
   masking, grid lines, and a `groups` parameter that annotates contiguous label runs

--- a/src/confusius/datasets/_cybis_pereira_2026.py
+++ b/src/confusius/datasets/_cybis_pereira_2026.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-from ._osf import OsfFileInfo, download_missing_osf_files, get_index
+from ._osf import OsfFileInfo, download_osf_files, get_index, read_cached_index
 from ._utils import get_datasets_dir
 
 _OSF_PROJECT_ID = "2v6f7"
@@ -233,9 +233,9 @@ def fetch_cybis_pereira_2026(
     refresh : bool, default: False
         Whether to re-fetch the dataset index from OSF and reconcile local
         files against it: missing files are downloaded, and cached files whose
-        MD5 no longer matches the index are re-downloaded. If `False` and all
-        requested files are already cached, the function returns immediately
-        without any network access.
+        MD5 changed upstream (comparing the cached index against the refreshed
+        one) are re-downloaded. If `False` and all requested files are already
+        cached, the function returns immediately without any network access.
 
     Returns
     -------
@@ -293,9 +293,10 @@ def fetch_cybis_pereira_2026(
                 f"Valid options: {sorted(_VALID_DATATYPES)}"
             )
 
+    previous_index = read_cached_index(bids_dir) if refresh else None
     index = get_index(bids_dir, _OSF_PROJECT_ID, _BIDS_ROOT, refresh=refresh)
     files = _filter_files(index, datasets, subjects, sessions, acqs, datatypes)
 
-    download_missing_osf_files(bids_dir, files, refresh=refresh)
+    download_osf_files(bids_dir, files, previous_index, refresh=refresh)
 
     return bids_dir

--- a/src/confusius/datasets/_cybis_pereira_2026.py
+++ b/src/confusius/datasets/_cybis_pereira_2026.py
@@ -231,10 +231,11 @@ def fetch_cybis_pereira_2026(
         (e.g. session-level `scans.tsv`, subject-level derivative
         aggregates) are always included.
     refresh : bool, default: False
-        Whether to re-fetch the dataset index from OSF and download any files
-        that are missing locally. If `False` and all requested files are
-        already cached, the function returns immediately without any network
-        access.
+        Whether to re-fetch the dataset index from OSF and reconcile local
+        files against it: missing files are downloaded, and cached files whose
+        MD5 no longer matches the index are re-downloaded. If `False` and all
+        requested files are already cached, the function returns immediately
+        without any network access.
 
     Returns
     -------
@@ -295,6 +296,6 @@ def fetch_cybis_pereira_2026(
     index = get_index(bids_dir, _OSF_PROJECT_ID, _BIDS_ROOT, refresh=refresh)
     files = _filter_files(index, datasets, subjects, sessions, acqs, datatypes)
 
-    download_missing_osf_files(bids_dir, files)
+    download_missing_osf_files(bids_dir, files, refresh=refresh)
 
     return bids_dir

--- a/src/confusius/datasets/_cybis_pereira_2026.py
+++ b/src/confusius/datasets/_cybis_pereira_2026.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-from ._osf import OsfFileInfo, download_osf_files, get_index, read_cached_index
+from ._osf import (
+    OsfFileInfo,
+    download_osf_files,
+    get_index,
+    read_cached_index,
+    update_cached_index,
+)
 from ._utils import get_datasets_dir
 
 _OSF_PROJECT_ID = "2v6f7"
@@ -298,5 +304,7 @@ def fetch_cybis_pereira_2026(
     files = _filter_files(index, datasets, subjects, sessions, acqs, datatypes)
 
     download_osf_files(bids_dir, files, previous_index, refresh=refresh)
+    if refresh:
+        update_cached_index(bids_dir, index, previous_index or {}, files)
 
     return bids_dir

--- a/src/confusius/datasets/_landemard_2026.py
+++ b/src/confusius/datasets/_landemard_2026.py
@@ -161,8 +161,9 @@ def fetch_landemard_2026(
         datatypes are downloaded. Files that do not sit under a datatype directory (e.g.
         subject-level `scans.tsv`) are always included.
     refresh : bool, default: False
-        Whether to re-fetch the dataset index from OSF and download any files that are
-        missing locally. If `False` and all requested files are already cached, the
+        Whether to re-fetch the dataset index from OSF and reconcile local files against
+        it: missing files are downloaded, and cached files whose MD5 no longer matches the
+        index are re-downloaded. If `False` and all requested files are already cached, the
         function returns immediately without any network access.
 
     Returns
@@ -222,6 +223,6 @@ def fetch_landemard_2026(
     index = get_index(bids_dir, _OSF_PROJECT_ID, _BIDS_ROOT, refresh=refresh)
     files = _filter_files(index, datasets, subjects, acqs, datatypes)
 
-    download_missing_osf_files(bids_dir, files)
+    download_missing_osf_files(bids_dir, files, refresh=refresh)
 
     return bids_dir

--- a/src/confusius/datasets/_landemard_2026.py
+++ b/src/confusius/datasets/_landemard_2026.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-from ._osf import OsfFileInfo, download_missing_osf_files, get_index
+from ._osf import OsfFileInfo, download_osf_files, get_index, read_cached_index
 from ._utils import get_datasets_dir
 
 _OSF_PROJECT_ID = "dkseb"
@@ -162,9 +162,10 @@ def fetch_landemard_2026(
         subject-level `scans.tsv`) are always included.
     refresh : bool, default: False
         Whether to re-fetch the dataset index from OSF and reconcile local files against
-        it: missing files are downloaded, and cached files whose MD5 no longer matches the
-        index are re-downloaded. If `False` and all requested files are already cached, the
-        function returns immediately without any network access.
+        it: missing files are downloaded, and cached files whose MD5 changed upstream
+        (comparing the cached index against the refreshed one) are re-downloaded. If
+        `False` and all requested files are already cached, the function returns
+        immediately without any network access.
 
     Returns
     -------
@@ -220,9 +221,10 @@ def fetch_landemard_2026(
                 f"Valid options: {sorted(_VALID_DATATYPES)}"
             )
 
+    previous_index = read_cached_index(bids_dir) if refresh else None
     index = get_index(bids_dir, _OSF_PROJECT_ID, _BIDS_ROOT, refresh=refresh)
     files = _filter_files(index, datasets, subjects, acqs, datatypes)
 
-    download_missing_osf_files(bids_dir, files, refresh=refresh)
+    download_osf_files(bids_dir, files, previous_index, refresh=refresh)
 
     return bids_dir

--- a/src/confusius/datasets/_landemard_2026.py
+++ b/src/confusius/datasets/_landemard_2026.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-from ._osf import OsfFileInfo, download_osf_files, get_index, read_cached_index
+from ._osf import (
+    OsfFileInfo,
+    download_osf_files,
+    get_index,
+    read_cached_index,
+    update_cached_index,
+)
 from ._utils import get_datasets_dir
 
 _OSF_PROJECT_ID = "dkseb"
@@ -226,5 +232,7 @@ def fetch_landemard_2026(
     files = _filter_files(index, datasets, subjects, acqs, datatypes)
 
     download_osf_files(bids_dir, files, previous_index, refresh=refresh)
+    if refresh:
+        update_cached_index(bids_dir, index, previous_index or {}, files)
 
     return bids_dir

--- a/src/confusius/datasets/_nunez_elizalde_2022.py
+++ b/src/confusius/datasets/_nunez_elizalde_2022.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-from ._osf import OsfFileInfo, download_osf_files, get_index, read_cached_index
+from ._osf import (
+    OsfFileInfo,
+    download_osf_files,
+    get_index,
+    read_cached_index,
+    update_cached_index,
+)
 from ._utils import get_datasets_dir
 
 _OSF_PROJECT_ID = "43skw"
@@ -199,5 +205,7 @@ def fetch_nunez_elizalde_2022(
     files = _filter_files(index, subjects, sessions, tasks, acqs)
 
     download_osf_files(bids_dir, files, previous_index, refresh=refresh)
+    if refresh:
+        update_cached_index(bids_dir, index, previous_index or {}, files)
 
     return bids_dir

--- a/src/confusius/datasets/_nunez_elizalde_2022.py
+++ b/src/confusius/datasets/_nunez_elizalde_2022.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-from ._osf import OsfFileInfo, download_missing_osf_files, get_index
+from ._osf import OsfFileInfo, download_osf_files, get_index, read_cached_index
 from ._utils import get_datasets_dir
 
 _OSF_PROJECT_ID = "43skw"
@@ -157,9 +157,10 @@ def fetch_nunez_elizalde_2022(
         angiography files are always included.
     refresh : bool, default: False
         Whether to re-fetch the dataset index from OSF and reconcile local files against
-        it: missing files are downloaded, and cached files whose MD5 no longer matches the
-        index are re-downloaded. If `False` and all requested files are already cached, the
-        function returns immediately without any network access.
+        it: missing files are downloaded, and cached files whose MD5 changed upstream
+        (comparing the cached index against the refreshed one) are re-downloaded. If
+        `False` and all requested files are already cached, the function returns
+        immediately without any network access.
 
     Returns
     -------
@@ -193,9 +194,10 @@ def fetch_nunez_elizalde_2022(
     if isinstance(acqs, str):
         acqs = [acqs]
 
+    previous_index = read_cached_index(bids_dir) if refresh else None
     index = get_index(bids_dir, _OSF_PROJECT_ID, _BIDS_ROOT, refresh=refresh)
     files = _filter_files(index, subjects, sessions, tasks, acqs)
 
-    download_missing_osf_files(bids_dir, files, refresh=refresh)
+    download_osf_files(bids_dir, files, previous_index, refresh=refresh)
 
     return bids_dir

--- a/src/confusius/datasets/_nunez_elizalde_2022.py
+++ b/src/confusius/datasets/_nunez_elizalde_2022.py
@@ -156,8 +156,9 @@ def fetch_nunez_elizalde_2022(
         all acquisitions are downloaded. Only applies to `fusi/` files;
         angiography files are always included.
     refresh : bool, default: False
-        Whether to re-fetch the dataset index from OSF and download any files that are
-        missing locally. If `False` and all requested files are already cached, the
+        Whether to re-fetch the dataset index from OSF and reconcile local files against
+        it: missing files are downloaded, and cached files whose MD5 no longer matches the
+        index are re-downloaded. If `False` and all requested files are already cached, the
         function returns immediately without any network access.
 
     Returns
@@ -195,6 +196,6 @@ def fetch_nunez_elizalde_2022(
     index = get_index(bids_dir, _OSF_PROJECT_ID, _BIDS_ROOT, refresh=refresh)
     files = _filter_files(index, subjects, sessions, tasks, acqs)
 
-    download_missing_osf_files(bids_dir, files)
+    download_missing_osf_files(bids_dir, files, refresh=refresh)
 
     return bids_dir

--- a/src/confusius/datasets/_osf.py
+++ b/src/confusius/datasets/_osf.py
@@ -233,7 +233,7 @@ def _select_downloads(
 
     A file is selected when it is absent from `bids_dir`. When `refresh` is
     `True`, a cached file is also selected when its md5 in `previous_index` (the
-    index it was last downloaded with) differs from — or is missing next to — its
+    index it was last downloaded with) differs from—or is missing next to—its
     md5 in `files` (the freshly fetched remote index). The cached index is trusted
     as the record of what is on disk, so files are never re-hashed; a cache entry
     that lacks an md5 (e.g. one predating md5 tracking) cannot be vouched for, so

--- a/src/confusius/datasets/_osf.py
+++ b/src/confusius/datasets/_osf.py
@@ -173,7 +173,7 @@ def update_cached_index(
     """Persist a refreshed index by merging, not replacing, the cached one.
 
     The cached `dataset_index.json` is the record of what is on disk, so it is
-    not overwritten wholesale with the remote index. Instead the merged index
+    not overwritten with the remote index. Instead the merged index
     is, per file:
 
     - the remote entry for every requested file (`files`), which has just been

--- a/src/confusius/datasets/_osf.py
+++ b/src/confusius/datasets/_osf.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import NotRequired, TypedDict
+from typing import TypedDict
 
 import pooch
 import requests
@@ -27,18 +27,26 @@ _OSF_DOWNLOAD_BASE = "https://osf.io/download/{}/"
 _INDEX_FILENAME = "dataset_index.json"
 """Filename of the per-dataset index mapping BIDS-relative paths to metadata."""
 
+_INDEX_ENTRY_KEYS = frozenset({"osf_path", "size", "md5"})
+"""Keys every entry in a current `dataset_index.json` must define.
+
+A cached index whose entries do not all define these keys is from an older,
+incompatible confusius release and is rejected by
+[`read_cached_index`][confusius.datasets._osf.read_cached_index]."""
+
 
 class OsfFileInfo(TypedDict):
     """Per-file metadata entry in an OSF-backed dataset index.
 
-    Indices written before md5 tracking omit the `md5` key entirely; newer
-    ones may still carry `md5: null` for a file whose hash is unknown. Both
-    cases read back as a missing hash via `dict.get("md5")`.
+    Every current index defines `md5` for each file (its value may be `null`
+    for a file whose hash is unknown). A locally cached index missing the key
+    is from an older release and is rejected on load, so consumers can assume
+    the key is present.
     """
 
     osf_path: str
     size: int
-    md5: NotRequired[str | None]
+    md5: str | None
 
 
 def resolve_index_url(project_id: str, bids_root: str) -> str:
@@ -127,15 +135,20 @@ def get_index(
     dict[str, OsfFileInfo]
         Mapping from BIDS-relative file paths to
         [`OsfFileInfo`][confusius.datasets._osf.OsfFileInfo] entries (`osf_path`, `size`
-        in bytes, and an optional `md5` hex digest). The schema is the same for every
-        dataset: the index is produced by the per-dataset upload script in the
-        confusius-tools GitHub organisation and stored on OSF as `dataset_index.json`.
-        Indices written before md5 tracking omit `md5`.
+        in bytes, and an `md5` hex digest). The schema is the same for every dataset: the
+        index is produced by the per-dataset upload script in the confusius-tools GitHub
+        organisation and stored on OSF as `dataset_index.json`.
+
+    Raises
+    ------
+    RuntimeError
+        If a cached index exists but does not match the current schema (see
+        [`read_cached_index`][confusius.datasets._osf.read_cached_index]).
     """
     index_path = data_dir / _INDEX_FILENAME
     cache_exists = index_path.exists()
     if not refresh and cache_exists:
-        return json.loads(index_path.read_text(encoding="utf-8"))
+        return read_cached_index(data_dir)
 
     url = resolve_index_url(project_id, bids_root)
     response = requests.get(url)
@@ -192,6 +205,41 @@ def update_cached_index(
     _write_index(data_dir / _INDEX_FILENAME, merged)
 
 
+def _validate_index(index: object, data_dir: Path) -> None:
+    """Raise a helpful error if a cached index does not match the current schema.
+
+    The check is deliberately structural: every entry must define the keys in
+    `_INDEX_ENTRY_KEYS`. It future-proofs later schema changes—any older on-disk
+    layout fails here rather than being silently mis-handled—and points the user at
+    the dataset directory to delete.
+
+    Parameters
+    ----------
+    index : object
+        Decoded contents of a local `dataset_index.json`.
+    data_dir : pathlib.Path
+        Dataset root directory holding the index, shown to the user so they know
+        which directory to remove.
+
+    Raises
+    ------
+    RuntimeError
+        If `index` is not a mapping whose every entry defines the expected keys.
+    """
+    if isinstance(index, dict) and all(
+        isinstance(entry, dict) and _INDEX_ENTRY_KEYS <= entry.keys()
+        for entry in index.values()
+    ):
+        return
+
+    raise RuntimeError(
+        f"The dataset index in {data_dir} has an outdated or unrecognised structure "
+        f"(every entry must define {sorted(_INDEX_ENTRY_KEYS)}). This local dataset was "
+        f"likely downloaded with an older version of confusius. Delete the dataset "
+        f"directory and fetch it again to update it:\n\n    {data_dir}\n"
+    )
+
+
 def read_cached_index(data_dir: Path) -> dict[str, OsfFileInfo]:
     """Return the locally cached dataset index, or `{}` if none exists.
 
@@ -200,6 +248,9 @@ def read_cached_index(data_dir: Path) -> dict[str, OsfFileInfo]:
     refresh to capture the md5s the cached files were downloaded with, then compare
     those against the freshly fetched remote index to decide which files changed
     upstream.
+
+    A cached index that is present is validated against the current schema, so a stale
+    index from an older confusius release is reported rather than mis-handled.
 
     Parameters
     ----------
@@ -210,11 +261,19 @@ def read_cached_index(data_dir: Path) -> dict[str, OsfFileInfo]:
     -------
     dict[str, OsfFileInfo]
         Cached index mapping, or an empty mapping when no cache exists.
+
+    Raises
+    ------
+    RuntimeError
+        If a cached index exists but does not match the current schema; the message
+        names the dataset directory to delete and re-fetch.
     """
     index_path = data_dir / _INDEX_FILENAME
     if not index_path.exists():
         return {}
-    return json.loads(index_path.read_text(encoding="utf-8"))
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+    _validate_index(index, data_dir)
+    return index
 
 
 def _select_downloads(
@@ -227,11 +286,11 @@ def _select_downloads(
 
     A file is selected when it is absent from `bids_dir`. When `refresh` is `True`, a
     cached file is also selected when its md5 in `previous_index` (the index it was last
-    downloaded with) differs from—or is missing next to—its md5 in `files` (the freshly
+    downloaded with) differs from—or is absent next to—its md5 in `files` (the freshly
     fetched remote index). The cached index is trusted as the record of what is on disk,
-    so files are never re-hashed; a cache entry that lacks an md5 (e.g. one predating
-    md5 tracking) cannot be vouched for, so the file is re-downloaded and its entry
-    refreshed rather than left in an unverifiable state.
+    so files are never re-hashed; a file whose cached entry has no usable md5 (a null
+    hash, or a path not previously catalogued) cannot be vouched for, so it is
+    re-downloaded and its entry refreshed rather than left in an unverifiable state.
 
     Parameters
     ----------
@@ -262,8 +321,8 @@ def _select_downloads(
         remote_md5 = info.get("md5")
         local_md5 = previous_index.get(rel_path, {}).get("md5")
         # Re-download when the remote md5 is known and the cached md5 either
-        # differs or is absent (a missing local md5 cannot be verified, so the
-        # file is refreshed instead of assumed current).
+        # differs or is unavailable (a null hash, or a path not previously
+        # catalogued): it cannot be verified, so refresh rather than assume current.
         if remote_md5 and local_md5 != remote_md5:
             selected[rel_path] = info
 

--- a/src/confusius/datasets/_osf.py
+++ b/src/confusius/datasets/_osf.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
+import warnings
 from pathlib import Path
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 
 import pooch
 import requests
@@ -29,10 +31,16 @@ _INDEX_FILENAME = "dataset_index.json"
 
 
 class OsfFileInfo(TypedDict):
-    """Per-file metadata entry in an OSF-backed dataset index."""
+    """Per-file metadata entry in an OSF-backed dataset index.
+
+    Indices written before md5 tracking omit the `md5` key entirely; newer
+    ones may still carry `md5: null` for a file whose hash is unknown. Both
+    cases read back as a missing hash via `dict.get("md5")`.
+    """
 
     osf_path: str
     size: int
+    md5: NotRequired[str | None]
 
 
 def resolve_index_url(project_id: str, bids_root: str) -> str:
@@ -115,10 +123,11 @@ def get_index(
     -------
     dict[str, OsfFileInfo]
         Mapping from BIDS-relative file paths to
-        [`OsfFileInfo`][confusius.datasets._osf.OsfFileInfo] entries (`osf_path` and
-        `size` in bytes). The schema is the same for every dataset: the index is
-        produced by the per-dataset upload script in the confusius-tools GitHub
-        organisation and stored on OSF as `dataset_index.json`.
+        [`OsfFileInfo`][confusius.datasets._osf.OsfFileInfo] entries (`osf_path`,
+        `size` in bytes, and an optional `md5` hex digest). The schema is the same
+        for every dataset: the index is produced by the per-dataset upload script
+        in the confusius-tools GitHub organisation and stored on OSF as
+        `dataset_index.json`. Indices written before md5 tracking omit `md5`.
     """
     index_path = data_dir / _INDEX_FILENAME
     if not refresh and index_path.exists():
@@ -134,8 +143,39 @@ def get_index(
     return index
 
 
-def download_missing_osf_files(bids_dir: Path, files: dict[str, OsfFileInfo]) -> None:
-    """Download missing OSF files described by an index mapping.
+def _file_md5(path: Path) -> str:
+    """Return the hex-encoded MD5 digest of a file.
+
+    Parameters
+    ----------
+    path : pathlib.Path
+        File to hash.
+
+    Returns
+    -------
+    str
+        Lowercase hexadecimal MD5 digest, matching the `md5` values stored in
+        `dataset_index.json`.
+    """
+    md5 = hashlib.md5()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            md5.update(chunk)
+    return md5.hexdigest()
+
+
+def _select_downloads(
+    bids_dir: Path,
+    files: dict[str, OsfFileInfo],
+    refresh: bool,
+) -> dict[str, OsfFileInfo]:
+    """Return the subset of `files` that must be (re)downloaded.
+
+    A file is selected when it is absent locally. When `refresh` is `True`, a
+    file that is present but whose local MD5 differs from the index `md5` is
+    also selected. Entries without an `md5` (an index predating md5 tracking,
+    or a `null` hash) fall back to the "download only if missing" behaviour and
+    trigger a single warning, since their content cannot be checked.
 
     Parameters
     ----------
@@ -143,12 +183,71 @@ def download_missing_osf_files(bids_dir: Path, files: dict[str, OsfFileInfo]) ->
         Local BIDS root directory where files are cached.
     files : dict[str, OsfFileInfo]
         Mapping from BIDS-relative paths to OSF download metadata.
+    refresh : bool
+        Whether to re-download cached files whose local MD5 no longer matches
+        the index.
+
+    Returns
+    -------
+    dict[str, OsfFileInfo]
+        Subset of `files` to download, preserving the input order.
     """
-    missing = {p: info for p, info in files.items() if not (bids_dir / p).exists()}
-    if not missing:
+    selected: dict[str, OsfFileInfo] = {}
+    unhashable = False
+
+    for rel_path, info in files.items():
+        dest = bids_dir / rel_path
+        if not dest.exists():
+            selected[rel_path] = info
+            continue
+        if not refresh:
+            continue
+        md5 = info.get("md5")
+        if not md5:
+            unhashable = True
+            continue
+        if _file_md5(dest) != md5:
+            selected[rel_path] = info
+
+    if refresh and unhashable:
+        warnings.warn(
+            "Some cached files could not be checked for upstream changes because "
+            "the dataset index has no md5 for them. Refresh only redownloaded "
+            "missing files for those entries. Re-run the dataset's upload script "
+            "to populate md5 hashes.",
+            stacklevel=2,
+        )
+
+    return selected
+
+
+def download_missing_osf_files(
+    bids_dir: Path,
+    files: dict[str, OsfFileInfo],
+    refresh: bool = False,
+) -> None:
+    """Download OSF files described by an index mapping.
+
+    Files absent from `bids_dir` are always downloaded. When `refresh` is
+    `True`, cached files whose local MD5 differs from the index `md5` are
+    re-downloaded as well; see
+    [`_select_downloads`][confusius.datasets._osf._select_downloads].
+
+    Parameters
+    ----------
+    bids_dir : pathlib.Path
+        Local BIDS root directory where files are cached.
+    files : dict[str, OsfFileInfo]
+        Mapping from BIDS-relative paths to OSF download metadata.
+    refresh : bool, default: False
+        Whether to re-download cached files whose local MD5 no longer matches
+        the index.
+    """
+    to_download = _select_downloads(bids_dir, files, refresh)
+    if not to_download:
         return
 
-    total_bytes = sum(info["size"] for info in missing.values())
+    total_bytes = sum(info["size"] for info in to_download.values())
 
     with quiet_pooch_logger():
         pooch_logger = pooch.get_logger()
@@ -163,7 +262,7 @@ def download_missing_osf_files(bids_dir: Path, files: dict[str, OsfFileInfo]) ->
         ) as progress:
             task = progress.add_task("Downloading dataset...", total=total_bytes)
 
-            for rel_path, file_info in missing.items():
+            for rel_path, file_info in to_download.items():
                 dest = bids_dir / rel_path
                 dest.parent.mkdir(parents=True, exist_ok=True)
                 progress.update(
@@ -172,12 +271,14 @@ def download_missing_osf_files(bids_dir: Path, files: dict[str, OsfFileInfo]) ->
                 )
                 adapter = _RichProgressAdapter(progress, task)
                 osf_path = file_info["osf_path"]
+                md5 = file_info.get("md5")
                 retrieve_with_retries(
                     url=_OSF_DOWNLOAD_BASE.format(osf_path.lstrip("/")),
                     dest=dest,
                     logger=pooch_logger,
                     progressbar=adapter,
                     on_retry=adapter.rewind,
+                    known_hash=f"md5:{md5}" if md5 else None,
                 )
 
             progress.update(task, description="Download complete.")

--- a/src/confusius/datasets/_osf.py
+++ b/src/confusius/datasets/_osf.py
@@ -108,7 +108,7 @@ def get_index(
     written back: the caller reconciles it against the cached index and persists
     the merged result via
     [`update_cached_index`][confusius.datasets._osf.update_cached_index], so that
-    files the caller did not reconsider keep their recorded md5.
+    files the caller did not update keep their recorded md5.
 
     Parameters
     ----------

--- a/src/confusius/datasets/_osf.py
+++ b/src/confusius/datasets/_osf.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-import hashlib
 import json
-import warnings
 from pathlib import Path
 from typing import NotRequired, TypedDict
 
@@ -143,49 +141,58 @@ def get_index(
     return index
 
 
-def _file_md5(path: Path) -> str:
-    """Return the hex-encoded MD5 digest of a file.
+def read_cached_index(data_dir: Path) -> dict[str, OsfFileInfo]:
+    """Return the locally cached dataset index, or `{}` if none exists.
+
+    Unlike [`get_index`][confusius.datasets._osf.get_index] this never touches
+    the network: it only decodes the on-disk `dataset_index.json`. Callers read
+    it before a refresh to capture the md5s the cached files were downloaded
+    with, then compare those against the freshly fetched remote index to decide
+    which files changed upstream.
 
     Parameters
     ----------
-    path : pathlib.Path
-        File to hash.
+    data_dir : pathlib.Path
+        Directory holding the cached index.
 
     Returns
     -------
-    str
-        Lowercase hexadecimal MD5 digest, matching the `md5` values stored in
-        `dataset_index.json`.
+    dict[str, OsfFileInfo]
+        Cached index mapping, or an empty mapping when no cache exists.
     """
-    md5 = hashlib.md5()
-    with path.open("rb") as handle:
-        for chunk in iter(lambda: handle.read(1 << 20), b""):
-            md5.update(chunk)
-    return md5.hexdigest()
+    index_path = data_dir / _INDEX_FILENAME
+    if not index_path.exists():
+        return {}
+    return json.loads(index_path.read_text(encoding="utf-8"))
 
 
 def _select_downloads(
     bids_dir: Path,
     files: dict[str, OsfFileInfo],
+    previous_index: dict[str, OsfFileInfo],
     refresh: bool,
 ) -> dict[str, OsfFileInfo]:
     """Return the subset of `files` that must be (re)downloaded.
 
-    A file is selected when it is absent locally. When `refresh` is `True`, a
-    file that is present but whose local MD5 differs from the index `md5` is
-    also selected. Entries without an `md5` (an index predating md5 tracking,
-    or a `null` hash) fall back to the "download only if missing" behaviour and
-    trigger a single warning, since their content cannot be checked.
+    A file is selected when it is absent from `bids_dir`. When `refresh` is
+    `True`, a cached file is also selected when its md5 in `previous_index` (the
+    index it was last downloaded with) differs from its md5 in `files` (the
+    freshly fetched remote index). The cached index is trusted as the record of
+    what is on disk, so files are never re-hashed; when either md5 is missing
+    (e.g. a cache predating md5 tracking) the file is left as is rather than
+    re-downloaded.
 
     Parameters
     ----------
     bids_dir : pathlib.Path
         Local BIDS root directory where files are cached.
     files : dict[str, OsfFileInfo]
-        Mapping from BIDS-relative paths to OSF download metadata.
+        Requested subset of the remote index.
+    previous_index : dict[str, OsfFileInfo]
+        Index cached before the refresh, used as the local md5 baseline.
     refresh : bool
-        Whether to re-download cached files whose local MD5 no longer matches
-        the index.
+        Whether to re-download cached files whose remote md5 differs from the
+        cached md5.
 
     Returns
     -------
@@ -193,7 +200,6 @@ def _select_downloads(
         Subset of `files` to download, preserving the input order.
     """
     selected: dict[str, OsfFileInfo] = {}
-    unhashable = False
 
     for rel_path, info in files.items():
         dest = bids_dir / rel_path
@@ -202,35 +208,29 @@ def _select_downloads(
             continue
         if not refresh:
             continue
-        md5 = info.get("md5")
-        if not md5:
-            unhashable = True
-            continue
-        if _file_md5(dest) != md5:
+        remote_md5 = info.get("md5")
+        local_md5 = previous_index.get(rel_path, {}).get("md5")
+        # ponytail: a filtered refresh (e.g. subjects=[...]) rewrites the whole
+        # cached index but only compares the filtered files, so an unfiltered
+        # file that changed upstream stays stale until refreshed in its own
+        # right. Merge the index on write if that ever matters.
+        if remote_md5 and local_md5 and remote_md5 != local_md5:
             selected[rel_path] = info
-
-    if refresh and unhashable:
-        warnings.warn(
-            "Some cached files could not be checked for upstream changes because "
-            "the dataset index has no md5 for them. Refresh only redownloaded "
-            "missing files for those entries. Re-run the dataset's upload script "
-            "to populate md5 hashes.",
-            stacklevel=2,
-        )
 
     return selected
 
 
-def download_missing_osf_files(
+def download_osf_files(
     bids_dir: Path,
     files: dict[str, OsfFileInfo],
+    previous_index: dict[str, OsfFileInfo] | None = None,
     refresh: bool = False,
 ) -> None:
-    """Download OSF files described by an index mapping.
+    """Download OSF files that are missing or whose upstream md5 changed.
 
     Files absent from `bids_dir` are always downloaded. When `refresh` is
-    `True`, cached files whose local MD5 differs from the index `md5` are
-    re-downloaded as well; see
+    `True`, cached files whose remote md5 differs from the md5 recorded in
+    `previous_index` are re-downloaded as well; see
     [`_select_downloads`][confusius.datasets._osf._select_downloads].
 
     Parameters
@@ -238,12 +238,17 @@ def download_missing_osf_files(
     bids_dir : pathlib.Path
         Local BIDS root directory where files are cached.
     files : dict[str, OsfFileInfo]
-        Mapping from BIDS-relative paths to OSF download metadata.
+        Requested subset of the remote index, mapping BIDS-relative paths to
+        OSF download metadata.
+    previous_index : dict[str, OsfFileInfo], optional
+        Index cached before the refresh, used as the local md5 baseline. Only
+        consulted when `refresh` is `True`; if not provided, an empty baseline
+        is used and refresh reduces to downloading missing files.
     refresh : bool, default: False
-        Whether to re-download cached files whose local MD5 no longer matches
-        the index.
+        Whether to re-download cached files whose remote md5 differs from the
+        cached md5.
     """
-    to_download = _select_downloads(bids_dir, files, refresh)
+    to_download = _select_downloads(bids_dir, files, previous_index or {}, refresh)
     if not to_download:
         return
 

--- a/src/confusius/datasets/_osf.py
+++ b/src/confusius/datasets/_osf.py
@@ -99,16 +99,14 @@ def get_index(
 ) -> dict[str, OsfFileInfo]:
     """Return the dataset index, preferring a locally cached copy.
 
-    When `refresh` is `False` and a cached index exists in `data_dir`, it is
-    decoded and returned directly (offline-friendly). Otherwise the latest index
-    is fetched from OSF and returned.
+    When `refresh` is `False` and a cached index exists in `data_dir`, it is decoded and
+    returned directly (offline-friendly). Otherwise the latest index is fetched from OSF
+    and returned.
 
-    The freshly fetched index is only persisted to disk on the very first fetch
-    (when no cache exists yet). On a refresh of an existing cache it is *not*
-    written back: the caller reconciles it against the cached index and persists
-    the merged result via
-    [`update_cached_index`][confusius.datasets._osf.update_cached_index], so that
-    files the caller did not update keep their recorded md5.
+    The freshly fetched index is only persisted to disk on the very first fetch (when no
+    cache exists yet). On a refresh of an existing cache, local and remote indices are
+    merged via [`update_cached_index`][confusius.datasets._osf.update_cached_index], so
+    that files the caller did not update keep their recorded md5.
 
     Parameters
     ----------
@@ -128,11 +126,11 @@ def get_index(
     -------
     dict[str, OsfFileInfo]
         Mapping from BIDS-relative file paths to
-        [`OsfFileInfo`][confusius.datasets._osf.OsfFileInfo] entries (`osf_path`,
-        `size` in bytes, and an optional `md5` hex digest). The schema is the same
-        for every dataset: the index is produced by the per-dataset upload script
-        in the confusius-tools GitHub organisation and stored on OSF as
-        `dataset_index.json`. Indices written before md5 tracking omit `md5`.
+        [`OsfFileInfo`][confusius.datasets._osf.OsfFileInfo] entries (`osf_path`, `size`
+        in bytes, and an optional `md5` hex digest). The schema is the same for every
+        dataset: the index is produced by the per-dataset upload script in the
+        confusius-tools GitHub organisation and stored on OSF as `dataset_index.json`.
+        Indices written before md5 tracking omit `md5`.
     """
     index_path = data_dir / _INDEX_FILENAME
     cache_exists = index_path.exists()
@@ -172,16 +170,12 @@ def update_cached_index(
 ) -> None:
     """Persist a refreshed index by merging, not replacing, the cached one.
 
-    The cached `dataset_index.json` is the record of what is on disk, so it is
-    not overwritten with the remote index. Instead the merged index
-    is, per file:
+    The cached `dataset_index.json` is the record of what is on disk, so it is not
+    overwritten with the remote index. Instead the updated index is:
 
-    - the remote entry for every requested file (`files`), which has just been
-      reconciled with disk (downloaded, or confirmed unchanged);
-    - the previously cached entry for any other file already known locally, so
-      an md5 baseline the caller did not reconsider is preserved rather than
-      silently advanced to the remote md5;
-    - otherwise the remote entry, cataloguing files not seen before.
+    - the remote entry for every newly added or updated file;
+    - the local entry for any unchanged file, so that future downloads can still detect
+      a mismatched md5;
 
     Parameters
     ----------
@@ -201,11 +195,11 @@ def update_cached_index(
 def read_cached_index(data_dir: Path) -> dict[str, OsfFileInfo]:
     """Return the locally cached dataset index, or `{}` if none exists.
 
-    Unlike [`get_index`][confusius.datasets._osf.get_index] this never touches
-    the network: it only decodes the on-disk `dataset_index.json`. Callers read
-    it before a refresh to capture the md5s the cached files were downloaded
-    with, then compare those against the freshly fetched remote index to decide
-    which files changed upstream.
+    Unlike [`get_index`][confusius.datasets._osf.get_index] this never touches the
+    network: it only decodes the on-disk `dataset_index.json`. Callers read it before a
+    refresh to capture the md5s the cached files were downloaded with, then compare
+    those against the freshly fetched remote index to decide which files changed
+    upstream.
 
     Parameters
     ----------
@@ -231,14 +225,13 @@ def _select_downloads(
 ) -> dict[str, OsfFileInfo]:
     """Return the subset of `files` that must be (re)downloaded.
 
-    A file is selected when it is absent from `bids_dir`. When `refresh` is
-    `True`, a cached file is also selected when its md5 in `previous_index` (the
-    index it was last downloaded with) differs from—or is missing next to—its
-    md5 in `files` (the freshly fetched remote index). The cached index is trusted
-    as the record of what is on disk, so files are never re-hashed; a cache entry
-    that lacks an md5 (e.g. one predating md5 tracking) cannot be vouched for, so
-    the file is re-downloaded and its entry refreshed rather than left in an
-    unverifiable state.
+    A file is selected when it is absent from `bids_dir`. When `refresh` is `True`, a
+    cached file is also selected when its md5 in `previous_index` (the index it was last
+    downloaded with) differs from—or is missing next to—its md5 in `files` (the freshly
+    fetched remote index). The cached index is trusted as the record of what is on disk,
+    so files are never re-hashed; a cache entry that lacks an md5 (e.g. one predating
+    md5 tracking) cannot be vouched for, so the file is re-downloaded and its entry
+    refreshed rather than left in an unverifiable state.
 
     Parameters
     ----------

--- a/src/confusius/datasets/_osf.py
+++ b/src/confusius/datasets/_osf.py
@@ -99,9 +99,16 @@ def get_index(
 ) -> dict[str, OsfFileInfo]:
     """Return the dataset index, preferring a locally cached copy.
 
-    When `refresh` is `False` and a cached index exists in `data_dir`,
-    it is decoded and returned directly (offline-friendly). Otherwise the
-    index is re-fetched from OSF and persisted to disk.
+    When `refresh` is `False` and a cached index exists in `data_dir`, it is
+    decoded and returned directly (offline-friendly). Otherwise the latest index
+    is fetched from OSF and returned.
+
+    The freshly fetched index is only persisted to disk on the very first fetch
+    (when no cache exists yet). On a refresh of an existing cache it is *not*
+    written back: the caller reconciles it against the cached index and persists
+    the merged result via
+    [`update_cached_index`][confusius.datasets._osf.update_cached_index], so that
+    files the caller did not reconsider keep their recorded md5.
 
     Parameters
     ----------
@@ -128,17 +135,67 @@ def get_index(
         `dataset_index.json`. Indices written before md5 tracking omit `md5`.
     """
     index_path = data_dir / _INDEX_FILENAME
-    if not refresh and index_path.exists():
+    cache_exists = index_path.exists()
+    if not refresh and cache_exists:
         return json.loads(index_path.read_text(encoding="utf-8"))
 
     url = resolve_index_url(project_id, bids_root)
     response = requests.get(url)
     response.raise_for_status()
     index = response.json()
+    if not cache_exists:
+        # First fetch: no cached md5s to preserve, so persist the full index.
+        _write_index(index_path, index)
+    return index
+
+
+def _write_index(index_path: Path, index: dict[str, OsfFileInfo]) -> None:
+    """Write a dataset index to disk as sorted, indented JSON.
+
+    Parameters
+    ----------
+    index_path : pathlib.Path
+        Destination path for `dataset_index.json`.
+    index : dict[str, OsfFileInfo]
+        Index mapping to serialise.
+    """
     index_path.write_text(
         json.dumps(index, indent=2, sort_keys=True) + "\n", encoding="utf-8"
     )
-    return index
+
+
+def update_cached_index(
+    data_dir: Path,
+    remote_index: dict[str, OsfFileInfo],
+    previous_index: dict[str, OsfFileInfo],
+    files: dict[str, OsfFileInfo],
+) -> None:
+    """Persist a refreshed index by merging, not replacing, the cached one.
+
+    The cached `dataset_index.json` is the record of what is on disk, so it is
+    not overwritten wholesale with the remote index. Instead the merged index
+    is, per file:
+
+    - the remote entry for every requested file (`files`), which has just been
+      reconciled with disk (downloaded, or confirmed unchanged);
+    - the previously cached entry for any other file already known locally, so
+      an md5 baseline the caller did not reconsider is preserved rather than
+      silently advanced to the remote md5;
+    - otherwise the remote entry, cataloguing files not seen before.
+
+    Parameters
+    ----------
+    data_dir : pathlib.Path
+        Directory holding the cached index.
+    remote_index : dict[str, OsfFileInfo]
+        Full index freshly fetched from OSF.
+    previous_index : dict[str, OsfFileInfo]
+        Index cached before the refresh.
+    files : dict[str, OsfFileInfo]
+        Requested subset of `remote_index` that was reconciled with disk.
+    """
+    merged: dict[str, OsfFileInfo] = {**remote_index, **previous_index, **files}
+    _write_index(data_dir / _INDEX_FILENAME, merged)
 
 
 def read_cached_index(data_dir: Path) -> dict[str, OsfFileInfo]:
@@ -176,11 +233,12 @@ def _select_downloads(
 
     A file is selected when it is absent from `bids_dir`. When `refresh` is
     `True`, a cached file is also selected when its md5 in `previous_index` (the
-    index it was last downloaded with) differs from its md5 in `files` (the
-    freshly fetched remote index). The cached index is trusted as the record of
-    what is on disk, so files are never re-hashed; when either md5 is missing
-    (e.g. a cache predating md5 tracking) the file is left as is rather than
-    re-downloaded.
+    index it was last downloaded with) differs from — or is missing next to — its
+    md5 in `files` (the freshly fetched remote index). The cached index is trusted
+    as the record of what is on disk, so files are never re-hashed; a cache entry
+    that lacks an md5 (e.g. one predating md5 tracking) cannot be vouched for, so
+    the file is re-downloaded and its entry refreshed rather than left in an
+    unverifiable state.
 
     Parameters
     ----------
@@ -210,11 +268,10 @@ def _select_downloads(
             continue
         remote_md5 = info.get("md5")
         local_md5 = previous_index.get(rel_path, {}).get("md5")
-        # ponytail: a filtered refresh (e.g. subjects=[...]) rewrites the whole
-        # cached index but only compares the filtered files, so an unfiltered
-        # file that changed upstream stays stale until refreshed in its own
-        # right. Merge the index on write if that ever matters.
-        if remote_md5 and local_md5 and remote_md5 != local_md5:
+        # Re-download when the remote md5 is known and the cached md5 either
+        # differs or is absent (a missing local md5 cannot be verified, so the
+        # file is refreshed instead of assumed current).
+        if remote_md5 and local_md5 != remote_md5:
             selected[rel_path] = info
 
     return selected
@@ -229,8 +286,8 @@ def download_osf_files(
     """Download OSF files that are missing or whose upstream md5 changed.
 
     Files absent from `bids_dir` are always downloaded. When `refresh` is
-    `True`, cached files whose remote md5 differs from the md5 recorded in
-    `previous_index` are re-downloaded as well; see
+    `True`, cached files whose remote md5 differs from — or is missing next to —
+    the md5 recorded in `previous_index` are re-downloaded as well; see
     [`_select_downloads`][confusius.datasets._osf._select_downloads].
 
     Parameters

--- a/src/confusius/datasets/_pooch.py
+++ b/src/confusius/datasets/_pooch.py
@@ -66,6 +66,7 @@ def retrieve_with_retries(
     logger: logging.Logger,
     progressbar: Any = False,
     on_retry: Callable[[], None] | None = None,
+    known_hash: str | None = None,
 ) -> None:
     """Download a file with `pooch`, retrying on transient network errors.
 
@@ -91,12 +92,17 @@ def retrieve_with_retries(
         Called with no arguments whenever a retry is about to occur.
         Useful for callers that need to rewind shared progress state
         that was advanced by the failed attempt.
+    known_hash : str, optional
+        Expected hash of the downloaded file in `pooch`'s
+        `"<algorithm>:<hexdigest>"` form (e.g. `"md5:abc123"`). Forwarded to
+        `pooch.retrieve`, which verifies the download and raises on mismatch.
+        If not provided, the download is not integrity-checked.
     """
     for attempt in range(1, _MAX_DOWNLOAD_RETRIES + 1):
         try:
             pooch.retrieve(
                 url=url,
-                known_hash=None,
+                known_hash=known_hash,
                 fname=dest.name,
                 path=dest.parent,
                 progressbar=progressbar,

--- a/tests/unit/test_datasets/test_osf.py
+++ b/tests/unit/test_datasets/test_osf.py
@@ -14,6 +14,7 @@ from confusius.datasets._osf import (
     get_index,
     read_cached_index,
     resolve_index_url,
+    update_cached_index,
 )
 
 _FAKE_PROJECT = "testproj"
@@ -96,8 +97,12 @@ def test_get_index_uses_cache_without_network(tmp_path):
     mock_requests.assert_not_called()
 
 
-def test_get_index_refreshes_when_requested(tmp_path):
-    """refresh=True re-fetches the index even when a cached copy exists."""
+def test_get_index_refreshes_without_persisting(tmp_path):
+    """refresh=True re-fetches the remote index but leaves the cache for the caller.
+
+    Persistence of a refreshed index is deferred to `update_cached_index`, which
+    merges rather than replaces, so `get_index` must not overwrite the cache here.
+    """
     (tmp_path / _INDEX_FILENAME).write_text(json.dumps({"stale": "data"}))
 
     responses = _make_osf_responses(_FAKE_INDEX)
@@ -106,7 +111,7 @@ def test_get_index_refreshes_when_requested(tmp_path):
 
     assert result == _FAKE_INDEX
     cached = json.loads((tmp_path / _INDEX_FILENAME).read_text())
-    assert cached == _FAKE_INDEX
+    assert cached == {"stale": "data"}
 
 
 # ---------------------------------------------------------------------------
@@ -235,8 +240,8 @@ def test_refresh_skips_when_md5_unchanged(tmp_path):
     assert calls == []
 
 
-def test_refresh_skips_when_cached_md5_absent(tmp_path):
-    """A cached file whose old index lacked md5 is kept, not re-downloaded silently."""
+def test_refresh_redownloads_when_cached_md5_absent(tmp_path):
+    """A cached file whose old index lacked md5 is re-downloaded, not trusted."""
     (tmp_path / "a.nii.gz").touch()
     files = {"a.nii.gz": {"osf_path": "/f1", "size": 5, "md5": "new"}}
     previous = {"a.nii.gz": {"osf_path": "/f1", "size": 5}}  # old-format entry
@@ -245,7 +250,8 @@ def test_refresh_skips_when_cached_md5_absent(tmp_path):
     with patch("confusius.datasets._pooch.pooch.retrieve", side_effect=retrieve):
         download_osf_files(tmp_path, files, previous, refresh=True)
 
-    assert calls == []
+    assert [c["fname"] for c in calls] == ["a.nii.gz"]
+    assert calls[0]["known_hash"] == "md5:new"
 
 
 def test_missing_file_downloads_with_known_hash(tmp_path):
@@ -261,3 +267,35 @@ def test_missing_file_downloads_with_known_hash(tmp_path):
 
     by_name = {c["fname"]: c["known_hash"] for c in calls}
     assert by_name == {"with_md5.nii.gz": "md5:abc123", "no_md5.nii.gz": None}
+
+
+# ---------------------------------------------------------------------------
+# update_cached_index — merge, don't replace
+# ---------------------------------------------------------------------------
+
+
+def test_update_cached_index_merges_without_replacing(tmp_path):
+    """Requested files adopt the remote entry; other files keep their cached one."""
+    remote_index = {
+        "requested.nii.gz": {"osf_path": "/f1", "size": 5, "md5": "new"},
+        "unrequested.nii.gz": {"osf_path": "/f2", "size": 6, "md5": "remote-changed"},
+        "brand_new.nii.gz": {"osf_path": "/f3", "size": 7, "md5": "fresh"},
+    }
+    previous_index = {
+        "requested.nii.gz": {"osf_path": "/f1", "size": 5, "md5": "old"},
+        "unrequested.nii.gz": {"osf_path": "/f2", "size": 6, "md5": "local-baseline"},
+    }
+    files = {"requested.nii.gz": remote_index["requested.nii.gz"]}
+
+    update_cached_index(tmp_path, remote_index, previous_index, files)
+
+    written = json.loads((tmp_path / _INDEX_FILENAME).read_text())
+    assert written == {
+        # Requested file was reconciled with disk, so it takes the remote md5.
+        "requested.nii.gz": {"osf_path": "/f1", "size": 5, "md5": "new"},
+        # Untouched file keeps its cached baseline instead of the remote md5,
+        # so a later refresh can still detect it changed upstream.
+        "unrequested.nii.gz": {"osf_path": "/f2", "size": 6, "md5": "local-baseline"},
+        # A file never seen locally is catalogued from the remote index.
+        "brand_new.nii.gz": {"osf_path": "/f3", "size": 7, "md5": "fresh"},
+    }

--- a/tests/unit/test_datasets/test_osf.py
+++ b/tests/unit/test_datasets/test_osf.py
@@ -19,7 +19,10 @@ from confusius.datasets._osf import (
 
 _FAKE_PROJECT = "testproj"
 _FAKE_BIDS_ROOT = "fake-bids"
-_FAKE_INDEX = {"a/b/c.nii.gz": "/file001", "top.json": "/file002"}
+_FAKE_INDEX = {
+    "a/b/c.nii.gz": {"osf_path": "/file001", "size": 10, "md5": "aaa"},
+    "top.json": {"osf_path": "/file002", "size": 20, "md5": "bbb"},
+}
 
 
 def _make_osf_responses(
@@ -177,6 +180,20 @@ def test_read_cached_index_decodes_existing(tmp_path):
     assert read_cached_index(tmp_path) == _FAKE_INDEX
 
 
+def test_read_cached_index_rejects_outdated_structure(tmp_path):
+    """An index missing the current keys errors, naming the directory to delete."""
+    (tmp_path / _INDEX_FILENAME).write_text(
+        json.dumps({"a.nii.gz": {"osf_path": "/f1", "size": 5}})  # no md5 key
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        read_cached_index(tmp_path)
+
+    message = str(excinfo.value)
+    assert str(tmp_path) in message
+    assert "md5" in message
+
+
 # ---------------------------------------------------------------------------
 # download_osf_files — md5-aware, index-vs-index refresh
 # ---------------------------------------------------------------------------
@@ -240,11 +257,11 @@ def test_refresh_skips_when_md5_unchanged(tmp_path):
     assert calls == []
 
 
-def test_refresh_redownloads_when_cached_md5_absent(tmp_path):
-    """A cached file whose old index lacked md5 is re-downloaded, not trusted."""
+def test_refresh_redownloads_when_cached_md5_null(tmp_path):
+    """A cached file whose entry has a null md5 is re-downloaded, not trusted."""
     (tmp_path / "a.nii.gz").touch()
     files = {"a.nii.gz": {"osf_path": "/f1", "size": 5, "md5": "new"}}
-    previous = {"a.nii.gz": {"osf_path": "/f1", "size": 5}}  # old-format entry
+    previous = {"a.nii.gz": {"osf_path": "/f1", "size": 5, "md5": None}}
 
     retrieve, calls = _recording_retrieve()
     with patch("confusius.datasets._pooch.pooch.retrieve", side_effect=retrieve):

--- a/tests/unit/test_datasets/test_osf.py
+++ b/tests/unit/test_datasets/test_osf.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from confusius.datasets._osf import (
     _INDEX_FILENAME,
+    download_missing_osf_files,
     get_index,
     resolve_index_url,
 )
@@ -151,3 +154,103 @@ def test_resolve_index_url_raises_if_index_file_not_on_osf():
     ):
         with pytest.raises(RuntimeError, match=_INDEX_FILENAME):
             resolve_index_url(_FAKE_PROJECT, _FAKE_BIDS_ROOT)
+
+
+# ---------------------------------------------------------------------------
+# download_missing_osf_files — md5-aware refresh
+# ---------------------------------------------------------------------------
+
+
+def _recording_retrieve():
+    """Return a (side_effect, calls) pair recording downloads and stubbing files.
+
+    The side effect mimics `pooch.retrieve`: it creates the destination file so
+    subsequent existence checks pass, and records each call's keyword arguments.
+    """
+    calls: list[dict] = []
+
+    def _retrieve(url, known_hash, fname, path, progressbar):
+        calls.append({"url": url, "known_hash": known_hash, "fname": fname})
+        dest = Path(path) / fname
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.touch()
+        return str(dest)
+
+    return _retrieve, calls
+
+
+def _write(path: Path, content: bytes) -> str:
+    """Write `content` to `path` and return its MD5 hex digest."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    return hashlib.md5(content).hexdigest()
+
+
+def test_download_skips_cached_file_without_refresh(tmp_path):
+    """A cached file is not re-downloaded when refresh is False, even if stale."""
+    dest = tmp_path / "a.nii.gz"
+    _write(dest, b"local")
+    files = {"a.nii.gz": {"osf_path": "/f1", "size": 5, "md5": "deadbeef"}}
+
+    retrieve, calls = _recording_retrieve()
+    with patch("confusius.datasets._pooch.pooch.retrieve", side_effect=retrieve):
+        download_missing_osf_files(tmp_path, files, refresh=False)
+
+    assert calls == []
+
+
+def test_refresh_redownloads_on_md5_mismatch(tmp_path):
+    """refresh re-downloads a cached file whose local MD5 differs from the index."""
+    dest = tmp_path / "a.nii.gz"
+    _write(dest, b"old-content")
+    remote_md5 = hashlib.md5(b"new-content").hexdigest()
+    files = {"a.nii.gz": {"osf_path": "/f1", "size": 11, "md5": remote_md5}}
+
+    retrieve, calls = _recording_retrieve()
+    with patch("confusius.datasets._pooch.pooch.retrieve", side_effect=retrieve):
+        download_missing_osf_files(tmp_path, files, refresh=True)
+
+    assert [c["fname"] for c in calls] == ["a.nii.gz"]
+    assert calls[0]["known_hash"] == f"md5:{remote_md5}"
+
+
+def test_refresh_skips_when_md5_matches(tmp_path):
+    """refresh leaves a cached file untouched when its MD5 matches the index."""
+    dest = tmp_path / "a.nii.gz"
+    local_md5 = _write(dest, b"same-content")
+    files = {"a.nii.gz": {"osf_path": "/f1", "size": 12, "md5": local_md5}}
+
+    retrieve, calls = _recording_retrieve()
+    with patch("confusius.datasets._pooch.pooch.retrieve", side_effect=retrieve):
+        download_missing_osf_files(tmp_path, files, refresh=True)
+
+    assert calls == []
+
+
+def test_refresh_without_md5_warns_and_keeps_cached(tmp_path):
+    """refresh cannot check an index entry lacking md5: keep the file and warn."""
+    dest = tmp_path / "a.nii.gz"
+    _write(dest, b"local")
+    files = {"a.nii.gz": {"osf_path": "/f1", "size": 5}}
+
+    retrieve, calls = _recording_retrieve()
+    with patch("confusius.datasets._pooch.pooch.retrieve", side_effect=retrieve):
+        with pytest.warns(UserWarning, match="no md5"):
+            download_missing_osf_files(tmp_path, files, refresh=True)
+
+    assert calls == []
+
+
+def test_missing_file_downloads_with_known_hash(tmp_path):
+    """A missing file is downloaded and its index md5 is forwarded to pooch."""
+    files = {
+        "with_md5.nii.gz": {"osf_path": "/f1", "size": 3, "md5": "abc123"},
+        "no_md5.nii.gz": {"osf_path": "/f2", "size": 3},
+    }
+
+    retrieve, calls = _recording_retrieve()
+    with patch("confusius.datasets._pooch.pooch.retrieve", side_effect=retrieve):
+        download_missing_osf_files(tmp_path, files, refresh=False)
+
+    by_name = {c["fname"]: c["known_hash"] for c in calls}
+    assert by_name == {"with_md5.nii.gz": "md5:abc123", "no_md5.nii.gz": None}

--- a/tests/unit/test_datasets/test_osf.py
+++ b/tests/unit/test_datasets/test_osf.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import hashlib
 import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -11,8 +10,9 @@ import pytest
 
 from confusius.datasets._osf import (
     _INDEX_FILENAME,
-    download_missing_osf_files,
+    download_osf_files,
     get_index,
+    read_cached_index,
     resolve_index_url,
 )
 
@@ -157,7 +157,23 @@ def test_resolve_index_url_raises_if_index_file_not_on_osf():
 
 
 # ---------------------------------------------------------------------------
-# download_missing_osf_files — md5-aware refresh
+# read_cached_index
+# ---------------------------------------------------------------------------
+
+
+def test_read_cached_index_returns_empty_when_absent(tmp_path):
+    """No cached index on disk yields an empty mapping, not an error."""
+    assert read_cached_index(tmp_path) == {}
+
+
+def test_read_cached_index_decodes_existing(tmp_path):
+    """An existing cached index is decoded from disk without network access."""
+    (tmp_path / _INDEX_FILENAME).write_text(json.dumps(_FAKE_INDEX))
+    assert read_cached_index(tmp_path) == _FAKE_INDEX
+
+
+# ---------------------------------------------------------------------------
+# download_osf_files — md5-aware, index-vs-index refresh
 # ---------------------------------------------------------------------------
 
 
@@ -179,64 +195,55 @@ def _recording_retrieve():
     return _retrieve, calls
 
 
-def _write(path: Path, content: bytes) -> str:
-    """Write `content` to `path` and return its MD5 hex digest."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_bytes(content)
-    return hashlib.md5(content).hexdigest()
-
-
 def test_download_skips_cached_file_without_refresh(tmp_path):
     """A cached file is not re-downloaded when refresh is False, even if stale."""
-    dest = tmp_path / "a.nii.gz"
-    _write(dest, b"local")
-    files = {"a.nii.gz": {"osf_path": "/f1", "size": 5, "md5": "deadbeef"}}
+    (tmp_path / "a.nii.gz").touch()
+    files = {"a.nii.gz": {"osf_path": "/f1", "size": 5, "md5": "new"}}
+    previous = {"a.nii.gz": {"osf_path": "/f1", "size": 5, "md5": "old"}}
 
     retrieve, calls = _recording_retrieve()
     with patch("confusius.datasets._pooch.pooch.retrieve", side_effect=retrieve):
-        download_missing_osf_files(tmp_path, files, refresh=False)
+        download_osf_files(tmp_path, files, previous, refresh=False)
 
     assert calls == []
 
 
-def test_refresh_redownloads_on_md5_mismatch(tmp_path):
-    """refresh re-downloads a cached file whose local MD5 differs from the index."""
-    dest = tmp_path / "a.nii.gz"
-    _write(dest, b"old-content")
-    remote_md5 = hashlib.md5(b"new-content").hexdigest()
-    files = {"a.nii.gz": {"osf_path": "/f1", "size": 11, "md5": remote_md5}}
+def test_refresh_redownloads_on_md5_change(tmp_path):
+    """refresh re-downloads a cached file whose remote md5 differs from the cache."""
+    (tmp_path / "a.nii.gz").touch()
+    files = {"a.nii.gz": {"osf_path": "/f1", "size": 11, "md5": "new"}}
+    previous = {"a.nii.gz": {"osf_path": "/f1", "size": 11, "md5": "old"}}
 
     retrieve, calls = _recording_retrieve()
     with patch("confusius.datasets._pooch.pooch.retrieve", side_effect=retrieve):
-        download_missing_osf_files(tmp_path, files, refresh=True)
+        download_osf_files(tmp_path, files, previous, refresh=True)
 
     assert [c["fname"] for c in calls] == ["a.nii.gz"]
-    assert calls[0]["known_hash"] == f"md5:{remote_md5}"
+    assert calls[0]["known_hash"] == "md5:new"
 
 
-def test_refresh_skips_when_md5_matches(tmp_path):
-    """refresh leaves a cached file untouched when its MD5 matches the index."""
-    dest = tmp_path / "a.nii.gz"
-    local_md5 = _write(dest, b"same-content")
-    files = {"a.nii.gz": {"osf_path": "/f1", "size": 12, "md5": local_md5}}
+def test_refresh_skips_when_md5_unchanged(tmp_path):
+    """refresh leaves a cached file untouched when the cached and remote md5 match."""
+    (tmp_path / "a.nii.gz").touch()
+    files = {"a.nii.gz": {"osf_path": "/f1", "size": 12, "md5": "same"}}
+    previous = {"a.nii.gz": {"osf_path": "/f1", "size": 12, "md5": "same"}}
 
     retrieve, calls = _recording_retrieve()
     with patch("confusius.datasets._pooch.pooch.retrieve", side_effect=retrieve):
-        download_missing_osf_files(tmp_path, files, refresh=True)
+        download_osf_files(tmp_path, files, previous, refresh=True)
 
     assert calls == []
 
 
-def test_refresh_without_md5_warns_and_keeps_cached(tmp_path):
-    """refresh cannot check an index entry lacking md5: keep the file and warn."""
-    dest = tmp_path / "a.nii.gz"
-    _write(dest, b"local")
-    files = {"a.nii.gz": {"osf_path": "/f1", "size": 5}}
+def test_refresh_skips_when_cached_md5_absent(tmp_path):
+    """A cached file whose old index lacked md5 is kept, not re-downloaded silently."""
+    (tmp_path / "a.nii.gz").touch()
+    files = {"a.nii.gz": {"osf_path": "/f1", "size": 5, "md5": "new"}}
+    previous = {"a.nii.gz": {"osf_path": "/f1", "size": 5}}  # old-format entry
 
     retrieve, calls = _recording_retrieve()
     with patch("confusius.datasets._pooch.pooch.retrieve", side_effect=retrieve):
-        with pytest.warns(UserWarning, match="no md5"):
-            download_missing_osf_files(tmp_path, files, refresh=True)
+        download_osf_files(tmp_path, files, previous, refresh=True)
 
     assert calls == []
 
@@ -250,7 +257,7 @@ def test_missing_file_downloads_with_known_hash(tmp_path):
 
     retrieve, calls = _recording_retrieve()
     with patch("confusius.datasets._pooch.pooch.retrieve", side_effect=retrieve):
-        download_missing_osf_files(tmp_path, files, refresh=False)
+        download_osf_files(tmp_path, files, refresh=False)
 
     by_name = {c["fname"]: c["known_hash"] for c in calls}
     assert by_name == {"with_md5.nii.gz": "md5:abc123", "no_md5.nii.gz": None}


### PR DESCRIPTION
Closes #260.

## Problem

The dataset fetchers' `refresh` flag only decided whether the *index* was re-fetched and whether *missing* files were downloaded. A file already on disk was never reconsidered (`download_missing_osf_files` selected `not (bids_dir / p).exists()`), and downloads used `known_hash=None`, so an upstream content change was silently ignored on `refresh=True`.

## Change

The dataset index now carries an `md5` per file. Rather than re-hashing local files (a full re-hash of a multi-GB dataset on every refresh is not acceptable), this trusts the cached `dataset_index.json` as the record of what is on disk and compares **index-to-index**.

On `refresh=True`, the fetcher captures the cached index *before* it is touched, fetches the remote index, and for each requested file re-downloads when the file is **missing** from disk, **changed** (remote md5 differs from the cached md5), or **unverifiable** (its cached entry has no usable md5 — a null hash, or a path not previously catalogued). Downloads pass `known_hash="md5:<hash>"` to pooch, so every download (refresh or first fetch) is integrity-verified on arrival. `refresh=False` is unchanged: download-missing-only, offline-friendly.

### Merge, don't replace, the cached index

`get_index` no longer overwrites the cache on refresh. After downloads, `update_cached_index` persists a **merged** index: the remote entry for every reconciled (requested) file, the previously cached entry for any other known file, and the remote entry for files never seen before. So a *filtered* refresh (e.g. `subjects=[...]`) updates only the files it actually reconciled and keeps the md5 baseline of everything else — an unrequested file that changed upstream is still detected the next time it is refreshed, rather than being silently marked current.

### Validate the cached index schema

We now assume every dataset index carries md5 going forward and stop degrading gracefully for older layouts. Whenever a locally cached `dataset_index.json` is read, its structure is validated: every entry must define `osf_path`, `size`, and `md5`. If it doesn't (e.g. a dataset downloaded by an older confusius release), the fetch fails fast with a clear error that names the dataset directory to delete and re-fetch. The check is structural, so any future index-schema change is caught the same way rather than silently mishandled. `OsfFileInfo.md5` is now a required (nullable) key.

The dataset upload/convert repos are separate from confusius, so nothing here asks maintainers to re-run them; the remote index always carries md5 going forward.

## Files

- `_osf.py` — adds `read_cached_index` (now schema-validating), `update_cached_index`, `_validate_index`, `_INDEX_ENTRY_KEYS`, and a `_write_index` helper; `get_index` reads the cache through `read_cached_index` and persists only on first fetch; `download_missing_osf_files` → `download_osf_files(bids_dir, files, previous_index=None, refresh=False)` selects missing/changed/unverifiable files via `_select_downloads` and threads md5 into `known_hash`. `OsfFileInfo.md5` becomes `str | None`.
- `_pooch.py` — `retrieve_with_retries` accepts `known_hash` and forwards it to `pooch.retrieve`.
- `_nunez_elizalde_2022.py`, `_cybis_pereira_2026.py`, `_landemard_2026.py` — read the cached index before refresh, pass it through, and merge-persist afterwards; `refresh` docstrings updated.
- The template fetcher (`_huang_2025.py`) is unchanged: it fetches by direct URL, not via the index, and already deletes-then-redownloads on refresh.

## Tests

`test_osf.py` covers `read_cached_index` (absent → `{}`, valid → decoded, outdated structure → error naming the directory), `get_index` not persisting on refresh, `update_cached_index` (requested → remote, untouched → cached baseline, unseen → catalogued), and `download_osf_files`: cached file kept without refresh, refresh re-downloads on md5 change, refresh skips on unchanged md5, refresh re-downloads a file whose cached md5 is null, and known_hash forwarding on first download.
