### PR TITLE
fix(plotting): suppress deprecated napari ScaleBar.unit warning

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,9 @@ Current development version for the next ConfUSIus release.
 
 ### :bug: Fixes
 
+- [`plot_napari`][confusius.plotting.plot_napari] no longer emits napari's
+  `FutureWarning` about the deprecated `ScaleBar.unit` API when `show_scale_bar=True`
+  ([#271](https://github.com/confusius-tools/confusius/pull/271)).
 - [`plot_volume`][confusius.plotting.plot_volume],
   [`plot_stat_map`][confusius.plotting.plot_stat_map],
   [`plot_composite`][confusius.plotting.plot_composite], and

--- a/src/confusius/plotting/napari.py
+++ b/src/confusius/plotting/napari.py
@@ -250,7 +250,19 @@ def plot_napari(
             (u for d, u in zip(all_dims, all_units) if d != time_dim and u is not None),
             "mm",
         )
-        viewer.scale_bar.unit = scale_bar_unit
+        # TODO: napari 0.7.x has deprecated ScaleBar.unit in favor of computing it
+        # from Layer.units, but does not yet implement that computation (planned for
+        # 0.8.0/0.9.0) -- setting it directly here is still the only way to get a
+        # physical unit on the scale bar. Suppress the FutureWarning until napari
+        # actually reads units from the layer list, then switch to relying on the
+        # `units` layer_kwarg set above instead of this call.
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="Setting unit on the ScaleBar model is deprecated",
+                category=FutureWarning,
+            )
+            viewer.scale_bar.unit = scale_bar_unit
 
     return viewer, layer
 


### PR DESCRIPTION
Suppresses the napari 0.7.0 FutureWarning from `plot_napari` when setting the scale bar unit. No functional replacement exists in napari 0.7.0 yet (see TODO comment).

Fixes #270