### PR TITLE
fix(plotting): stop sort_coords_for_plot from reordering slice_mode panels

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,7 +12,9 @@ Current development version for the next ConfUSIus release.
 
 ### :bug: Fixes
 
-- [`plot_stat_map`][confusius.plotting.plot_stat_map] and
+- [`plot_volume`][confusius.plotting.plot_volume],
+  [`plot_stat_map`][confusius.plotting.plot_stat_map],
+  [`plot_composite`][confusius.plotting.plot_composite], and
   [`VolumePlotter.add_contours`][confusius.plotting.VolumePlotter.add_contours] no
   longer silently reorder panels when `slice_mode`'s own coordinate isn't already
   sorted (e.g. a `region` dimension built from an arbitrary list of acronyms, or a

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,15 @@ icon: lucide/history
 
 Current development version for the next ConfUSIus release.
 
+### :bug: Fixes
+
+- [`plot_stat_map`][confusius.plotting.plot_stat_map] and
+  [`VolumePlotter.add_contours`][confusius.plotting.VolumePlotter.add_contours] no
+  longer silently reorder panels when `slice_mode`'s own coordinate isn't already
+  sorted (e.g. a `region` dimension built from an arbitrary list of acronyms, or a
+  descending `z`). Only the two display dimensions are sorted for plotting geometry now
+  ([#268](https://github.com/confusius-tools/confusius/pull/268)).
+
 ### :sparkles: Enhancements
 
 - Dataset fetchers called with `refresh=True` now re-download cached files whose upstream

--- a/docs/examples/04_connectivity/02_atlas_seed_map.py
+++ b/docs/examples/04_connectivity/02_atlas_seed_map.py
@@ -128,8 +128,7 @@ atlas_native = atlas.resample_like(moving, subject_to_atlas)
 # `seed_masks`.
 
 # %%
-seed_regions = ["SSp-bfd", "RSP", "HIP", "VPM"]
-seed_masks = atlas_native.get_masks(seed_regions, sides="left")
+seed_masks = atlas_native.get_masks(["SSp-bfd", "RSP", "HIP", "VPM"], sides="left")
 
 # %% [markdown]
 # ## Smooth and compute nuisance regressors
@@ -203,14 +202,11 @@ plotter = cf.plotting.plot_stat_map(
     vmax=0.8,
     threshold=0.20,
     cbar_label="Pearson correlation",
-    show_titles=False,
     show_axes=False,
     figure=fig,
     axes=axes,
     bg_color=bg_color,
 )
 plotter.add_contours(seed_masks.rename(mask="region"), linewidths=1.5)
-for ax, region in zip(axes.ravel(), seed_regions):
-    ax.set_title(region)
 
 _ = fig.suptitle("Seed-based connectivity maps", fontsize=16)

--- a/src/confusius/plotting/image.py
+++ b/src/confusius/plotting/image.py
@@ -634,7 +634,7 @@ class VolumePlotter:
         return [(idx, idx) for idx in range(len(actual_coords))]
 
     def _prepare_slice_inputs(self, data: xr.DataArray, *, caller: str) -> xr.DataArray:
-        """Coerce complex, squeeze, validate `slice_mode`/3D, and sort coords."""
+        """Coerce complex, squeeze, validate `slice_mode`/3D, and sort display coords."""
         data = coerce_complex_to_magnitude(data, caller=caller)
         squeeze_dims = [
             d for d in data.dims if d != self.slice_mode and data.sizes[d] == 1
@@ -651,7 +651,11 @@ class VolumePlotter:
                 f"Data must be 3D, but got shape {data.shape} with dims "
                 f"{list(data.dims)}."
             )
-        return sort_coords_for_plot(data, data.dims)
+        # Only the two display dims need sorting for pcolormesh/contour geometry;
+        # sorting slice_mode itself would silently reorder panels (e.g. non-monotonic
+        # z, or a "region" dim built from an arbitrary list of acronyms).
+        display_dims = [d for d in data.dims if d != self.slice_mode]
+        return sort_coords_for_plot(data, display_dims)
 
     def _resolve_axes_layout(
         self,
@@ -1486,7 +1490,10 @@ class VolumePlotter:
         if mask.ndim != 3:
             raise ValueError(f"mask must be 3D, got shape {mask.shape}")
 
-        mask = sort_coords_for_plot(mask, mask.dims)
+        # Only sort the display dims: sorting slice_mode itself would silently
+        # reorder panels (e.g. non-monotonic z, or an arbitrary "region" order).
+        display_dims = [str(d) for d in mask.dims if d != self.slice_mode]
+        mask = sort_coords_for_plot(mask, display_dims)
 
         unique_labels = sorted(
             [label for label in np.unique(mask.values) if label != 0]
@@ -1518,7 +1525,6 @@ class VolumePlotter:
         else:
             color_map = colors
 
-        display_dims = [str(d) for d in mask.dims if d != self.slice_mode]
         dim_row, dim_col = display_dims[0], display_dims[1]
 
         if slice_coords is None:

--- a/tests/unit/test_plotting/test_image.py
+++ b/tests/unit/test_plotting/test_image.py
@@ -632,6 +632,26 @@ class TestNonNumericSliceMode:
         with pytest.raises(ValueError, match="must be numeric positional indices"):
             plot_volume(data, slice_mode="region", slice_coords=["b"])
 
+    def test_region_panel_order_matches_input_not_alphabetical(self, matplotlib_pyplot):
+        """Regression test: panels follow the given region order, unsorted.
+
+        `_prepare_slice_inputs` used to sort every dim (including `slice_mode`)
+        for pcolormesh geometry, which silently reordered non-alphabetical
+        `region` coordinates and desynced them from externally-tracked labels.
+        Only the two display dims should be sorted.
+        """
+        regions = ["SSp-bfd", "RSP", "HIP", "VPM"]
+        data = xr.DataArray(
+            np.arange(4 * 3 * 3, dtype=float).reshape(4, 3, 3),
+            name="r",
+            dims=["region", "y", "x"],
+            coords={"region": regions, "y": np.arange(3.0), "x": np.arange(3.0)},
+        )
+        plotter = plot_volume(data, slice_mode="region", show_colorbar=False)
+
+        titles = [ax.get_title() for ax in plotter.axes.ravel()]
+        assert titles == [f"region = {region}" for region in regions]
+
 
 class TestVolumePlotterUtilities:
     """Tests for VolumePlotter utility methods."""


### PR DESCRIPTION
## Summary
- `sort_coords_for_plot` was sorting all of `data.dims`, including `slice_mode` itself; only the two display dims need sorting for pcolormesh/contour geometry. Sorting `slice_mode` silently reorders which slice becomes which panel whenever that coordinate isn't already monotonic increasing (e.g. a `region` dim from an arbitrary acronym list, or descending `z`).
- Scoped the sort to display dims at both call sites: `VolumePlotter._prepare_slice_inputs` and `add_contours`.
- Updated the seed-map example to rely on `plot_stat_map`'s own titles instead of a manually zipped region list — that mismatch is what surfaced the bug (`SSp-bfd`/`HIP` labels were swapped).

Fixes #267.

## Test plan
- [x] Added regression test asserting panel titles follow the given (non-alphabetical) region order
- [x] `uv run pytest tests/unit/test_plotting/` — 178 passed
- [x] `uv run just pre-commit` — all hooks pass