### PR TITLE
chore(deps): bump dev stack (ty, ruff, zensical, prek, pytest)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,21 +9,17 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.20
     hooks:
-      # Run the linter.
       - id: ruff-check
         exclude: ^docs/
         types_or: [python, pyi, jupyter]
         args: [ --fix ]
-      # Run the formatter.
       - id: ruff-format
         types_or: [ python, pyi, jupyter ]
 
-  - repo: local
+  - repo: https://github.com/astral-sh/ty-pre-commit
+    rev: v0.0.57
     hooks:
-    - id: ty
-      name: ty check
-      entry: uv run ty check src/
-      language: python
+      - id: ty
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.2

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -170,14 +170,14 @@ Released 2026-07-07.
   non-finite value, instead of crashing deep inside
   `matplotlib.colors.LinearSegmentedColormap.from_list` with an opaque `IndexError`
   ([#259](https://github.com/confusius-tools/confusius/pull/259)).
-- `save_nifti` now drops attrs that cannot be serialized to JSON as-is (e.g. matplotlib
-  `ListedColormap`/`BoundaryNorm` objects) instead of writing their `str()` repr into the
-  sidecar, which could corrupt fields such as `cmap` on reload. A warning lists the
-  dropped keys. [`confusius.load`][confusius.io.load] now rebuilds `cmap`/`norm` from
-  `rgb_lookup` when they are missing, so atlas-derived masks and annotations keep their
-  canonical colors after a save/load round-trip. **[Napari plugin]** The reader now
-  falls back to the `"gray"` colormap (with a napari warning) instead of crashing when a
-  layer's `cmap` attr is not a valid napari colormap name
+- [`save_nifti`][confusius.io.save_nifti] now drops attrs that cannot be serialized to
+  JSON as-is (e.g. matplotlib `ListedColormap`/`BoundaryNorm` objects) instead of
+  writing their `str()` repr into the sidecar, which could corrupt fields such as `cmap`
+  on reload. A warning lists the dropped keys. [`confusius.load`][confusius.io.load] now
+  rebuilds `cmap`/`norm` from `rgb_lookup` when they are missing, so atlas-derived masks
+  and annotations keep their canonical colors after a save/load round-trip. **[Napari
+  plugin]** The reader now falls back to the `"gray"` colormap (with a napari warning)
+  instead of crashing when a layer's `cmap` attr is not a valid napari colormap name
   ([#255](https://github.com/confusius-tools/confusius/pull/255)).
 - [`Atlas.get_masks`][confusius.atlas.Atlas.get_masks] now suffixes the `mask`
   coordinate with `_L`/`_R` for `sides="left"`/`"right"`, so requesting the same region

--- a/docs/images/gui/generate.py
+++ b/docs/images/gui/generate.py
@@ -38,12 +38,14 @@ Notes
 
 import csv
 from pathlib import Path
+from typing import cast
 
 import napari
 import numpy as np
 from napari.layers import Image
 from napari.qt import get_qapp
 from qtpy.QtCore import QEventLoop, Qt, QTimer
+from qtpy.QtWidgets import QWidget
 from rich.console import Console
 
 import confusius as cf  # noqa: F401  # Register xarray accessors.
@@ -368,7 +370,7 @@ def _napari_screenshot(viewer: napari.Viewer, path: str) -> None:
     sees or resizes it.
     """
     win = viewer.window._qt_window
-    win.setAttribute(Qt.WA_DontShowOnScreen)
+    win.setAttribute(Qt.WidgetAttribute.WA_DontShowOnScreen)
     win.show()
     win.resize(1400, 900)
     get_qapp().processEvents()
@@ -477,10 +479,14 @@ try:
 
     # Retrieve the Signals panel from the accordion container layout.
     _container2 = widget2._accordion_btns[0][0].parent()
-    ts_panel = _container2.layout().itemAt(2 * 2 + 1).widget()
+    if not isinstance(_container2, QWidget):
+        raise RuntimeError("Accordion container is not a QWidget")
+    _layout2 = _container2.layout()
+    _item2 = _layout2.itemAt(2 * 2 + 1) if _layout2 is not None else None
+    ts_panel = cast(QWidget, _item2.widget() if _item2 is not None else None)
 
     # Open the bottom dock with the signals plotter.
-    plotter = ts_panel._ensure_plotter()
+    plotter = getattr(ts_panel, "_ensure_plotter")()
     _qt_sleep(350)  # Let the dock resize QTimer.singleShot(200, …) fire.
 
     # Inject a signal from the spatial centre of the volume directly,
@@ -527,9 +533,10 @@ try:
     qc_panel = widget3._accordion_panels["Quality Control"]
 
     # Select the layer in the QC panel.
-    idx = qc_panel._layer_combo.findText(layer_name)
+    layer_combo = getattr(qc_panel, "_layer_combo")
+    idx = layer_combo.findText(layer_name)
     if idx >= 0:
-        qc_panel._layer_combo.setCurrentIndex(idx)
+        layer_combo.setCurrentIndex(idx)
 
     # Compute QC metrics synchronously (bypasses the background thread).
     console.print("  Computing DVARS")
@@ -540,7 +547,7 @@ try:
     results["carpet"] = _prepare_carpet_data(da)
 
     # Inject results — this creates the bottom dock and draws the plots.
-    qc_panel._on_compute_returned(results, da, layer_name)
+    getattr(qc_panel, "_on_compute_returned")(results, da, layer_name)
     get_qapp().processEvents()
 
     # Wait for the dock resize QTimer.singleShot(200, …) to fire.
@@ -577,7 +584,11 @@ try:
     # Open Signals panel (index 2).
     _open_accordion(widget4, 2)
     _container4 = widget4._accordion_btns[0][0].parent()
-    ts_panel4 = _container4.layout().itemAt(2 * 2 + 1).widget()
+    if not isinstance(_container4, QWidget):
+        raise RuntimeError("Accordion container is not a QWidget")
+    _layout4 = _container4.layout()
+    _item4 = _layout4.itemAt(2 * 2 + 1) if _layout4 is not None else None
+    ts_panel4 = cast(QWidget, _item4.widget() if _item4 is not None else None)
 
     layer4 = viewer4.layers[0]
     shape4 = layer4.data.shape[1:]  # (z, y, x)
@@ -587,7 +598,7 @@ try:
     # Place points at the centroids of the two atlas-derived cortical ROIs.
     pt_red = GUI_POINT_LEFT
     pt_teal = GUI_POINT_RIGHT
-    pts_layer4 = viewer4.add_points(
+    pts_layer4 = getattr(viewer4, "add_points")(
         np.array([pt_red, pt_teal]),
         name="ROI Points",
         scale=scale_3d4,
@@ -598,7 +609,7 @@ try:
     )
 
     # Open the bottom dock.
-    plotter4 = ts_panel4._ensure_plotter()
+    plotter4 = getattr(ts_panel4, "_ensure_plotter")()
     _qt_sleep(350)
 
     # Re-activate the image layer so the x-axis dropdown picks up its xarray dims
@@ -610,7 +621,7 @@ try:
     # (radio checked, combo enabled and showing "ROI Points"). The radio toggle fires
     # _on_source_mode_changed → _sync_source_to_plotter, which sets the layer and mode
     # on the plotter automatically.
-    ts_panel4._radio_points.setChecked(True)
+    getattr(ts_panel4, "_radio_points").setChecked(True)
     get_qapp().processEvents()
 
     viewer4.window._qt_window.resize(1400, 1050)
@@ -643,7 +654,11 @@ try:
     # Open Signals panel (index 2).
     _open_accordion(widget5, 2)
     _container5 = widget5._accordion_btns[0][0].parent()
-    ts_panel5 = _container5.layout().itemAt(2 * 2 + 1).widget()
+    if not isinstance(_container5, QWidget):
+        raise RuntimeError("Accordion container is not a QWidget")
+    _layout5 = _container5.layout()
+    _item5 = _layout5.itemAt(2 * 2 + 1) if _layout5 is not None else None
+    ts_panel5 = cast(QWidget, _item5.widget() if _item5 is not None else None)
 
     layer5 = viewer5.layers[0]
     shape5 = layer5.data.shape[1:]  # (z, y, x)
@@ -655,7 +670,7 @@ try:
     labels_data[0, GUI_LEFT_ROI] = 1
     labels_data[0, GUI_RIGHT_ROI] = 2
 
-    labels_layer5 = viewer5.add_labels(
+    labels_layer5 = getattr(viewer5, "add_labels")(
         labels_data,
         name="Brain Regions",
         scale=scale_3d5,
@@ -663,7 +678,7 @@ try:
     )
 
     # Open the bottom dock.
-    plotter5 = ts_panel5._ensure_plotter()
+    plotter5 = getattr(ts_panel5, "_ensure_plotter")()
     _qt_sleep(350)
 
     # Re-activate the image layer so the x-axis dropdown picks up its xarray dims
@@ -674,7 +689,7 @@ try:
     # Select the Labels radio button on the panel so the UI reflects the correct state
     # (radio checked, combo enabled and showing "Brain Regions"). The radio toggle fires
     # _on_source_mode_changed → _sync_source_to_plotter automatically.
-    ts_panel5._radio_labels.setChecked(True)
+    getattr(ts_panel5, "_radio_labels").setChecked(True)
     get_qapp().processEvents()
 
     viewer5.window._qt_window.resize(1400, 1050)
@@ -734,7 +749,7 @@ try:
 
     # Size the window, then refit camera to layers (napari "home" button).
     win6 = viewer6.window._qt_window
-    win6.setAttribute(Qt.WA_DontShowOnScreen)
+    win6.setAttribute(Qt.WidgetAttribute.WA_DontShowOnScreen)
     win6.show()
     win6.resize(1400, 900)
     get_qapp().processEvents()
@@ -831,7 +846,7 @@ try:
     _label_data8 = np.zeros(spatial_shape8, dtype=np.int32)
     _label_data8[0][_blob1] = 1
     _label_data8[0][_blob2] = 2
-    labels8 = viewer8.add_labels(
+    labels8 = getattr(viewer8, "add_labels")(
         _label_data8,
         name="Labels (3D)",
         scale=spatial_scale8,
@@ -855,7 +870,7 @@ try:
 
     # --- Signals plotter in Labels mode (mean signal per region) with the cursor. ---
     signals_panel8 = widget8._accordion_panels["Signals"]
-    plotter8 = signals_panel8._ensure_plotter()
+    plotter8 = getattr(signals_panel8, "_ensure_plotter")()
     _qt_sleep(350)
     plotter8.set_source_mode("labels")
     plotter8.set_labels_layer(labels8)
@@ -873,7 +888,7 @@ try:
     # Open the Events accordion and show the window so the geometry is final.
     _open_accordion(widget8, _accordion_index(widget8, "Events"))
     win8 = viewer8.window._qt_window
-    win8.setAttribute(Qt.WA_DontShowOnScreen)
+    win8.setAttribute(Qt.WidgetAttribute.WA_DontShowOnScreen)
     win8.show()
     win8.resize(1400, 1050)
     get_qapp().processEvents()
@@ -884,9 +899,9 @@ try:
     scroll8 = widget8.findChild(QScrollArea)
     if scroll8 is not None and scroll8.widget() is not None:
         first_btn8 = widget8._accordion_btns[0][0]
-        scroll8.verticalScrollBar().setValue(
-            first_btn8.mapTo(scroll8.widget(), QPoint(0, 0)).y()
-        )
+        scroll_bar = scroll8.verticalScrollBar()
+        if scroll_bar is not None:
+            scroll_bar.setValue(first_btn8.mapTo(scroll8.widget(), QPoint(0, 0)).y())
     get_qapp().processEvents()
 
     # --- GIF frame capture --------------------------------------------------
@@ -940,11 +955,12 @@ try:
 
     def _type_name8(name: str) -> None:
         """Type *name* into the event-name field one character at a time."""
-        events_panel8._name_edit.setText("")
+        name_edit = getattr(events_panel8, "_name_edit")
+        name_edit.setText("")
         get_qapp().processEvents()
         _grab8(repeat=2)
         for i in range(1, len(name) + 1):
-            events_panel8._name_edit.setText(name[:i])
+            name_edit.setText(name[:i])
             get_qapp().processEvents()
             _grab8()
         _grab8(repeat=2)
@@ -954,7 +970,7 @@ try:
         _set_cursor8(onset)
         _type_name8(name)
         # Start (S) marks the onset at the current time.
-        events_panel8._on_start()
+        getattr(events_panel8, "_on_start")()
         get_qapp().processEvents()
         _grab8(badge_text="S  ·  Start", repeat=7)
         # Scrub the time slider forward to the offset.
@@ -962,7 +978,7 @@ try:
             _set_cursor8(float(t))
             _grab8()
         # End (E) creates the event, shading the plot and filling the table.
-        events_panel8._on_end()
+        getattr(events_panel8, "_on_end")()
         get_qapp().processEvents()
         get_qapp().processEvents()
         _grab8(badge_text="E  ·  End", repeat=7)

--- a/docs/images/qc/generate.py
+++ b/docs/images/qc/generate.py
@@ -122,7 +122,13 @@ for is_dark, suffix in [(False, "light"), (True, "dark")]:
 
     flagged = dvars > threshold
     flagged_dvars = dvars.where(flagged, drop=True)
-    dvars.plot(ax=ax, color=line_color, linewidth=0.8, label=dvars.attrs["long_name"])
+    ax.plot(
+        dvars.coords["time"].values,
+        dvars.values,
+        color=line_color,
+        linewidth=0.8,
+        label=dvars.attrs["long_name"],
+    )
     if flagged_dvars.size > 0:
         ax.plot(
             np.asarray(flagged_dvars["time"].values, dtype=float),
@@ -162,9 +168,9 @@ _ok("Saved qc-dvars-light.png and qc-dvars-dark.png")
 _section("Carpet Plot")
 
 for bg_color, suffix in [("white", "light"), ("black", "dark")]:
-    fig, ax = plot_carpet(pwd, mask=brain_mask, bg_color=bg_color)
-    fig.savefig(str(HERE / f"qc-carpet-{suffix}.png"), **_SAVEFIG_KWARGS)
-    plt.close(fig)
+    fig, _ax = plot_carpet(pwd, mask=brain_mask, bg_color=bg_color)
+    fig.figure.savefig(str(HERE / f"qc-carpet-{suffix}.png"), **_SAVEFIG_KWARGS)
+    plt.close(fig.figure)
 
 _ok("Saved qc-carpet-light.png and qc-carpet-dark.png")
 

--- a/docs/images/visualization/generate.py
+++ b/docs/images/visualization/generate.py
@@ -113,9 +113,12 @@ def _hex_triplet_to_rgb(raw_hex: str) -> tuple[float, float, float] | None:
         return None
 
     try:
-        return tuple(int(value[i : i + 2], 16) / 255 for i in (0, 2, 4))
+        r = int(value[0:2], 16) / 255
+        g = int(value[2:4], 16) / 255
+        b = int(value[4:6], 16) / 255
     except ValueError:
         return None
+    return r, g, b
 
 
 def _require_structure_tree_csv(bids_root: Path) -> Path:
@@ -403,7 +406,7 @@ def _napari_screenshot(
     sees or resizes it.
     """
     win = viewer.window._qt_window
-    win.setAttribute(Qt.WA_DontShowOnScreen)
+    win.setAttribute(Qt.WidgetAttribute.WA_DontShowOnScreen)
     win.show()
     win.resize(1100, 750)
     get_qapp().processEvents()
@@ -500,7 +503,7 @@ try:
     viewer_orbit.dims.ndisplay = 3
 
     win = viewer_orbit.window._qt_window
-    win.setAttribute(Qt.WA_DontShowOnScreen)
+    win.setAttribute(Qt.WidgetAttribute.WA_DontShowOnScreen)
     win.show()
     win.resize(1100, 750)
     get_qapp().processEvents()
@@ -526,13 +529,18 @@ try:
         h, w = raw.shape[:2]
         scale = GIF_WIDTH / w
         frames_pil.append(
-            Image.fromarray(raw).resize((GIF_WIDTH, int(h * scale)), Image.LANCZOS)
+            Image.fromarray(raw).resize(
+                (GIF_WIDTH, int(h * scale)), Image.Resampling.LANCZOS
+            )
         )
 
     viewer_orbit.close()
 
-    palette_src = frames_pil[0].quantize(colors=256, dither=0)
-    quantized = [frame.quantize(palette=palette_src, dither=0) for frame in frames_pil]
+    palette_src = frames_pil[0].quantize(colors=256, dither=Image.Dither.NONE)
+    quantized = [
+        frame.quantize(palette=palette_src, dither=Image.Dither.NONE)
+        for frame in frames_pil
+    ]
 
     out_path = str(HERE / "napari-3d-orbit.gif")
     quantized[0].save(
@@ -669,8 +677,6 @@ try:
         colormap="gray",
     )
 
-    labels_layer.data[...] = 0
-
     if atlas_mask is None or not roi_labels:
         raise RuntimeError(f"Atlas-driven {_ROI_STRUCTURE_NAME} ROIs are unavailable.")
 
@@ -681,8 +687,9 @@ try:
         roi_labels,
     )
 
-    labels_layer.data[..., left_roi] = 1
-    labels_layer.data[..., right_roi] = 2
+    labels_data = np.asarray(labels_layer.data)
+    labels_data[..., left_roi] = 1
+    labels_data[..., right_roi] = 2
     console.print(
         "  Painted symmetric atlas ROIs "
         f"for {_ROI_STRUCTURE_NAME} ({len(label_ids)} labels)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,16 +62,16 @@ dev = [
     "jupytext>=1.16.0",
     "nbclient>=0.10.0",
     "nbformat>=5.10.0",
-    "numpydoc>=1.9.0",
-    "prek>=0.2.0,<0.3.0",
-    "pytest>=8.4.2",
+    "numpydoc>=1.11.0rc0",
+    "prek>=0.4.8",
+    "pytest>=9.1.1",
     "pytest-cov>=6.0.0",
-    "pytest-mpl>=0.16.0",
-    "ruff>=0.8.0",
-    "ty>=0.0.10,<0.1.0",
+    "pytest-mpl>=0.19.0",
+    "ruff>=0.15.20",
+    "ty>=0.0.57,<0.1.0",
     "mike @ git+https://github.com/squidfunk/mike.git",
-    "zensical>=0.0.40",
-    "mkdocstrings[python]>=1.0.3",
+    "zensical>=0.0.47",
+    "mkdocstrings[python]>=1.0.4",
     "pytest-qt>=4.5.0",
 ]
 
@@ -112,6 +112,9 @@ omit = ["*/confusius/_napari/*", "*/confusius/_cli.py"]
 
 [tool.ruff]
 exclude = ["benchmark/*"]
+
+[tool.ty.src]
+include = ["src", "tests"]
 
 [tool.pytest.ini_options]
 minversion = "8.0"

--- a/tests/integration/test_io/test_autc_conversion.py
+++ b/tests/integration/test_io/test_autc_conversion.py
@@ -227,6 +227,7 @@ class TestAUTCConversion:
 
         zarr_group = zarr.open_group(output_path, mode="r")
         iq_array = zarr_group["iq"]
+        assert isinstance(iq_array, zarr.Array)
         assert iq_array.shards == (6, 1, 6, 4)
 
     def test_cleanup_on_error(self, synthetic_autc_session, tmp_path):

--- a/tests/integration/test_io/test_echoframe_conversion.py
+++ b/tests/integration/test_io/test_echoframe_conversion.py
@@ -272,6 +272,7 @@ class TestEchoFrameConversion:
 
         zarr_group = zarr.open_group(output_path, mode="r")
         iq_array = zarr_group["iq"]
+        assert isinstance(iq_array, zarr.Array)
         assert iq_array.shards == (6, 1, 6, 4)
 
     def test_cleanup_on_error(self, synthetic_echoframe_session, tmp_path):

--- a/tests/unit/test_atlas/conftest.py
+++ b/tests/unit/test_atlas/conftest.py
@@ -59,9 +59,9 @@ def mock_structures(obj_path: Path) -> _MockStructuresDict:
     Only the root region (997) has a mesh file assigned.
     """
     tree = treelib.Tree()
-    tree.create_node("root", 997)
-    tree.create_node("child", 10, parent=997)
-    tree.create_node("grandchild", 20, parent=10)
+    tree.create_node("root", 997)  # ty: ignore[invalid-argument-type]
+    tree.create_node("child", 10, parent=997)  # ty: ignore[invalid-argument-type]
+    tree.create_node("grandchild", 20, parent=10)  # ty: ignore[invalid-argument-type]
 
     structure_list = [
         {
@@ -162,4 +162,9 @@ def atlas(mock_structures: _MockStructuresDict) -> Atlas:
     # hemisphere clip splits it 3/3. Fixed to the mesh, independent of the resolution.
     rl_midline = 0.1
 
-    return Atlas(dataset, mock_structures, mesh_vertex_transform, rl_midline)
+    return Atlas(
+        dataset,
+        mock_structures,  # ty: ignore[invalid-argument-type]
+        mesh_vertex_transform,
+        rl_midline,
+    )

--- a/tests/unit/test_atlas/test_atlas.py
+++ b/tests/unit/test_atlas/test_atlas.py
@@ -69,7 +69,7 @@ class TestAtlasConstruction:
                 "resolution": resolution_um,
             }
 
-        result = Atlas.from_brainglobe(_MockBgAtlas())  # type: ignore[arg-type]
+        result = Atlas.from_brainglobe(_MockBgAtlas())  # ty: ignore[invalid-argument-type]
 
         assert isinstance(result, Atlas)
         assert result.reference.dtype == np.float32
@@ -298,7 +298,7 @@ class TestGetMasks:
 
     def test_invalid_side_value_raises(self, atlas: Atlas) -> None:
         with pytest.raises(ValueError, match="Invalid side"):
-            atlas.get_masks(10, sides="center")  # type: ignore[arg-type]
+            atlas.get_masks(10, sides="center")  # ty: ignore[invalid-argument-type]
 
     def test_unknown_region_id_raises(self, atlas: Atlas) -> None:
         with pytest.raises(KeyError):
@@ -736,6 +736,7 @@ class TestResampleLike:
         composed = atlas_module._compose_mesh_vertex_transforms(
             old_transform, new_transform, reference, reference
         )
+        assert isinstance(composed, xr.DataArray)
         np.testing.assert_array_equal(
             composed.coords["component"].values, ["z", "y", "x"]
         )
@@ -798,7 +799,7 @@ class TestResampleLike:
             shape=reference.shape,
             spacing=[0.05, 0.05, 0.05],
             origin=[0.0, 0.0, 0.0],
-            dims=reference.dims,
+            dims=[str(dim) for dim in reference.dims],
         )
 
         np.testing.assert_allclose(by_grid.reference.values, by_like.reference.values)

--- a/tests/unit/test_bids_events.py
+++ b/tests/unit/test_bids_events.py
@@ -161,7 +161,7 @@ class TestWriteEvents:
         """A non-DataFrame events argument is rejected."""
         path = tmp_path / "events.tsv"
         with pytest.raises(TypeError, match="DataFrame"):
-            write_events(path, [(0.0, 1.0, "stim")])
+            write_events(path, [(0.0, 1.0, "stim")])  # ty: ignore[invalid-argument-type]
 
     def test_rejects_missing_required_column(self, tmp_path):
         """A DataFrame without a duration column is rejected."""

--- a/tests/unit/test_connectivity/test_matrix.py
+++ b/tests/unit/test_connectivity/test_matrix.py
@@ -186,13 +186,13 @@ class TestValidation:
         """fit raises TypeError for non-iterable input."""
         measure = ConnectivityMatrix()
         with pytest.raises(TypeError, match="DataArray"):
-            measure.fit(1.0)
+            measure.fit(1.0)  # ty: ignore[invalid-argument-type]
 
     def test_numpy_array_input_raises(self):
         """fit raises TypeError for numpy array input (DataArrays required)."""
         measure = ConnectivityMatrix()
         with pytest.raises(TypeError, match="DataArray"):
-            measure.fit([np.ones((100, N_FEATURES))])
+            measure.fit([np.ones((100, N_FEATURES))])  # ty: ignore[invalid-argument-type]
 
     def test_no_time_dim_raises(self):
         """fit raises ValueError when a subject is missing the time dimension."""
@@ -226,7 +226,7 @@ class TestValidation:
 
     def test_invalid_kind_raises(self, signals):
         """fit raises ValueError for an unknown kind."""
-        measure = ConnectivityMatrix(kind="unknown")
+        measure = ConnectivityMatrix(kind="unknown")  # ty: ignore[invalid-argument-type]
         with pytest.raises(ValueError, match="kind must be one of"):
             measure.fit(signals)
 

--- a/tests/unit/test_datasets/test_osf.py
+++ b/tests/unit/test_datasets/test_osf.py
@@ -10,6 +10,7 @@ import pytest
 
 from confusius.datasets._osf import (
     _INDEX_FILENAME,
+    OsfFileInfo,
     download_osf_files,
     get_index,
     read_cached_index,
@@ -19,7 +20,7 @@ from confusius.datasets._osf import (
 
 _FAKE_PROJECT = "testproj"
 _FAKE_BIDS_ROOT = "fake-bids"
-_FAKE_INDEX = {
+_FAKE_INDEX: dict[str, OsfFileInfo] = {
     "a/b/c.nii.gz": {"osf_path": "/file001", "size": 10, "md5": "aaa"},
     "top.json": {"osf_path": "/file002", "size": 20, "md5": "bbb"},
 }
@@ -220,8 +221,12 @@ def _recording_retrieve():
 def test_download_skips_cached_file_without_refresh(tmp_path):
     """A cached file is not re-downloaded when refresh is False, even if stale."""
     (tmp_path / "a.nii.gz").touch()
-    files = {"a.nii.gz": {"osf_path": "/f1", "size": 5, "md5": "new"}}
-    previous = {"a.nii.gz": {"osf_path": "/f1", "size": 5, "md5": "old"}}
+    files: dict[str, OsfFileInfo] = {
+        "a.nii.gz": {"osf_path": "/f1", "size": 5, "md5": "new"}
+    }
+    previous: dict[str, OsfFileInfo] = {
+        "a.nii.gz": {"osf_path": "/f1", "size": 5, "md5": "old"}
+    }
 
     retrieve, calls = _recording_retrieve()
     with patch("confusius.datasets._pooch.pooch.retrieve", side_effect=retrieve):
@@ -233,8 +238,12 @@ def test_download_skips_cached_file_without_refresh(tmp_path):
 def test_refresh_redownloads_on_md5_change(tmp_path):
     """refresh re-downloads a cached file whose remote md5 differs from the cache."""
     (tmp_path / "a.nii.gz").touch()
-    files = {"a.nii.gz": {"osf_path": "/f1", "size": 11, "md5": "new"}}
-    previous = {"a.nii.gz": {"osf_path": "/f1", "size": 11, "md5": "old"}}
+    files: dict[str, OsfFileInfo] = {
+        "a.nii.gz": {"osf_path": "/f1", "size": 11, "md5": "new"}
+    }
+    previous: dict[str, OsfFileInfo] = {
+        "a.nii.gz": {"osf_path": "/f1", "size": 11, "md5": "old"}
+    }
 
     retrieve, calls = _recording_retrieve()
     with patch("confusius.datasets._pooch.pooch.retrieve", side_effect=retrieve):
@@ -247,8 +256,12 @@ def test_refresh_redownloads_on_md5_change(tmp_path):
 def test_refresh_skips_when_md5_unchanged(tmp_path):
     """refresh leaves a cached file untouched when the cached and remote md5 match."""
     (tmp_path / "a.nii.gz").touch()
-    files = {"a.nii.gz": {"osf_path": "/f1", "size": 12, "md5": "same"}}
-    previous = {"a.nii.gz": {"osf_path": "/f1", "size": 12, "md5": "same"}}
+    files: dict[str, OsfFileInfo] = {
+        "a.nii.gz": {"osf_path": "/f1", "size": 12, "md5": "same"}
+    }
+    previous: dict[str, OsfFileInfo] = {
+        "a.nii.gz": {"osf_path": "/f1", "size": 12, "md5": "same"}
+    }
 
     retrieve, calls = _recording_retrieve()
     with patch("confusius.datasets._pooch.pooch.retrieve", side_effect=retrieve):
@@ -260,8 +273,12 @@ def test_refresh_skips_when_md5_unchanged(tmp_path):
 def test_refresh_redownloads_when_cached_md5_null(tmp_path):
     """A cached file whose entry has a null md5 is re-downloaded, not trusted."""
     (tmp_path / "a.nii.gz").touch()
-    files = {"a.nii.gz": {"osf_path": "/f1", "size": 5, "md5": "new"}}
-    previous = {"a.nii.gz": {"osf_path": "/f1", "size": 5, "md5": None}}
+    files: dict[str, OsfFileInfo] = {
+        "a.nii.gz": {"osf_path": "/f1", "size": 5, "md5": "new"}
+    }
+    previous: dict[str, OsfFileInfo] = {
+        "a.nii.gz": {"osf_path": "/f1", "size": 5, "md5": None}
+    }
 
     retrieve, calls = _recording_retrieve()
     with patch("confusius.datasets._pooch.pooch.retrieve", side_effect=retrieve):
@@ -273,9 +290,9 @@ def test_refresh_redownloads_when_cached_md5_null(tmp_path):
 
 def test_missing_file_downloads_with_known_hash(tmp_path):
     """A missing file is downloaded and its index md5 is forwarded to pooch."""
-    files = {
+    files: dict[str, OsfFileInfo] = {
         "with_md5.nii.gz": {"osf_path": "/f1", "size": 3, "md5": "abc123"},
-        "no_md5.nii.gz": {"osf_path": "/f2", "size": 3},
+        "no_md5.nii.gz": {"osf_path": "/f2", "size": 3, "md5": None},
     }
 
     retrieve, calls = _recording_retrieve()
@@ -293,16 +310,18 @@ def test_missing_file_downloads_with_known_hash(tmp_path):
 
 def test_update_cached_index_merges_without_replacing(tmp_path):
     """Requested files adopt the remote entry; other files keep their cached one."""
-    remote_index = {
+    remote_index: dict[str, OsfFileInfo] = {
         "requested.nii.gz": {"osf_path": "/f1", "size": 5, "md5": "new"},
         "unrequested.nii.gz": {"osf_path": "/f2", "size": 6, "md5": "remote-changed"},
         "brand_new.nii.gz": {"osf_path": "/f3", "size": 7, "md5": "fresh"},
     }
-    previous_index = {
+    previous_index: dict[str, OsfFileInfo] = {
         "requested.nii.gz": {"osf_path": "/f1", "size": 5, "md5": "old"},
         "unrequested.nii.gz": {"osf_path": "/f2", "size": 6, "md5": "local-baseline"},
     }
-    files = {"requested.nii.gz": remote_index["requested.nii.gz"]}
+    files: dict[str, OsfFileInfo] = {
+        "requested.nii.gz": remote_index["requested.nii.gz"]
+    }
 
     update_cached_index(tmp_path, remote_index, previous_index, files)
 

--- a/tests/unit/test_decomposition/test_fastica.py
+++ b/tests/unit/test_decomposition/test_fastica.py
@@ -1,5 +1,7 @@
 """Tests for confusius.decomposition.FastICA."""
 
+from typing import Literal, TypedDict
+
 import numpy as np
 import pytest
 import xarray as xr
@@ -9,7 +11,15 @@ from sklearn.utils.validation import check_is_fitted
 from confusius.decomposition import FastICA
 
 
-FASTICA_TEST_KWARGS = {
+class _FasticaTestKwargs(TypedDict):
+    n_components: int
+    random_state: int
+    max_iter: int
+    tol: float
+    fun: Literal["cube"]
+
+
+FASTICA_TEST_KWARGS: _FasticaTestKwargs = {
     "n_components": 2,
     "random_state": 0,
     "max_iter": 1000,
@@ -182,13 +192,13 @@ def test_inverse_transform_raises_for_invalid_input_type(sample_3dt_volume):
     model = FastICA(**FASTICA_TEST_KWARGS).fit(sample_3dt_volume)
 
     with pytest.raises(TypeError, match="DataArray or ndarray"):
-        model.inverse_transform([1, 2, 3])
+        model.inverse_transform([1, 2, 3])  # ty: ignore[invalid-argument-type]
 
 
 def test_fit_rejects_invalid_mode(sample_3dt_volume):
     """fit raises ValueError for unknown mode values."""
     with pytest.raises(ValueError, match="mode must be"):
-        FastICA(mode="invalid").fit(sample_3dt_volume)  # type: ignore[arg-type]
+        FastICA(mode="invalid").fit(sample_3dt_volume)  # ty: ignore[invalid-argument-type]
 
 
 def test_fit_requires_time_dimension(sample_3dt_volume):
@@ -220,7 +230,7 @@ def test_fit_rejects_unexpected_fit_params(sample_3dt_volume):
     with pytest.raises(TypeError, match="unexpected keyword argument"):
         FastICA().fit(
             sample_3dt_volume,
-            sample_weight=np.ones(sample_3dt_volume.sizes["time"]),
+            sample_weight=np.ones(sample_3dt_volume.sizes["time"]),  # ty: ignore[unknown-argument]
         )
 
 

--- a/tests/unit/test_decomposition/test_nmf.py
+++ b/tests/unit/test_decomposition/test_nmf.py
@@ -218,7 +218,7 @@ def test_inverse_transform_raises_for_invalid_input_type(nmf_3dt_volume):
     model = NMF(n_components=3, random_state=0).fit(nmf_3dt_volume)
 
     with pytest.raises(TypeError, match="DataArray or ndarray"):
-        model.inverse_transform([1, 2, 3])
+        model.inverse_transform([1, 2, 3])  # ty: ignore[invalid-argument-type]
 
 
 def test_fit_requires_time_dimension(nmf_3dt_volume):
@@ -273,7 +273,7 @@ def test_fit_rejects_unexpected_fit_params(nmf_3dt_volume):
     with pytest.raises(TypeError, match="unexpected keyword argument"):
         NMF().fit(
             nmf_3dt_volume,
-            sample_weight=np.ones(nmf_3dt_volume.sizes["time"]),
+            sample_weight=np.ones(nmf_3dt_volume.sizes["time"]),  # ty: ignore[unknown-argument]
         )
 
 
@@ -446,7 +446,7 @@ def test_spatial_mode_matches_reference_implementation(nmf_3dt_volume):
 def test_fit_rejects_invalid_mode(nmf_3dt_volume):
     """fit raises for unsupported NMF mode."""
     with pytest.raises(ValueError, match="mode must be 'temporal' or 'spatial'"):
-        NMF(mode="invalid").fit(nmf_3dt_volume)  # type: ignore[arg-type]
+        NMF(mode="invalid").fit(nmf_3dt_volume)  # ty: ignore[invalid-argument-type]
 
 
 def test_mask_restricts_features(nmf_3dt_volume):

--- a/tests/unit/test_decomposition/test_pca.py
+++ b/tests/unit/test_decomposition/test_pca.py
@@ -139,7 +139,7 @@ def test_inverse_transform_raises_for_invalid_input_type(sample_3dt_volume):
     model = PCA(n_components=4, random_state=0).fit(sample_3dt_volume)
 
     with pytest.raises(TypeError, match="DataArray or ndarray"):
-        model.inverse_transform([1, 2, 3])
+        model.inverse_transform([1, 2, 3])  # ty: ignore[invalid-argument-type]
 
 
 def test_fit_requires_time_dimension(sample_3dt_volume):
@@ -194,7 +194,7 @@ def test_fit_rejects_unexpected_fit_params(sample_3dt_volume):
     with pytest.raises(TypeError, match="unexpected keyword argument"):
         PCA().fit(
             sample_3dt_volume,
-            sample_weight=np.ones(sample_3dt_volume.sizes["time"]),
+            sample_weight=np.ones(sample_3dt_volume.sizes["time"]),  # ty: ignore[unknown-argument]
         )
 
 
@@ -370,7 +370,7 @@ def test_spatial_mode_matches_reference_implementation(sample_3dt_volume):
 def test_fit_raises_for_invalid_mode(sample_3dt_volume):
     """fit raises for unsupported PCA mode."""
     with pytest.raises(ValueError, match="mode must be 'temporal' or 'spatial'"):
-        PCA(mode="invalid").fit(sample_3dt_volume)  # type: ignore[arg-type]
+        PCA(mode="invalid").fit(sample_3dt_volume)  # ty: ignore[invalid-argument-type]
 
 
 def test_mask_restricts_features(sample_3dt_volume):

--- a/tests/unit/test_extract/test_labels.py
+++ b/tests/unit/test_extract/test_labels.py
@@ -16,7 +16,7 @@ class TestWithLabels:
         with pytest.raises(TypeError, match="xarray.DataArray"):
             extract.extract_with_labels(
                 sample_3dt_volume,
-                np.zeros((4, 6, 8), dtype=int),  # type: ignore[arg-type]
+                np.zeros((4, 6, 8), dtype=int),  # ty: ignore[invalid-argument-type]
             )
 
     def test_labels_dtype_validation(self, sample_3dt_volume):
@@ -127,7 +127,7 @@ class TestWithLabels:
         labels = xr.DataArray(np.ones((3, 4), dtype=int), dims=["y", "x"])
 
         with pytest.raises(ValueError, match="Invalid reduction"):
-            extract.extract_with_labels(data, labels, reduction="invalid")  # type: ignore[arg-type]
+            extract.extract_with_labels(data, labels, reduction="invalid")  # ty: ignore[invalid-argument-type]
 
     def test_dask_laziness(self):
         """Test that the result is lazy when the input is a Dask-backed array."""

--- a/tests/unit/test_glm/test_contrasts.py
+++ b/tests/unit/test_glm/test_contrasts.py
@@ -53,7 +53,7 @@ class TestContrastFromEstimate:
         variance = np.ones(5)
 
         with pytest.raises(ValueError, match="'t' or 'F'"):
-            Contrast.from_estimate(effect, variance, stat_type="chi2")
+            Contrast.from_estimate(effect, variance, stat_type="chi2")  # ty: ignore[invalid-argument-type]
 
 
 # -----------------------------------------------------------------------------

--- a/tests/unit/test_glm/test_design.py
+++ b/tests/unit/test_glm/test_design.py
@@ -469,7 +469,7 @@ class TestEdgeCases:
         """Unknown drift_model values raise."""
         with pytest.raises(ValueError, match="drift_model"):
             make_first_level_design_matrix(
-                frame_times, basic_events, drift_model="unknown"
+                frame_times, basic_events, drift_model="unknown"  # ty: ignore[invalid-argument-type]
             )
 
 
@@ -488,7 +488,7 @@ class TestDesignMatrixInputValidation:
 
     def test_invalid_hrf_model_raises(self, frame_times, stim_event):
         with pytest.raises(ValueError, match="Unknown hrf_model"):
-            make_first_level_design_matrix(frame_times, stim_event, hrf_model="invalid")
+            make_first_level_design_matrix(frame_times, stim_event, hrf_model="invalid")  # ty: ignore[invalid-argument-type]
 
     def test_invalid_drift_order_raises(self, frame_times, stim_event):
         with pytest.raises(ValueError, match="drift_order must be >= 0"):
@@ -511,7 +511,7 @@ class TestDesignMatrixInputValidation:
 
     def test_events_must_be_dataframe(self, frame_times):
         with pytest.raises(TypeError, match="pandas DataFrame"):
-            make_first_level_design_matrix(frame_times, events=[1, 2, 3])
+            make_first_level_design_matrix(frame_times, events=[1, 2, 3])  # ty: ignore[invalid-argument-type]
 
     def test_events_missing_onset_column_raises(self, frame_times):
         events = pd.DataFrame({"trial_type": ["stim"], "duration": [1.0]})

--- a/tests/unit/test_glm/test_first_level.py
+++ b/tests/unit/test_glm/test_first_level.py
@@ -246,7 +246,7 @@ class TestFirstLevelModelContrast:
 
     def test_invalid_output_type_raises(self):
         with pytest.raises(ValueError, match="output_type"):
-            self.model.compute_contrast("A", output_type="invalid")
+            self.model.compute_contrast("A", output_type="invalid")  # ty: ignore[invalid-argument-type]
 
 
 class TestFirstLevelModelContrastMultiRun:

--- a/tests/unit/test_glm/test_models.py
+++ b/tests/unit/test_glm/test_models.py
@@ -143,6 +143,7 @@ class TestARModel:
             [np.corrcoef(results.residuals[:-1, v], results.residuals[1:, v])[0, 1]
              for v in range(n_voxels)]
         )
+        assert results.whitened_residuals is not None
         white_ac = np.mean(
             [np.corrcoef(results.whitened_residuals[:-1, v],
                          results.whitened_residuals[1:, v])[0, 1]

--- a/tests/unit/test_glm/test_second_level.py
+++ b/tests/unit/test_glm/test_second_level.py
@@ -173,7 +173,7 @@ class TestSecondLevelModelContrast:
 
     def test_invalid_output_type_raises(self):
         with pytest.raises(ValueError, match="output_type"):
-            self.model.compute_contrast(output_type="invalid")
+            self.model.compute_contrast(output_type="invalid")  # ty: ignore[invalid-argument-type]
 
 
 class TestSecondLevelModelFContrast:
@@ -262,12 +262,12 @@ class TestSecondLevelModelErrors:
     def test_not_list_raises(self):
         model = SecondLevelModel()
         with pytest.raises(ValueError, match="non-empty list"):
-            model.fit(xr.DataArray(np.ones((5, 3))))
+            model.fit(xr.DataArray(np.ones((5, 3))))  # ty: ignore[invalid-argument-type]
 
     def test_list_of_non_dataarrays_raises(self):
         model = SecondLevelModel()
         with pytest.raises(TypeError, match="FirstLevelModel or"):
-            model.fit([np.ones((3, 4)), np.ones((3, 4))])
+            model.fit([np.ones((3, 4)), np.ones((3, 4))])  # ty: ignore[invalid-argument-type]
 
     def test_empty_input_raises(self):
         model = SecondLevelModel()

--- a/tests/unit/test_io/test_nifti.py
+++ b/tests/unit/test_io/test_nifti.py
@@ -1776,7 +1776,7 @@ class TestSaveNifti:
         output_path = tmp_path / "output_nifti2.nii"
         save_nifti(da, output_path, nifti_version=2)
 
-        loaded = nib.nifti1.Nifti1Image.from_filename(output_path)
+        loaded = nib.nifti2.Nifti2Image.from_filename(output_path)
         assert isinstance(loaded, nib.nifti2.Nifti2Image)
 
     def test_save_valid_derived_metadata_emits_no_validation_warning(

--- a/tests/unit/test_io/test_nifti.py
+++ b/tests/unit/test_io/test_nifti.py
@@ -250,7 +250,7 @@ class TestLoadNifti:
 
         # Patch the saved header directly to set pixdim[5] (the 5th NIfTI axis)
         # to -2.0 (bypasses nibabel's `set_zooms` positivity check).
-        loaded = nib.load(nifti_path)
+        loaded = nib.nifti1.Nifti1Image.from_filename(nifti_path)
         loaded.header.structarr["pixdim"][5] = np.float32(-2.0)
         loaded.to_filename(nifti_path)
 
@@ -1016,7 +1016,7 @@ class TestSaveNifti:
         with pytest.warns(UserWarning, match="spacing is undefined"):
             save_nifti(da, output_path)
 
-        loaded = nib.load(output_path)
+        loaded = nib.nifti1.Nifti1Image.from_filename(output_path)
         # NIfTI order: (x, y, z) — only the missing z slot is inserted.
         assert loaded.shape == (8, 6, 1)
         np.testing.assert_array_almost_equal(
@@ -1066,7 +1066,7 @@ class TestSaveNifti:
         with pytest.warns(UserWarning, match="spacing is undefined"):
             save_nifti(da, output_path)
 
-        loaded = nib.load(output_path)
+        loaded = nib.nifti1.Nifti1Image.from_filename(output_path)
         assert loaded.shape == (6, 5, 3, 4, 2)
         np.testing.assert_array_equal(
             np.asarray(loaded.dataobj), data.transpose(4, 3, 2, 1, 0)
@@ -1093,7 +1093,7 @@ class TestSaveNifti:
         output_path = tmp_path / "bspl.nii.gz"
         save_nifti(da, output_path)
 
-        loaded = nib.load(output_path)
+        loaded = nib.nifti1.Nifti1Image.from_filename(output_path)
         # NIfTI shape: (x, y, z, time=1, component=3)
         assert loaded.shape == (6, 5, 4, 1, 3)
         # The synthetic time slot does not encode a real TR.
@@ -1178,7 +1178,7 @@ class TestSaveNifti:
         output_path = tmp_path / "constant.nii.gz"
         save_nifti(da, output_path)
 
-        loaded = nib.load(output_path)
+        loaded = nib.nifti1.Nifti1Image.from_filename(output_path)
         assert loaded.header.structarr["pixdim"][5] == pytest.approx(0.0)
 
         sidecar_path = output_path.with_suffix("").with_suffix(".json")
@@ -1236,7 +1236,13 @@ class TestSaveNifti:
         save_nifti(da, output_path)
 
         # NIfTI shape: (x=8, y=6, z=4, time=1, component=0).
-        assert nib.load(output_path).shape == (8, 6, 4, 1, 0)
+        assert nib.nifti1.Nifti1Image.from_filename(output_path).shape == (
+            8,
+            6,
+            4,
+            1,
+            0,
+        )
 
     def test_save_extra_dim_coord_attrs_roundtrip_through_sidecar(
         self, tmp_path
@@ -1315,7 +1321,7 @@ class TestSaveNifti:
         output_path = tmp_path / "negative_channel_spacing.nii.gz"
         save_nifti(da, output_path)
 
-        loaded = nib.load(output_path)
+        loaded = nib.nifti1.Nifti1Image.from_filename(output_path)
         assert loaded.header.structarr["pixdim"][5] == pytest.approx(-2.0)
 
         with open(tmp_path / "negative_channel_spacing.json") as f:
@@ -1433,7 +1439,7 @@ class TestSaveNifti:
         with pytest.warns(UserWarning, match="using the median step"):
             save_nifti(da, output_path)
 
-        loaded = nib.load(output_path)
+        loaded = nib.nifti1.Nifti1Image.from_filename(output_path)
         assert loaded.header.get_zooms()[:3] == pytest.approx((1.0, 1.0, 2.0))
 
     def test_save_creates_sidecar(self, tmp_path, sample_3d_volume):
@@ -1756,7 +1762,7 @@ class TestSaveNifti:
 
         save_nifti(da, output_path)
 
-        loaded = nib.load(output_path)
+        loaded = nib.nifti1.Nifti1Image.from_filename(output_path)
         assert loaded.get_data_dtype() == np.dtype(np.uint8)
         np.testing.assert_array_equal(
             np.asarray(loaded.dataobj),
@@ -1770,7 +1776,7 @@ class TestSaveNifti:
         output_path = tmp_path / "output_nifti2.nii"
         save_nifti(da, output_path, nifti_version=2)
 
-        loaded = nib.load(output_path)
+        loaded = nib.nifti1.Nifti1Image.from_filename(output_path)
         assert isinstance(loaded, nib.nifti2.Nifti2Image)
 
     def test_save_valid_derived_metadata_emits_no_validation_warning(
@@ -2283,7 +2289,7 @@ class TestSaveNifti:
         output_path = tmp_path / "selected_qform.nii.gz"
         save_nifti(da, output_path, qform="physical_to_template")
 
-        loaded = nib.load(output_path)
+        loaded = nib.nifti1.Nifti1Image.from_filename(output_path)
         q = loaded.header.get_qform()
         np.testing.assert_allclose(q[:3, :3], np.eye(3), atol=1e-6)
 
@@ -2304,7 +2310,7 @@ class TestSaveNifti:
         output_path = tmp_path / "default_qform_key.nii.gz"
         save_nifti(da, output_path)
 
-        loaded = nib.load(output_path)
+        loaded = nib.nifti1.Nifti1Image.from_filename(output_path)
         np.testing.assert_allclose(
             loaded.header.get_qform()[:3, :3], np.diag([3.0, 3.0, 3.0]), atol=1e-6
         )
@@ -2326,7 +2332,7 @@ class TestSaveNifti:
         output_path = tmp_path / "named_sform.nii.gz"
         save_nifti(da, output_path, sform="physical_to_template")
 
-        loaded = nib.load(output_path)
+        loaded = nib.nifti1.Nifti1Image.from_filename(output_path)
         assert loaded.header.get_sform(coded=True)[1] == 1
 
     def test_named_sform_code_kwarg_overrides_attrs(self, tmp_path):
@@ -2349,7 +2355,7 @@ class TestSaveNifti:
         output_path = tmp_path / "sform_code_override.nii.gz"
         save_nifti(da, output_path, sform="physical_to_sform", sform_code=2)
 
-        loaded = nib.load(output_path)
+        loaded = nib.nifti1.Nifti1Image.from_filename(output_path)
         assert loaded.header.get_sform(coded=True)[1] == 2
 
     def test_explicit_qform_code_kwarg_overrides_attrs(self, tmp_path):
@@ -2368,7 +2374,7 @@ class TestSaveNifti:
         output_path = tmp_path / "qform_code_override.nii.gz"
         save_nifti(da, output_path, qform_code=2)
 
-        loaded = nib.load(output_path)
+        loaded = nib.nifti1.Nifti1Image.from_filename(output_path)
         assert loaded.header.get_qform(coded=True)[1] == 2
 
     def test_form_codes_from_attrs_used_when_no_kwarg(self, tmp_path):
@@ -2392,7 +2398,7 @@ class TestSaveNifti:
         output_path = tmp_path / "codes_from_attrs.nii.gz"
         save_nifti(da, output_path)
 
-        loaded = nib.load(output_path)
+        loaded = nib.nifti1.Nifti1Image.from_filename(output_path)
         assert loaded.header.get_qform(coded=True)[1] == 2
         assert loaded.header.get_sform(coded=True)[1] == 2
 
@@ -2433,7 +2439,7 @@ class TestSaveNifti:
         output_path = tmp_path / "no_sform.nii.gz"
         save_nifti(da, output_path)
 
-        loaded = nib.load(output_path)
+        loaded = nib.nifti1.Nifti1Image.from_filename(output_path)
         assert loaded.header.get_sform(coded=True)[1] == 0
 
 
@@ -2468,7 +2474,7 @@ class TestRoundtrip:
 
         out_path = tmp_path / "out.nii.gz"
         save_nifti(load_nifti(in_path), out_path)
-        reloaded = nib.load(out_path)
+        reloaded = nib.nifti1.Nifti1Image.from_filename(out_path)
 
         # sform survives (primary frame); qform must survive too.
         np.testing.assert_allclose(
@@ -2502,7 +2508,7 @@ class TestRoundtrip:
         da, _ = apply_affine(da, da.attrs["affines"]["physical_to_qform"])
         out_path = tmp_path / "out.nii.gz"
         save_nifti(da, out_path)
-        reloaded = nib.load(out_path)
+        reloaded = nib.nifti1.Nifti1Image.from_filename(out_path)
 
         np.testing.assert_allclose(
             reloaded.header.get_qform(coded=True)[0], qform, atol=1e-4
@@ -2721,7 +2727,9 @@ class TestRoundtrip:
         assert sidecar["VolumeTiming"] == pytest.approx(time_values.tolist())
         assert sidecar["FrameAcquisitionDuration"] == pytest.approx(4.6)
         assert "RepetitionTime" not in sidecar
-        assert nib.load(nifti_path).header.get_zooms()[3] == pytest.approx(0.0)
+        assert nib.nifti1.Nifti1Image.from_filename(nifti_path).header.get_zooms()[
+            3
+        ] == pytest.approx(0.0)
 
         loaded = load_nifti(nifti_path)
         np.testing.assert_allclose(loaded.coords["time"].values, time_values)

--- a/tests/unit/test_iq/test_process.py
+++ b/tests/unit/test_iq/test_process.py
@@ -1,5 +1,7 @@
 """Unit tests for IQ processing functions."""
 
+from typing import Literal, NotRequired, TypedDict
+
 import dask.array as da
 import numpy as np
 import numpy.typing as npt
@@ -17,6 +19,14 @@ from confusius.iq.process import (
     process_iq_to_bmode,
     process_iq_to_power_doppler,
 )
+
+
+class _ProcessedTimingKwargs(TypedDict):
+    clutter_window_width: int
+    clutter_window_stride: int
+    inner_window_width: int
+    inner_window_stride: int
+    processed_time_reference: NotRequired[Literal["start", "center", "end"]]
 
 
 class TestComputeProcessedVolumeTimes:
@@ -167,29 +177,36 @@ class TestComputeProcessedVolumeTimes:
                     },
                 )
             )
-            kwargs = dict(processed_time_reference="start")
+            with pytest.raises(ValueError, match=bad_ref_kwarg):
+                compute_processed_volume_timings(
+                    iq,
+                    clutter_window_width=10,
+                    clutter_window_stride=10,
+                    inner_window_width=10,
+                    inner_window_stride=10,
+                    processed_time_reference="start",
+                )
         else:
-            kwargs = dict(processed_time_reference="invalid")
-
-        kwargs.update(
-            clutter_window_width=10,
-            clutter_window_stride=10,
-            inner_window_width=10,
-            inner_window_stride=10,
-        )
-        with pytest.raises(ValueError, match=bad_ref_kwarg):
-            compute_processed_volume_timings(iq, **kwargs)
+            with pytest.raises(ValueError, match=bad_ref_kwarg):
+                compute_processed_volume_timings(
+                    iq,
+                    clutter_window_width=10,
+                    clutter_window_stride=10,
+                    inner_window_width=10,
+                    inner_window_stride=10,
+                    processed_time_reference="invalid",  # ty: ignore[invalid-argument-type]
+                )
 
     def test_matches_docstring_example(self):
         """Result matches the examples from the docstring."""
         iq = self._make_iq(np.arange(100) * 0.1, volume_acquisition_duration=0.1)
-        kwargs = dict(
-            clutter_window_width=50,
-            clutter_window_stride=50,
-            inner_window_width=50,
-            inner_window_stride=50,
-            processed_time_reference="start",
-        )
+        kwargs: _ProcessedTimingKwargs = {
+            "clutter_window_width": 50,
+            "clutter_window_stride": 50,
+            "inner_window_width": 50,
+            "inner_window_stride": 50,
+            "processed_time_reference": "start",
+        }
         output_times, output_durations = compute_processed_volume_timings(iq, **kwargs)
         assert_allclose(
             output_times,
@@ -197,7 +214,12 @@ class TestComputeProcessedVolumeTimes:
         )
         assert_allclose(output_durations, [5.0, 5.0])
         output_times, output_durations = compute_processed_volume_timings(
-            iq, **{**kwargs, "processed_time_reference": "center"}
+            iq,
+            clutter_window_width=kwargs["clutter_window_width"],
+            clutter_window_stride=kwargs["clutter_window_stride"],
+            inner_window_width=kwargs["inner_window_width"],
+            inner_window_stride=kwargs["inner_window_stride"],
+            processed_time_reference="center",
         )
         assert_allclose(
             output_times,

--- a/tests/unit/test_multipose/test_slice_timing.py
+++ b/tests/unit/test_multipose/test_slice_timing.py
@@ -377,5 +377,5 @@ class TestCorrectSliceTiming:
         with pytest.raises(ValueError, match="broadcast"):
             correct_slice_timings(
                 consolidated_scan_4d.load(),
-                fill_value=(1.0, 2.0, 3.0),  # type: ignore[arg-type]
+                fill_value=(1.0, 2.0, 3.0),  # ty: ignore[invalid-argument-type]
             )

--- a/tests/unit/test_napari/test_signal_manager.py
+++ b/tests/unit/test_napari/test_signal_manager.py
@@ -14,8 +14,12 @@ def test_manager_refreshes_rows_from_store(qtbot, signals_store, signals_csv):
     qtbot.addWidget(dialog)
 
     assert dialog._table.rowCount() == 2
-    assert dialog._table.item(0, 1).text() == "a"
-    assert dialog._table.item(1, 3).text() == "series.csv"
+    name_item = dialog._table.item(0, 1)
+    file_item = dialog._table.item(1, 3)
+    assert name_item is not None
+    assert file_item is not None
+    assert name_item.text() == "a"
+    assert file_item.text() == "series.csv"
 
 
 def test_manager_applies_store_mutations(
@@ -26,10 +30,12 @@ def test_manager_applies_store_mutations(
     qtbot.addWidget(dialog)
 
     name_item = dialog._table.item(0, 1)
+    assert name_item is not None
     name_item.setText("baseline")
     assert signals_store.imported_signals()[0].name == "baseline"
 
     visible_item = dialog._table.item(0, 0)
+    assert visible_item is not None
     visible_item.setCheckState(Qt.CheckState.Unchecked)
     assert signals_store.imported_signals()[0].visible is False
 

--- a/tests/unit/test_napari/test_utils.py
+++ b/tests/unit/test_napari/test_utils.py
@@ -29,6 +29,7 @@ def test_recolor_toolbar_icons_preserves_disabled_state(qtbot):
     qtbot.addWidget(toolbar)
 
     action = toolbar.addAction("Back")
+    assert action is not None
     action.setIcon(_solid_icon("#000000"))
 
     recolor_toolbar_icons(toolbar, "#ffffff")
@@ -50,6 +51,7 @@ def test_recolor_toolbar_icons_uses_original_icon_on_retheme(qtbot):
     qtbot.addWidget(toolbar)
 
     action = toolbar.addAction("Back")
+    assert action is not None
     action.setIcon(_solid_icon("#000000"))
 
     recolor_toolbar_icons(toolbar, "#ffffff")

--- a/tests/unit/test_napari/test_video_panel.py
+++ b/tests/unit/test_napari/test_video_panel.py
@@ -53,7 +53,7 @@ def _inject_fake_video(panel, fv, *, frame_step=1, name="Video: test"):
     entry = _VideoEntry(
         path=Path(f"{name}.mp4"),
         video=fv,
-        frame_dtype=np.uint8,
+        frame_dtype=np.dtype(np.uint8),
         frame_shape=fv.frame_shape,
         video_h=fv.frame_shape[0],
         video_w=fv.frame_shape[1],
@@ -66,6 +66,15 @@ def _inject_fake_video(panel, fv, *, frame_step=1, name="Video: test"):
     return entry
 
 
+def _video_array(fv, *, dtype, frame_shape, **kwargs):
+    return _VideoArray(
+        fv,
+        dtype=np.dtype(dtype),
+        frame_shape=frame_shape,
+        **kwargs,
+    )
+
+
 # ---------------------------------------------------------------------------
 # _VideoArray
 # ---------------------------------------------------------------------------
@@ -74,25 +83,25 @@ def _inject_fake_video(panel, fv, *, frame_step=1, name="Video: test"):
 class TestVideoArray:
     def test_integer_index(self):
         fv = _FakeVideo(n_frames=5, h=4, w=6)
-        arr = _VideoArray(fv, dtype=np.uint8, frame_shape=(4, 6))
+        arr = _video_array(fv, dtype=np.uint8, frame_shape=(4, 6))
         np.testing.assert_array_equal(arr[2], fv[2])
 
     def test_slice_index(self):
         fv = _FakeVideo(n_frames=10, h=4, w=6)
-        arr = _VideoArray(fv, dtype=np.uint8, frame_shape=(4, 6))
+        arr = _video_array(fv, dtype=np.uint8, frame_shape=(4, 6))
         frames = arr[2:5]
         assert frames.shape == (3, 4, 6)
         np.testing.assert_array_equal(frames[0], fv[2])
 
     def test_tuple_index_with_spatial_slice(self):
         fv = _FakeVideo(n_frames=5, h=8, w=10)
-        arr = _VideoArray(fv, dtype=np.uint8, frame_shape=(8, 10))
+        arr = _video_array(fv, dtype=np.uint8, frame_shape=(8, 10))
         result = arr[1, :4, :5]
         np.testing.assert_array_equal(result, fv[1][:4, :5])
 
     def test_shape_dtype_len(self):
         fv = _FakeVideo(n_frames=8, h=16, w=32)
-        arr = _VideoArray(fv, dtype=np.float32, frame_shape=(16, 32))
+        arr = _video_array(fv, dtype=np.float32, frame_shape=(16, 32))
         assert arr.shape == (8, 16, 32)
         assert arr.dtype == np.float32
         assert len(arr) == 8
@@ -100,39 +109,39 @@ class TestVideoArray:
 
     def test_unsupported_index_raises(self):
         fv = _FakeVideo(n_frames=3, h=4, w=6)
-        arr = _VideoArray(fv, dtype=np.uint8, frame_shape=(4, 6))
+        arr = _video_array(fv, dtype=np.uint8, frame_shape=(4, 6))
         with pytest.raises(IndexError, match="Unsupported time index type"):
             arr[[0, 1]]
 
     def test_dimension_padding(self):
         fv = _FakeVideo(n_frames=5, h=4, w=6)
-        arr = _VideoArray(fv, dtype=np.uint8, frame_shape=(4, 6), n_pad=1)
+        arr = _video_array(fv, dtype=np.uint8, frame_shape=(4, 6), n_pad=1)
         assert arr.shape == (5, 1, 4, 6)
         # Integer index on pad dim should return the frame.
         np.testing.assert_array_equal(arr[2, 0], fv[2])
 
     def test_rgb_shape(self):
         fv = _FakeVideo(n_frames=5, h=4, w=6, rgb=True)
-        arr = _VideoArray(fv, dtype=np.uint8, frame_shape=(4, 6, 3))
+        arr = _video_array(fv, dtype=np.uint8, frame_shape=(4, 6, 3))
         assert arr.shape == (5, 4, 6, 3)
         np.testing.assert_array_equal(arr[1], fv[1])
 
     def test_rgb_with_padding(self):
         fv = _FakeVideo(n_frames=5, h=4, w=6, rgb=True)
-        arr = _VideoArray(fv, dtype=np.uint8, frame_shape=(4, 6, 3), n_pad=1)
+        arr = _video_array(fv, dtype=np.uint8, frame_shape=(4, 6, 3), n_pad=1)
         assert arr.shape == (5, 1, 4, 6, 3)
         np.testing.assert_array_equal(arr[2, 0], fv[2])
 
     def test_empty_slice(self):
         fv = _FakeVideo(n_frames=5, h=4, w=6)
-        arr = _VideoArray(fv, dtype=np.uint8, frame_shape=(4, 6))
+        arr = _video_array(fv, dtype=np.uint8, frame_shape=(4, 6))
         result = arr[3:3]
         assert result.shape == (0, 4, 6)
 
     def test_explicit_h_before_w(self):
         """VideoArray with H at dim 1, W at dim 3 (e.g. displaying z x)."""
         fv = _FakeVideo(n_frames=5, h=4, w=6)
-        arr = _VideoArray(
+        arr = _video_array(
             fv,
             dtype=np.uint8,
             frame_shape=(4, 6),
@@ -149,7 +158,7 @@ class TestVideoArray:
     def test_explicit_w_before_h(self):
         """VideoArray with W at dim 1, H at dim 3 (e.g. displaying x z)."""
         fv = _FakeVideo(n_frames=5, h=4, w=6)
-        arr = _VideoArray(
+        arr = _video_array(
             fv,
             dtype=np.uint8,
             frame_shape=(4, 6),
@@ -166,7 +175,7 @@ class TestVideoArray:
     def test_explicit_dims_rgb_with_transpose(self):
         """RGB video with W before H in layout."""
         fv = _FakeVideo(n_frames=5, h=4, w=6, rgb=True)
-        arr = _VideoArray(
+        arr = _video_array(
             fv,
             dtype=np.uint8,
             frame_shape=(4, 6, 3),
@@ -188,7 +197,7 @@ class TestVideoArray:
         fixes it, but _update_layers fires first with slice(None)).
         """
         fv = _FakeVideo(n_frames=1000, h=4, w=6)
-        arr = _VideoArray(fv, dtype=np.uint8, frame_shape=(4, 6))
+        arr = _video_array(fv, dtype=np.uint8, frame_shape=(4, 6))
         result = arr[slice(None), :, :]
         assert result.shape == (1, 4, 6)
         np.testing.assert_array_equal(result[0], fv[0])
@@ -196,7 +205,7 @@ class TestVideoArray:
     def test_bounded_time_slice_still_works(self):
         """Bounded slices (thick slicing / projections) decode normally."""
         fv = _FakeVideo(n_frames=20, h=4, w=6)
-        arr = _VideoArray(fv, dtype=np.uint8, frame_shape=(4, 6))
+        arr = _video_array(fv, dtype=np.uint8, frame_shape=(4, 6))
         result = arr[5:10]
         assert result.shape == (5, 4, 6)
         np.testing.assert_array_equal(result[0], fv[5])
@@ -394,7 +403,7 @@ class TestFrameStep:
     def test_frame_step_reduces_time_shape(self):
         """With step=3, time dimension is len(range(0, n_frames, step))."""
         fv = _FakeVideo(n_frames=12, h=4, w=6)
-        arr = _VideoArray(fv, dtype=np.uint8, frame_shape=(4, 6), step=3)
+        arr = _video_array(fv, dtype=np.uint8, frame_shape=(4, 6), step=3)
         # 12 frames with step 3: indices 0, 3, 6, 9 -> 4 logical frames.
         assert arr.shape == (4, 4, 6)
         # Logical frame 0 -> physical frame 0.

--- a/tests/unit/test_napari/test_writers.py
+++ b/tests/unit/test_napari/test_writers.py
@@ -407,8 +407,11 @@ class TestDaFromNapariLayer:
         from confusius._napari._io._writers import _compute_dataarray_from_layer
 
         # Simulate pint Unit objects as napari passes them.
-        pixel_unit = MagicMock()
-        pixel_unit.__str__ = lambda self: "pixel"
+        class _PixelUnit:
+            def __str__(self) -> str:
+                return "pixel"
+
+        pixel_unit = _PixelUnit()
 
         data = np.zeros((4,))
         da = _compute_dataarray_from_layer(

--- a/tests/unit/test_plotting/test_image.py
+++ b/tests/unit/test_plotting/test_image.py
@@ -17,6 +17,16 @@ from confusius.plotting import (
 )
 
 
+def _axes(plotter):
+    assert plotter.axes is not None
+    return plotter.axes
+
+
+def _figure(plotter):
+    assert plotter.figure is not None
+    return plotter.figure
+
+
 class TestPlotVolume:
     """Tests for plot_volume function."""
 
@@ -64,7 +74,7 @@ class TestPlotVolume:
         with pytest.warns(UserWarning, match="Complex-valued data"):
             plotter = plot_volume(complex_data, slice_mode="z", slice_coords=[z_coord])
 
-        plotted_values = plotter.axes[0, 0].collections[0].get_array().data
+        plotted_values = _axes(plotter)[0, 0].collections[0].get_array().data
         assert np.all(plotted_values >= 0)
 
     @pytest.mark.parametrize("threshold_mode", ["lower", "upper"])
@@ -86,7 +96,7 @@ class TestPlotVolume:
             threshold_mode=threshold_mode,
         )
 
-        ax = plotter.axes[0, 0]
+        ax = _axes(plotter)[0, 0]
         plotted_data = ax.collections[0].get_array()
         original_slice = sample_3d_volume.sel(z=z_coord, method="nearest").values
 
@@ -111,7 +121,7 @@ class TestPlotVolume:
             data, slice_mode="z", slice_coords=[z_coord], threshold=0.5
         )
         # norm(0) = 0.5, which is inside [-0.5, 0.5] — must map to gray.
-        r, g, b, _ = plotter.axes[0, 0].collections[0].cmap(0.5)
+        r, g, b, _ = _axes(plotter)[0, 0].collections[0].cmap(0.5)
         assert r == pytest.approx(g, abs=1e-2)
         assert g == pytest.approx(b, abs=1e-2)
 
@@ -135,7 +145,7 @@ class TestPlotVolume:
         )
         # Position 0.55 is between the wrong linear boundary (0.5) and the correct
         # norm boundary (≈0.667), so it must map to gray.
-        r, g, b, _ = plotter.axes[0, 0].collections[0].cmap(0.55)
+        r, g, b, _ = _axes(plotter)[0, 0].collections[0].cmap(0.55)
         assert r == pytest.approx(g, abs=1e-2)
         assert g == pytest.approx(b, abs=1e-2)
 
@@ -150,7 +160,7 @@ class TestPlotVolume:
             vmax=3.0,
         )
 
-        collection = plotter.axes[0, 0].collections[0]
+        collection = _axes(plotter)[0, 0].collections[0]
         assert collection.norm.vmin == pytest.approx(-3.0)
         assert collection.norm.vmax == pytest.approx(3.0)
 
@@ -171,7 +181,7 @@ class TestPlotVolume:
             show_colorbar=False,
         )
 
-        quadmesh = plotter.axes[0, 0].collections[0]
+        quadmesh = _axes(plotter)[0, 0].collections[0]
         quadmesh.update_scalarmappable()
         alphas = np.unique(quadmesh.get_facecolor()[:, 3])
         assert alphas.size > 0
@@ -182,8 +192,8 @@ class TestPlotVolume:
         z_coord = sample_3d_volume.coords["z"].values[0]
         plotter = plot_volume(sample_3d_volume, slice_mode="z", slice_coords=[z_coord])
 
-        plot_axes = set(plotter.axes.ravel())
-        extra_axes = [ax for ax in plotter.figure.axes if ax not in plot_axes]
+        plot_axes = set(_axes(plotter).ravel())
+        extra_axes = [ax for ax in _figure(plotter).axes if ax not in plot_axes]
         assert len(extra_axes) == 1
 
     def test_no_colorbar_when_disabled(self, sample_3d_volume, matplotlib_pyplot):
@@ -196,8 +206,8 @@ class TestPlotVolume:
             show_colorbar=False,
         )
 
-        plot_axes = set(plotter.axes.ravel())
-        extra_axes = [ax for ax in plotter.figure.axes if ax not in plot_axes]
+        plot_axes = set(_axes(plotter).ravel())
+        extra_axes = [ax for ax in _figure(plotter).axes if ax not in plot_axes]
         assert len(extra_axes) == 0
 
     def test_cbar_label_is_set(self, sample_3d_volume, matplotlib_pyplot):
@@ -210,8 +220,8 @@ class TestPlotVolume:
             cbar_label="Power (dB)",
         )
 
-        plot_axes = set(plotter.axes.ravel())
-        extra_axes = [ax for ax in plotter.figure.axes if ax not in plot_axes]
+        plot_axes = set(_axes(plotter).ravel())
+        extra_axes = [ax for ax in _figure(plotter).axes if ax not in plot_axes]
         assert len(extra_axes) == 1
         assert extra_axes[0].get_ylabel() == "Power (dB)"
 
@@ -228,14 +238,14 @@ class TestPlotVolume:
             cbar_label="Power (dB)",
         )
 
-        ax = plotter.axes[0, 0]
+        ax = _axes(plotter)[0, 0]
         assert ax.title.get_fontsize() == pytest.approx(20)
         assert ax.xaxis.label.get_fontsize() == pytest.approx(18)
         assert ax.yaxis.label.get_fontsize() == pytest.approx(18)
         assert ax.get_xticklabels()[0].get_fontsize() == pytest.approx(17)
 
-        plot_axes = set(plotter.axes.ravel())
-        cbar_axes = [ax for ax in plotter.figure.axes if ax not in plot_axes]
+        plot_axes = set(_axes(plotter).ravel())
+        cbar_axes = [ax for ax in _figure(plotter).axes if ax not in plot_axes]
         assert len(cbar_axes) == 1
         assert cbar_axes[0].yaxis.label.get_fontsize() == pytest.approx(18)
         assert cbar_axes[0].get_yticklabels()[0].get_fontsize() == pytest.approx(17)
@@ -295,14 +305,14 @@ class TestPlotVolume:
             sample_3d_volume, slice_mode="z", slice_coords=z_coords, nrows=2, ncols=2
         )
 
-        for ax in plotter.axes.ravel()[2:]:
+        for ax in _axes(plotter).ravel()[2:]:
             assert not ax.get_visible()
 
     def test_axis_limits_match_data_edges(self, sample_3d_volume, matplotlib_pyplot):
         """Axes limits exactly equal data edges — no matplotlib auto-margin."""
         z_coord = sample_3d_volume.coords["z"].values[0]
         plotter = plot_volume(sample_3d_volume, slice_mode="z", slice_coords=[z_coord])
-        ax = plotter.axes[0, 0]
+        ax = _axes(plotter)[0, 0]
 
         x_centers = sample_3d_volume.coords["x"].values.astype(float)
         y_centers = sample_3d_volume.coords["y"].values.astype(float)
@@ -323,7 +333,7 @@ class TestPlotVolume:
         plotter = plot_volume(
             data, slice_mode="z", slice_coords=[0], show_colorbar=False
         )
-        ax = plotter.axes[0, 0]
+        ax = _axes(plotter)[0, 0]
 
         assert ax.get_xlim() == pytest.approx((0.0, 5.0))
         assert ax.get_ylim() == pytest.approx((4.0, 0.0))
@@ -340,7 +350,7 @@ class TestPlotVolume:
             yincrease=True,
             show_colorbar=False,
         )
-        ax = plotter.axes[0, 0]
+        ax = _axes(plotter)[0, 0]
         y_centers = sample_3d_volume.coords["y"].values.astype(float)
         dy = y_centers[1] - y_centers[0]
         assert ax.get_ylim() == pytest.approx(
@@ -402,9 +412,9 @@ class TestPlotVolume:
         )
         # Should plot single slice without error
         plotter = plot_volume(data, slice_mode="z", show_colorbar=False)
-        assert plotter.axes.shape == (1, 1)
+        assert _axes(plotter).shape == (1, 1)
         # Verify the slice was plotted
-        assert len(plotter.axes[0, 0].collections) == 1
+        assert len(_axes(plotter)[0, 0].collections) == 1
 
     def test_non_monotonic_coords_are_sorted_before_plotting(
         self, sample_3d_volume, matplotlib_pyplot
@@ -416,7 +426,7 @@ class TestPlotVolume:
         plotter = plot_volume(
             data, slice_mode="z", slice_coords=[z_coord], show_colorbar=False
         )
-        ax = plotter.axes[0, 0]
+        ax = _axes(plotter)[0, 0]
 
         y_sorted = np.sort(data.coords["y"].values.astype(float))
         x_sorted = np.sort(data.coords["x"].values.astype(float))
@@ -472,7 +482,7 @@ class TestVolumePlotterAddVolume:
         subset = sample_3d_volume.sel(z=sample_3d_volume.coords["z"].values[:2])
         plotter.add_volume(subset, cmap="hot", alpha=0.5, show_colorbar=False)
 
-        axes_flat = plotter.axes.ravel()
+        axes_flat = _axes(plotter).ravel()
         assert len(axes_flat[0].collections) == 2
         assert len(axes_flat[1].collections) == 2
         assert len(axes_flat[2].collections) == 1
@@ -507,7 +517,7 @@ class TestVolumePlotterAddVolume:
             sample_3d_volume, match_coordinates=False, alpha=alpha
         )
 
-        axes_flat = plotter.axes.ravel()
+        axes_flat = _axes(plotter).ravel()
         npt.assert_allclose(axes_flat[0].collections[0].get_alpha(), 0.25)
         npt.assert_allclose(axes_flat[1].collections[0].get_alpha(), 0.75)
 
@@ -528,7 +538,7 @@ class TestVolumePlotterAddVolume:
 
         plotter = plot_volume(descending, alpha=alpha)
 
-        axes_flat = plotter.axes.ravel()
+        axes_flat = _axes(plotter).ravel()
         npt.assert_allclose(axes_flat[0].collections[0].get_alpha(), 0.25)
         npt.assert_allclose(axes_flat[1].collections[0].get_alpha(), 0.75)
 
@@ -602,7 +612,7 @@ class TestNonNumericSliceMode:
             data, slice_mode="region", slice_coords=["b"], show_colorbar=False
         )
 
-        ax = plotter.axes[0, 0]
+        ax = _axes(plotter)[0, 0]
         np.testing.assert_array_equal(
             ax.collections[0].get_array().data, data.sel(region="b").values
         )
@@ -649,7 +659,7 @@ class TestNonNumericSliceMode:
         )
         plotter = plot_volume(data, slice_mode="region", show_colorbar=False)
 
-        titles = [ax.get_title() for ax in plotter.axes.ravel()]
+        titles = [ax.get_title() for ax in _axes(plotter).ravel()]
         assert titles == [f"region = {region}" for region in regions]
 
 
@@ -676,7 +686,7 @@ class TestVolumePlotterUtilities:
         import matplotlib.pyplot as plt
 
         plotter = plot_volume(sample_3d_volume, slice_mode="z")
-        fig_num = plotter.figure.number
+        fig_num = _figure(plotter).number
 
         plotter.close()
 
@@ -767,7 +777,7 @@ class TestPlotContours:
             coords={"z": [0.0], "y": [0.0, 0.5, 1.0, 1.5], "x": [0.0, 0.5, 1.0, 1.5]},
         )
         plotter = plot_contours(mask, slice_mode="z", fontsize=16)
-        ax = plotter.axes[0, 0]
+        ax = _axes(plotter)[0, 0]
 
         assert ax.title.get_fontsize() == pytest.approx(16)
         assert ax.xaxis.label.get_fontsize() == pytest.approx(14.4)
@@ -801,7 +811,7 @@ class TestVolumePlotterAddContours:
         mask = self._make_mask(sample_3d_volume, [0, 1])
         plotter.add_contours(mask, colors="red")
 
-        axes_flat = plotter.axes.ravel()
+        axes_flat = _axes(plotter).ravel()
         assert len(axes_flat[0].lines) > 0
         assert len(axes_flat[1].lines) > 0
         assert len(axes_flat[2].lines) == 0
@@ -902,7 +912,7 @@ class TestRoiHover:
             show_colorbar=False,
             roi_labels=roi_labels,
         )
-        ax = atlas_plotter.axes.flat[0]
+        ax = _axes(atlas_plotter).flat[0]
         self._fire_motion(ax, x, y)
         assert (
             ax.format_coord(x, y)
@@ -919,7 +929,7 @@ class TestRoiHover:
         volume_plotter = plot_volume(
             volume, slice_mode="z", slice_coords=[0.0], show_colorbar=False
         )
-        ax = volume_plotter.axes.flat[0]
+        ax = _axes(volume_plotter).flat[0]
         self._fire_motion(ax, x, y)
         assert (
             ax.format_coord(x, y) == f"x={x:.3g}, y={y:.3g}; pd={sampled_value:.4g} dB"
@@ -931,7 +941,7 @@ class TestRoiHover:
             volume, slice_coords=[0.0], match_coordinates=False, show_colorbar=False
         )
         overlay.add_contours(labels, slice_coords=[0.0], roi_labels=roi_labels)
-        ax = overlay.axes.flat[0]
+        ax = _axes(overlay).flat[0]
         self._fire_motion(ax, x, y)
         assert (
             ax.format_coord(x, y) == f"x={x:.3g}, y={y:.3g}; pd={sampled_value:.4g} dB"
@@ -973,8 +983,8 @@ class TestRoiHover:
             show_colorbar=False,
             roi_labels=roi_labels,
         )
-        fig = plotter.figure
-        ax = plotter.axes.flat[0]
+        fig = _figure(plotter)
+        ax = _axes(plotter).flat[0]
         plotter_ref = weakref.ref(plotter)
         manager_ref = weakref.ref(plotter._hover_manager)
         assert manager_ref() in _CONFUSIUS_HOVER_MANAGERS

--- a/tests/unit/test_plotting/test_image_composite.py
+++ b/tests/unit/test_plotting/test_image_composite.py
@@ -8,6 +8,11 @@ import xarray as xr
 from confusius.plotting import VolumePlotter, plot_composite
 
 
+def _axes(plotter):
+    assert plotter.axes is not None
+    return plotter.axes
+
+
 def _shifted_volume(template: xr.DataArray, shift: float = 0.07) -> xr.DataArray:
     """Return a second volume on the same grid as `template` with shifted values."""
     return xr.DataArray(
@@ -39,7 +44,7 @@ class TestAddCompositeChannels:
             lo, hi = arr.min(), arr.max()
             return (arr - lo) / (hi - lo) if hi > lo else np.zeros_like(arr)
 
-        rgb = plotter.axes[0, 0].collections[0].get_array()
+        rgb = _axes(plotter)[0, 0].collections[0].get_array()
         assert rgb.shape == (data1.sizes["y"], data1.sizes["x"], 3)
         npt.assert_allclose(rgb[..., 0], _norm(slice1), atol=1e-6)
         npt.assert_allclose(rgb[..., 1], _norm(slice2), atol=1e-6)
@@ -66,10 +71,10 @@ class TestAddCompositeResample:
         )
 
         # All panels should be rendered at data1's (y, x) shape.
-        rgb0 = plotter.axes[0, 0].collections[0].get_array()
+        rgb0 = _axes(plotter)[0, 0].collections[0].get_array()
         assert rgb0.shape == (data1.sizes["y"], data1.sizes["x"], 3)
         # And we should get one panel per data1 z-slice.
-        rendered = [ax for ax in plotter.axes.ravel() if ax.collections]
+        rendered = [ax for ax in _axes(plotter).ravel() if ax.collections]
         assert len(rendered) == data1.sizes["z"]
 
     def test_resample_false_shape_mismatch_raises(
@@ -107,7 +112,7 @@ class TestAddCompositeResample:
         )
 
         # The rendered xlim should sit on data1's coordinate centre.
-        x_min, x_max = plotter.axes.ravel()[0].get_xlim()
+        x_min, x_max = _axes(plotter).ravel()[0].get_xlim()
         xlim_mid = 0.5 * (x_min + x_max)
         data1_mid = 0.5 * (float(x_coords.min()) + float(x_coords.max()))
         assert abs(xlim_mid - data1_mid) < 1e-6
@@ -126,7 +131,7 @@ class TestAddCompositeResample:
             sample_3d_volume, data2, resample=False, atol=1.0
         )
 
-        x_min, x_max = plotter.axes.ravel()[0].get_xlim()
+        x_min, x_max = _axes(plotter).ravel()[0].get_xlim()
         xlim_mid = 0.5 * (x_min + x_max)
         data1_mid = 0.5 * (float(x_coords.min()) + float(x_coords.max()))
         data2_mid = data1_mid + x_shift
@@ -167,7 +172,7 @@ class TestAddCompositeResampleKwargs:
         # Under shared normalisation the range spans [data1.min(), 5.0]; the
         # fill value 5.0 normalises to 1.0, so no cyan voxel should exceed the
         # cyan contribution from in-FOV data2 voxels.
-        rgb0 = plotter.axes[0, 0].collections[0].get_array()
+        rgb0 = _axes(plotter)[0, 0].collections[0].get_array()
         # Cyan channel (G == B). All voxels in data2 have the same value (5.0),
         # so after normalisation the cyan channel should be uniform at 1.0.
         npt.assert_allclose(rgb0[..., 1], 1.0, atol=1e-5)
@@ -180,7 +185,7 @@ class TestAddCompositeResampleKwargs:
             data1, data2, resample=True, normalize_strategy="shared",
             resample_kwargs={"default_value": 0.0},
         )
-        rgb0 = plotter.axes[0, 0].collections[0].get_array()
+        rgb0 = _axes(plotter)[0, 0].collections[0].get_array()
         # range is [min(data1), 5.0]. fill=0.0 normalises to something < in-FOV.
         # At least some out-of-FOV cyan voxels should be < 1.0 (since fill < max).
         assert float(rgb0[..., 1].min()) < 1.0
@@ -210,11 +215,11 @@ class TestAddCompositeNormalize:
         # The dim slices share the same volume-wide normalisation, so their max
         # in the red channel should stay well below 1.0.
         dim_max = max(
-            float(plotter.axes.ravel()[i].collections[0].get_array()[..., 0].max())
+            float(_axes(plotter).ravel()[i].collections[0].get_array()[..., 0].max())
             for i in range(data1.sizes["z"] - 1)
         )
         bright_max = float(
-            plotter.axes.ravel()[data1.sizes["z"] - 1]
+            _axes(plotter).ravel()[data1.sizes["z"] - 1]
             .collections[0]
             .get_array()[..., 0]
             .max()
@@ -228,7 +233,7 @@ class TestAddCompositeNormalize:
             data1, data2, resample=False, normalize_strategy="per_slice"
         )
         for i in range(data1.sizes["z"]):
-            rgb = plotter.axes.ravel()[i].collections[0].get_array()
+            rgb = _axes(plotter).ravel()[i].collections[0].get_array()
             assert float(rgb[..., 0].max()) == pytest.approx(1.0, abs=1e-6)
 
     def test_shared_uses_one_range(self, sample_3d_volume, matplotlib_pyplot):
@@ -249,11 +254,11 @@ class TestAddCompositeNormalize:
             data1, data2, resample=False, normalize_strategy="shared"
         )
         red_max = max(
-            float(plotter.axes.ravel()[i].collections[0].get_array()[..., 0].max())
+            float(_axes(plotter).ravel()[i].collections[0].get_array()[..., 0].max())
             for i in range(data1.sizes["z"])
         )
         cyan_max = max(
-            float(plotter.axes.ravel()[i].collections[0].get_array()[..., 1].max())
+            float(_axes(plotter).ravel()[i].collections[0].get_array()[..., 1].max())
             for i in range(data1.sizes["z"])
         )
         assert red_max == pytest.approx(0.25, abs=1e-6)
@@ -280,7 +285,7 @@ class TestAddCompositeValidation:
                 sample_3d_volume,
                 sample_3d_volume,
                 resample=False,
-                normalize_strategy="foo",  # type: ignore[arg-type]
+                normalize_strategy="foo",  # ty: ignore[invalid-argument-type]
             )
 
 
@@ -331,7 +336,7 @@ class TestPlotComposite:
     ):
         plotter = plot_composite(sample_3d_volume, sample_3d_volume, resample=False)
         assert isinstance(plotter, VolumePlotter)
-        rendered = [ax for ax in plotter.axes.ravel() if ax.collections]
+        rendered = [ax for ax in _axes(plotter).ravel() if ax.collections]
         assert len(rendered) == sample_3d_volume.sizes["z"]
 
     def test_forwards_slice_mode_to_volume_plotter(
@@ -341,7 +346,7 @@ class TestPlotComposite:
             sample_3d_volume, sample_3d_volume, resample=False, slice_mode="y"
         )
         assert plotter.slice_mode == "y"
-        rendered = [ax for ax in plotter.axes.ravel() if ax.collections]
+        rendered = [ax for ax in _axes(plotter).ravel() if ax.collections]
         assert len(rendered) == sample_3d_volume.sizes["y"]
 
     def test_rejects_time_dim(self, sample_3dt_volume, matplotlib_pyplot):
@@ -402,7 +407,7 @@ class TestCompositeAccessor:
 
         plotter = sample_3d_volume.fusi.plot.composite(sample_3d_volume, resample=False)
         assert isinstance(plotter, VolumePlotter)
-        rendered = [ax for ax in plotter.axes.ravel() if ax.collections]
+        rendered = [ax for ax in _axes(plotter).ravel() if ax.collections]
         assert len(rendered) == sample_3d_volume.sizes["z"]
 
     def test_accessor_shared_normalize(self, sample_3d_volume, matplotlib_pyplot):
@@ -412,5 +417,5 @@ class TestCompositeAccessor:
             sample_3d_volume, resample=False, normalize_strategy="shared"
         )
         # data1 == data2, so red and cyan channels must be pointwise equal.
-        rgb = plotter.axes.ravel()[0].collections[0].get_array()
+        rgb = _axes(plotter).ravel()[0].collections[0].get_array()
         npt.assert_allclose(rgb[..., 0], rgb[..., 1])

--- a/tests/unit/test_plotting/test_image_stat_map.py
+++ b/tests/unit/test_plotting/test_image_stat_map.py
@@ -7,6 +7,11 @@ import xarray as xr
 from confusius.plotting import VolumePlotter, plot_stat_map
 
 
+def _axes(plotter):
+    assert plotter.axes is not None
+    return plotter.axes
+
+
 def _signed_stat_map(template: xr.DataArray) -> xr.DataArray:
     """Return a stat map on `template`'s grid with known signed values.
 
@@ -113,7 +118,7 @@ class TestPlotStatMapVisualRegression:
     def test_plot_stat_map_non_diverging(self, matplotlib_pyplot):
         """Baseline test for a non-diverging statistic (auto-detected: sequential + viridis)."""
         bg_volume, stat_map = _create_deterministic_bg_and_stat_map()
-        plotter = plot_stat_map(np.abs(stat_map), bg_volume=bg_volume, slice_mode="z")
+        plotter = plot_stat_map(abs(stat_map), bg_volume=bg_volume, slice_mode="z")
         return plotter.figure
 
 
@@ -124,7 +129,7 @@ class TestPlotStatMap:
         stat_map = _signed_stat_map(sample_3d_volume)
         plotter = plot_stat_map(stat_map, bg_volume=sample_3d_volume, slice_mode="z")
         assert isinstance(plotter, VolumePlotter)
-        rendered = [ax for ax in plotter.axes.ravel() if ax.collections]
+        rendered = [ax for ax in _axes(plotter).ravel() if ax.collections]
         assert len(rendered) == sample_3d_volume.sizes["z"]
         # Background + overlay were both drawn on every panel.
         assert all(len(ax.collections) == 2 for ax in rendered)
@@ -133,7 +138,7 @@ class TestPlotStatMap:
         stat_map = _signed_stat_map(sample_3d_volume)
         plotter = plot_stat_map(stat_map, bg_volume=sample_3d_volume, slice_mode="y")
         assert plotter.slice_mode == "y"
-        rendered = [ax for ax in plotter.axes.ravel() if ax.collections]
+        rendered = [ax for ax in _axes(plotter).ravel() if ax.collections]
         assert len(rendered) == sample_3d_volume.sizes["y"]
 
     def test_overlay_sets_no_explicit_alpha_by_default(
@@ -143,7 +148,7 @@ class TestPlotStatMap:
         through (the default colormaps are opaque)."""
         stat_map = _signed_stat_map(sample_3d_volume)
         plotter = plot_stat_map(stat_map, bg_volume=sample_3d_volume, slice_mode="z")
-        overlay = plotter.axes.ravel()[0].collections[-1]
+        overlay = _axes(plotter).ravel()[0].collections[-1]
         assert overlay.get_alpha() is None
 
     def test_explicit_alpha_blends_overlay_with_background(
@@ -153,7 +158,7 @@ class TestPlotStatMap:
         plotter = plot_stat_map(
             stat_map, bg_volume=sample_3d_volume, slice_mode="z", alpha=0.5
         )
-        overlay = plotter.axes.ravel()[0].collections[-1]
+        overlay = _axes(plotter).ravel()[0].collections[-1]
         assert overlay.get_alpha() == 0.5
 
     def test_overlay_uses_coolwarm_by_default_for_signed_data(
@@ -161,7 +166,7 @@ class TestPlotStatMap:
     ):
         stat_map = _signed_stat_map(sample_3d_volume)
         plotter = plot_stat_map(stat_map, bg_volume=sample_3d_volume, slice_mode="z")
-        overlay = plotter.axes.ravel()[0].collections[-1]
+        overlay = _axes(plotter).ravel()[0].collections[-1]
         assert overlay.cmap.name.startswith("coolwarm")
 
     def test_default_bounds_are_symmetric_min_max_for_signed_data(
@@ -169,7 +174,7 @@ class TestPlotStatMap:
     ):
         stat_map = _signed_stat_map(sample_3d_volume)
         plotter = plot_stat_map(stat_map, bg_volume=sample_3d_volume, slice_mode="z")
-        norm = plotter.axes.ravel()[0].collections[-1].norm
+        norm = _axes(plotter).ravel()[0].collections[-1].norm
         assert norm.vmax == 10.0
         assert norm.vmin == -10.0
 
@@ -180,7 +185,7 @@ class TestPlotStatMap:
         plotter = plot_stat_map(
             stat_map, bg_volume=sample_3d_volume, slice_mode="z", vmin=-5.0, vmax=5.0
         )
-        norm = plotter.axes.ravel()[0].collections[-1].norm
+        norm = _axes(plotter).ravel()[0].collections[-1].norm
         assert norm.vmax == 5.0
         assert norm.vmin == -5.0
 
@@ -193,7 +198,7 @@ class TestPlotStatMap:
         plotter = plot_stat_map(
             stat_map, bg_volume=sample_3d_volume, slice_mode="z", vmax=5.0
         )
-        norm = plotter.axes.ravel()[0].collections[-1].norm
+        norm = _axes(plotter).ravel()[0].collections[-1].norm
         assert norm.vmax == 10.0
         assert norm.vmin == -10.0
 
@@ -202,7 +207,7 @@ class TestPlotStatMap:
     ):
         stat_map = _nonneg_stat_map(sample_3d_volume)  # min=0, max=10
         plotter = plot_stat_map(stat_map, bg_volume=sample_3d_volume, slice_mode="z")
-        overlay = plotter.axes.ravel()[0].collections[-1]
+        overlay = _axes(plotter).ravel()[0].collections[-1]
         assert overlay.cmap.name.startswith("viridis")
         assert overlay.norm.vmin == 0.0
         assert overlay.norm.vmax == 10.0
@@ -212,7 +217,7 @@ class TestPlotStatMap:
     ):
         stat_map = -_nonneg_stat_map(sample_3d_volume)  # min=-10, max=0
         plotter = plot_stat_map(stat_map, bg_volume=sample_3d_volume, slice_mode="z")
-        overlay = plotter.axes.ravel()[0].collections[-1]
+        overlay = _axes(plotter).ravel()[0].collections[-1]
         assert overlay.cmap.name.startswith("viridis_r")
         assert overlay.norm.vmin == -10.0
         assert overlay.norm.vmax == 0.0
@@ -229,7 +234,7 @@ class TestPlotStatMap:
             vmax=5.0,
             auto_range=False,
         )
-        overlay = plotter.axes.ravel()[0].collections[-1]
+        overlay = _axes(plotter).ravel()[0].collections[-1]
         assert overlay.cmap.name.startswith("coolwarm")
         assert overlay.norm.vmin == -2.0
         assert overlay.norm.vmax == 5.0
@@ -241,7 +246,7 @@ class TestPlotStatMap:
         plotter = plot_stat_map(
             stat_map, bg_volume=sample_3d_volume, slice_mode="z", cmap="hot"
         )
-        overlay = plotter.axes.ravel()[0].collections[-1]
+        overlay = _axes(plotter).ravel()[0].collections[-1]
         assert overlay.cmap.name.startswith("hot")
 
     def test_threshold_masks_overlay(self, sample_3d_volume, matplotlib_pyplot):
@@ -253,7 +258,7 @@ class TestPlotStatMap:
             threshold=9.0,
             threshold_mode="lower",
         )
-        overlay = plotter.axes.ravel()[0].collections[-1]
+        overlay = _axes(plotter).ravel()[0].collections[-1]
         arr = overlay.get_array()
         assert np.ma.is_masked(arr)
 
@@ -267,7 +272,7 @@ class TestPlotStatMap:
             slice_mode="z",
             bg_kwargs={"cmap": "hot", "vmin": 0.0, "vmax": 1.0},
         )
-        background = plotter.axes.ravel()[0].collections[0]
+        background = _axes(plotter).ravel()[0].collections[0]
         assert background.cmap.name.startswith("hot")
         assert background.norm.vmin == 0.0
         assert background.norm.vmax == 1.0
@@ -284,7 +289,7 @@ class TestPlotStatMap:
         plotter = plot_stat_map(
             stat_map, bg_volume=bg_volume, slice_mode="z", alpha=alpha
         )
-        overlay = plotter.axes.ravel()[0].collections[-1]
+        overlay = _axes(plotter).ravel()[0].collections[-1]
         assert overlay.get_alpha() == pytest.approx(0.5)
 
     def test_without_background_plots_stat_map_alone(
@@ -292,7 +297,7 @@ class TestPlotStatMap:
     ):
         stat_map = _signed_stat_map(sample_3d_volume)
         plotter = plot_stat_map(stat_map, slice_mode="z")
-        rendered = [ax for ax in plotter.axes.ravel() if ax.collections]
+        rendered = [ax for ax in _axes(plotter).ravel() if ax.collections]
         assert len(rendered) == stat_map.sizes["z"]
         assert all(len(ax.collections) == 1 for ax in rendered)
         norm = rendered[0].collections[0].norm
@@ -313,7 +318,7 @@ class TestStatMapAccessor:
             bg_volume=sample_3d_volume, slice_mode="z"
         )
         assert isinstance(plotter, VolumePlotter)
-        rendered = [ax for ax in plotter.axes.ravel() if ax.collections]
+        rendered = [ax for ax in _axes(plotter).ravel() if ax.collections]
         assert len(rendered) == sample_3d_volume.sizes["z"]
 
     def test_accessor_without_background(self, sample_3d_volume, matplotlib_pyplot):
@@ -321,6 +326,6 @@ class TestStatMapAccessor:
 
         stat_map = _signed_stat_map(sample_3d_volume)
         plotter = stat_map.fusi.plot.stat_map(slice_mode="z")
-        rendered = [ax for ax in plotter.axes.ravel() if ax.collections]
+        rendered = [ax for ax in _axes(plotter).ravel() if ax.collections]
         assert len(rendered) == stat_map.sizes["z"]
         assert all(len(ax.collections) == 1 for ax in rendered)

--- a/tests/unit/test_plotting/test_matrix.py
+++ b/tests/unit/test_plotting/test_matrix.py
@@ -45,7 +45,7 @@ class TestPlotMatrixValidation:
     def test_unknown_triangle_raises(self, matplotlib_pyplot):
         """An unsupported triangle mode raises ValueError."""
         with pytest.raises(ValueError, match="Unknown triangle mode"):
-            plot_matrix(_correlation_matrix(4), triangle="bogus")
+            plot_matrix(_correlation_matrix(4), triangle="bogus")  # ty: ignore[invalid-argument-type]
 
 
 class TestPlotMatrixBehaviour:
@@ -190,9 +190,13 @@ class TestPlotMatrixBehaviour:
         groups = ["cortex"] * 3 + ["thalamus"] * 3
         fig, ax = plot_matrix(_correlation_matrix(6), labels=labels, groups=groups)
 
+        from matplotlib.backends.backend_agg import FigureCanvasAgg
+
         fig.canvas.draw()
+        assert isinstance(fig.canvas, FigureCanvasAgg)
         renderer = fig.canvas.get_renderer()
         label_bbox = ax.yaxis.get_tightbbox(renderer)
+        assert label_bbox is not None
         row_ax = min(
             (axis for axis in fig.axes if axis is not ax),
             key=lambda axis: axis.get_position().x0,
@@ -272,7 +276,10 @@ class TestPlotMatrixBehaviour:
     def test_tri_masks_expected_side(self, matplotlib_pyplot, tri, masked_upper):
         """lower/diag_lower mask the strict upper triangle and vice versa."""
         _, ax = plot_matrix(_correlation_matrix(4), triangle=tri)
-        image_mask = ax.collections[0].get_array().mask
+        image_mask = np.asarray(
+            np.ma.masked_array(ax.collections[0].get_array()).mask,
+            dtype=bool,
+        )
         assert bool(image_mask[0, 1]) == masked_upper
         assert bool(image_mask[1, 0]) == (not masked_upper)
 
@@ -280,7 +287,11 @@ class TestPlotMatrixBehaviour:
     def test_tri_strict_excludes_diagonal(self, matplotlib_pyplot, tri):
         """lower/upper mask the diagonal; diag_lower/diag_upper keep it."""
         _, ax = plot_matrix(_correlation_matrix(4), triangle=tri)
-        assert bool(ax.collections[0].get_array().mask[0, 0])
+        image_mask = np.asarray(
+            np.ma.masked_array(ax.collections[0].get_array()).mask,
+            dtype=bool,
+        )
+        assert bool(image_mask[0, 0])
 
 
 class TestPlotMatrixVisualRegression:

--- a/tests/unit/test_plotting/test_napari.py
+++ b/tests/unit/test_plotting/test_napari.py
@@ -115,7 +115,7 @@ class TestPlotNapari:
 
     def test_invalid_layer_type_raises(self, sample_3d_volume) -> None:
         with pytest.raises(ValueError, match="Unknown layer_type"):
-            plot_napari(sample_3d_volume, layer_type="bogus")  # type: ignore[arg-type]
+            plot_napari(sample_3d_volume, layer_type="bogus")  # ty: ignore[invalid-argument-type]
 
     def test_non_uniform_spatial_coords_warn(
         self, sample_3d_volume, make_napari_viewer

--- a/tests/unit/test_registration/test_affines.py
+++ b/tests/unit/test_registration/test_affines.py
@@ -32,7 +32,12 @@ class TestDecompose44:
                 for zooms in permutations([1.1, 1.9, 2.3]):
                     for shears in permutations([0.01, 0.04, 0.09]):
                         Rmat = Rotation.from_euler("xyz", rots).as_matrix()
-                        M = compose_affine(trans, Rmat, zooms, shears)
+                        M = compose_affine(
+                            np.asarray(trans, dtype=float),
+                            Rmat,
+                            np.asarray(zooms, dtype=float),
+                            np.asarray(shears, dtype=float),
+                        )
                         T, R, Z, S = decompose_affine(M)
                         assert_array_almost_equal(compose_affine(T, R, Z, S), M)
 

--- a/tests/unit/test_registration/test_volume.py
+++ b/tests/unit/test_registration/test_volume.py
@@ -61,7 +61,7 @@ class TestRegisterVolumeValidation:
             register_volume(
                 sample_2d_dataarray_spatial,
                 sample_2d_dataarray_spatial,
-                initialization="moments",
+                initialization="moments",  # ty: ignore[invalid-argument-type]
             )
 
     def test_non_array_initialization_raises_value_error(
@@ -72,7 +72,7 @@ class TestRegisterVolumeValidation:
             register_volume(
                 sample_2d_dataarray_spatial,
                 sample_2d_dataarray_spatial,
-                initialization=[[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+                initialization=[[1, 0, 0], [0, 1, 0], [0, 0, 1]],  # ty: ignore[invalid-argument-type]
             )
 
     def test_shape_mismatch_no_error(
@@ -151,8 +151,11 @@ class TestRegisterVolumeOutput:
             dims=("y", "x"),
             coords={"y": np.arange(20) * 0.5, "x": np.arange(40) * 0.1},
         )
-        _, bspline_tx, _ = register_volume(
-            da, da, transform_type="bspline", mesh_size=(4, 4)
+        _, bspline_tx, _ = register_volume(  # ty: ignore[no-matching-overload]
+            da,
+            da,
+            transform_type="bspline",
+            mesh_size=(4, 4),
         )
 
         y_span = float(
@@ -930,12 +933,7 @@ class TestDisplacementField:
         moving = xr.DataArray(shifted[np.newaxis], dims=fixed.dims, coords=fixed.coords)
         _, bspline_tx, _ = register_volume(moving, fixed, transform_type="bspline")
 
-        grid = dict(
-            shape=[fixed.sizes[d] for d in fixed.dims],
-            spacing=[fixed.fusi.spacing[d] for d in fixed.dims],
-            origin=[fixed.fusi.origin[d] for d in fixed.dims],
-            dims=list(fixed.dims),
-        )
+        grid = get_grid_kwargs_from_dataarray(fixed)
         field = sample_displacement_field(bspline_tx, **grid)
         assert not np.isnan(field.values).any()
 
@@ -971,12 +969,7 @@ class TestDisplacementField:
         moving = xr.DataArray(shifted[np.newaxis], dims=fixed.dims, coords=fixed.coords)
         _, bspline_tx, _ = register_volume(moving, fixed, transform_type="bspline")
 
-        grid = dict(
-            shape=[fixed.sizes[d] for d in fixed.dims],
-            spacing=[fixed.fusi.spacing[d] for d in fixed.dims],
-            origin=[fixed.fusi.origin[d] for d in fixed.dims],
-            dims=list(fixed.dims),
-        )
+        grid = get_grid_kwargs_from_dataarray(fixed)
         field = sample_displacement_field(bspline_tx, **grid)
         inverse_field = invert_displacement_field(field)
 

--- a/tests/unit/test_signal/test_censor.py
+++ b/tests/unit/test_signal/test_censor.py
@@ -147,7 +147,7 @@ def test_interpolate_rejects_non_dataarray_mask(sample_timeseries):
     signals = sample_timeseries(n_time=100)
 
     with pytest.raises(TypeError, match="sample_mask must be an xarray.DataArray"):
-        interpolate_samples(signals, np.ones(100, dtype=bool))  # type: ignore[arg-type]
+        interpolate_samples(signals, np.ones(100, dtype=bool))  # ty: ignore[invalid-argument-type]
 
 
 def test_interpolate_rejects_mask_without_time_dimension(sample_timeseries):

--- a/tests/unit/test_signal/test_clean.py
+++ b/tests/unit/test_signal/test_clean.py
@@ -136,7 +136,7 @@ def test_clean_filter_low_pass_matches_filter_butterworth(sample_timeseries):
 def test_clean_rejects_non_dict_filter_kwargs(sample_timeseries):
     """Test filter_butterworth_kwargs must be a dict."""
     with pytest.raises(TypeError, match="filter_butterworth_kwargs must be a dict"):
-        clean(sample_timeseries(), filter_butterworth_kwargs=1)  # type: ignore[arg-type]
+        clean(sample_timeseries(), filter_butterworth_kwargs=1)  # ty: ignore[invalid-argument-type]
 
 
 def test_clean_rejects_cutoffs_inside_filter_kwargs(sample_timeseries):
@@ -148,7 +148,7 @@ def test_clean_rejects_cutoffs_inside_filter_kwargs(sample_timeseries):
 def test_clean_rejects_non_dict_interpolate_kwargs(sample_timeseries):
     """Test interpolate_kwargs must be a dict."""
     with pytest.raises(TypeError, match="interpolate_kwargs must be a dict"):
-        clean(sample_timeseries(), interpolate_kwargs=1)  # type: ignore[arg-type]
+        clean(sample_timeseries(), interpolate_kwargs=1)  # ty: ignore[invalid-argument-type]
 
 
 def test_clean_rejects_method_inside_interpolate_kwargs(sample_timeseries):

--- a/tests/unit/test_signal/test_compcor.py
+++ b/tests/unit/test_signal/test_compcor.py
@@ -1,5 +1,7 @@
 """Tests for CompCor functions."""
 
+from typing import NotRequired, TypedDict
+
 import dask.array as da
 import numpy as np
 import pytest
@@ -7,6 +9,13 @@ import xarray as xr
 from numpy.testing import assert_allclose
 
 from confusius.signal import compute_compcor_confounds
+
+
+class _CompcorKwargs(TypedDict):
+    n_components: int
+    detrend: bool
+    noise_mask: NotRequired[xr.DataArray]
+    variance_threshold: NotRequired[float]
 
 
 def _create_mask_like(data, mask_values):
@@ -218,10 +227,10 @@ def test_compute_compcor_invalid_n_components(sample_timeseries):
     noise_mask = np.ones(50, dtype=bool)
 
     with pytest.raises(ValueError, match="must be positive"):
-        compute_compcor_confounds(signals, noise_mask=noise_mask, n_components=0)
+        compute_compcor_confounds(signals, noise_mask=noise_mask, n_components=0)  # ty: ignore[invalid-argument-type]
 
     with pytest.raises(ValueError, match="must be positive"):
-        compute_compcor_confounds(signals, noise_mask=noise_mask, n_components=-1)
+        compute_compcor_confounds(signals, noise_mask=noise_mask, n_components=-1)  # ty: ignore[invalid-argument-type]
 
 
 def test_compute_compcor_no_time_dimension():
@@ -233,7 +242,7 @@ def test_compute_compcor_no_time_dimension():
     noise_mask = np.ones(50, dtype=bool)
 
     with pytest.raises(ValueError, match="must have a 'time' dimension"):
-        compute_compcor_confounds(signals, noise_mask=noise_mask, n_components=5)
+        compute_compcor_confounds(signals, noise_mask=noise_mask, n_components=5)  # ty: ignore[invalid-argument-type]
 
 
 def test_compute_compcor_mask_shape_mismatch(sample_timeseries):
@@ -460,7 +469,7 @@ def test_compute_compcor_reference_svd(
         signals.values[:, i] *= (i + 1) * 0.1
 
     # Build kwargs based on mode
-    kwargs = {"n_components": 5, "detrend": False}
+    kwargs: _CompcorKwargs = {"n_components": 5, "detrend": False}
 
     if use_noise_mask:
         mask_values = np.zeros(n_voxels, dtype=bool)

--- a/tests/unit/test_signal/test_confounds.py
+++ b/tests/unit/test_signal/test_confounds.py
@@ -200,7 +200,7 @@ def test_regress_confounds_invalid_type(sample_timeseries):
     signals = sample_timeseries()
 
     with pytest.raises(TypeError, match="must be an xarray.DataArray"):
-        regress_confounds(signals, "invalid")  # type: ignore[arg-type]
+        regress_confounds(signals, "invalid")  # ty: ignore[invalid-argument-type]
 
 
 def test_regress_confounds_confounds_missing_time_dimension(sample_timeseries):

--- a/tests/unit/test_stats/test_thresholding.py
+++ b/tests/unit/test_stats/test_thresholding.py
@@ -134,7 +134,7 @@ class TestAdjustPvalues:
     def test_invalid_method_raises(self, pmap):
         """An unknown correction method is rejected."""
         with pytest.raises(ValueError, match="method must be one of"):
-            adjust_pvalues(pmap, method="hochberg")
+            adjust_pvalues(pmap, method="hochberg")  # ty: ignore[invalid-argument-type]
 
     def test_no_tested_voxels_raises(self):
         """An all-zero p-map with skipzero leaves nothing to test."""
@@ -346,7 +346,7 @@ class TestValidation:
     def test_invalid_method(self, zmap):
         """An unknown correction method is rejected."""
         with pytest.raises(ValueError, match="method must be None or one of"):
-            apply_statistical_threshold(zmap, method="hochberg")
+            apply_statistical_threshold(zmap, method="hochberg")  # ty: ignore[invalid-argument-type]
 
     def test_negative_cluster_threshold(self, zmap):
         """A negative cluster threshold is rejected."""

--- a/tests/unit/test_timing.py
+++ b/tests/unit/test_timing.py
@@ -89,7 +89,7 @@ def test_convert_time_reference_rejects_invalid_reference() -> None:
         convert_time_reference(
             np.array([0.0, 1.0]),
             volume_duration=0.5,
-            from_reference="invalid",
+            from_reference="invalid",  # ty: ignore[invalid-argument-type]
             to_reference="start",
         )
 

--- a/tools/gallery/execute.py
+++ b/tools/gallery/execute.py
@@ -91,7 +91,7 @@ def execute_example(
         notebook.cells.insert(0, _theme_setup_cell(theme))
 
     kernel_manager = KernelManager()
-    kernel_manager.kernel_cmd = [  # type: ignore[unresolved-attribute]
+    kernel_manager.kernel_cmd = [  # ty: ignore[unresolved-attribute]
         sys.executable,
         "-m",
         "ipykernel_launcher",

--- a/tools/gallery/render.py
+++ b/tools/gallery/render.py
@@ -10,6 +10,18 @@ from pathlib import Path
 import nbformat
 
 
+def _join_str_list(value: object) -> str | None:
+    """Join a list of strings, returning `None` for any other input."""
+    if not isinstance(value, list):
+        return None
+    parts: list[str] = []
+    for item in value:
+        if not isinstance(item, str):
+            return None
+        parts.append(item)
+    return "".join(parts)
+
+
 def _cell_tags(cell: nbformat.NotebookNode) -> set[str]:
     """Return the tags attached to one notebook cell."""
     return set(cell.metadata.get("tags", []))
@@ -18,11 +30,12 @@ def _cell_tags(cell: nbformat.NotebookNode) -> set[str]:
 def _png_data(output: dict[str, object]) -> str | None:
     """Return the base64 PNG payload from an output if present."""
     data = output.get("data")
-    if not isinstance(data, dict) or "image/png" not in data:
+    if not isinstance(data, dict):
         return None
-    png = data["image/png"]
-    if isinstance(png, list):
-        return "".join(png)
+    png = data.get("image/png")
+    png_joined = _join_str_list(png)
+    if png_joined is not None:
+        return png_joined
     if isinstance(png, str):
         return png
     return None
@@ -150,13 +163,15 @@ def _is_blank_widget_output(output: dict[str, object]) -> bool:
     data = output.get("data")
     if not isinstance(data, dict) or not data:
         return False
-    if any(key.startswith("image/") for key in data):
+    if any(isinstance(key, str) and key.startswith("image/") for key in data):
         return False
     if not set(data).issubset({"text/html", "text/plain"}):
         return False
 
     plain = data.get("text/plain", "")
-    text = "".join(plain) if isinstance(plain, list) else str(plain)
+    text = _join_str_list(plain)
+    if text is None:
+        text = str(plain)
     return not text.strip()
 
 
@@ -189,7 +204,9 @@ def _summarize_output(output: dict[str, object]) -> str:
         if isinstance(data, dict):
             for key in keys:
                 value = data[key]
-                text = "".join(value) if isinstance(value, list) else str(value)
+                text = _join_str_list(value)
+                if text is None:
+                    text = str(value)
                 text = text.replace("\n", "\\n")
                 summary += f"\n    {key}: {text[:500]}"
         metadata = output.get("metadata")

--- a/uv.lock
+++ b/uv.lock
@@ -1569,7 +1569,7 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.12'" },
+    { name = "zipp" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
@@ -3198,7 +3198,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -833,18 +833,18 @@ dev = [
     { name = "ipykernel", specifier = ">=6.29.0" },
     { name = "jupytext", specifier = ">=1.16.0" },
     { name = "mike", git = "https://github.com/squidfunk/mike.git" },
-    { name = "mkdocstrings", extras = ["python"], specifier = ">=1.0.3" },
+    { name = "mkdocstrings", extras = ["python"], specifier = ">=1.0.4" },
     { name = "nbclient", specifier = ">=0.10.0" },
     { name = "nbformat", specifier = ">=5.10.0" },
-    { name = "numpydoc", specifier = ">=1.9.0" },
-    { name = "prek", specifier = ">=0.2.0,<0.3.0" },
-    { name = "pytest", specifier = ">=8.4.2" },
+    { name = "numpydoc", specifier = ">=1.11.0rc0" },
+    { name = "prek", specifier = ">=0.4.8" },
+    { name = "pytest", specifier = ">=9.1.1" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
-    { name = "pytest-mpl", specifier = ">=0.16.0" },
+    { name = "pytest-mpl", specifier = ">=0.19.0" },
     { name = "pytest-qt", specifier = ">=4.5.0" },
-    { name = "ruff", specifier = ">=0.8.0" },
-    { name = "ty", specifier = ">=0.0.10,<0.1.0" },
-    { name = "zensical", specifier = ">=0.0.40" },
+    { name = "ruff", specifier = ">=0.15.20" },
+    { name = "ty", specifier = ">=0.0.57,<0.1.0" },
+    { name = "zensical", specifier = ">=0.0.47" },
 ]
 
 [[package]]
@@ -3054,15 +3054,15 @@ wheels = [
 
 [[package]]
 name = "numpydoc"
-version = "1.10.0"
+version = "1.11.0rc0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e9/3c/dfccc9e7dee357fb2aa13c3890d952a370dd0ed071e0f7ed62ed0df567c1/numpydoc-1.10.0.tar.gz", hash = "sha256:3f7970f6eee30912260a6b31ac72bba2432830cd6722569ec17ee8d3ef5ffa01", size = 94027, upload-time = "2025-12-02T16:39:12.937Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/75/67/144cb738b446308e55671e8fde9c6189f1dd5a6558b00cef69206a4f80dd/numpydoc-1.11.0rc0.tar.gz", hash = "sha256:f394cb211ad319c27a5927131117a485ff90cc53d131e744053ddc303e76a7ac", size = 96049, upload-time = "2026-06-10T22:03:33.147Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/5e/3a6a3e90f35cea3853c45e5d5fb9b7192ce4384616f932cf7591298ab6e1/numpydoc-1.10.0-py3-none-any.whl", hash = "sha256:3149da9874af890bcc2a82ef7aae5484e5aa81cb2778f08e3c307ba6d963721b", size = 69255, upload-time = "2025-12-02T16:39:11.561Z" },
+    { url = "https://files.pythonhosted.org/packages/68/bf/e16b5200d42e5b6a8be28e9f950df44f0555f7a6faf641752dc8a62c610b/numpydoc-1.11.0rc0-py3-none-any.whl", hash = "sha256:d5c6822d70ba2d329e8572bd9edbcbae8b66c443a1be2850e3b2c6976635750c", size = 70991, upload-time = "2026-06-10T22:03:31.877Z" },
 ]
 
 [[package]]
@@ -3327,26 +3327,26 @@ wheels = [
 
 [[package]]
 name = "prek"
-version = "0.2.30"
+version = "0.4.8"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/51/87/2ad90e933c59676b8ce373a643ba5c58e96d4626f08a796af07607a4e827/prek-0.2.30.tar.gz", hash = "sha256:e421b7854eb2228c060b40e7282c4ce4c9889f41062351bc34f55472af2a608c", size = 291247, upload-time = "2026-01-18T13:23:15.171Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/46/e436a6eb9fdb4d3fd08d0ab7fdba19fe03a9e994ec810de57869b853bd8e/prek-0.4.8.tar.gz", hash = "sha256:d15d8bef72ab7b02c7dc01458ac9e05b3131534492b5ce9bb11c4f6f636fa868", size = 494570, upload-time = "2026-07-04T12:05:10.941Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/1a/8dcd4580106190be9c313a72a15e309d41176fc4b6414167fba638bcee75/prek-0.2.30-py3-none-linux_armv6l.whl", hash = "sha256:50b25003fa94c0df6cd6683714ac0c6122e4f3d18ae6a487333823ec812b57d4", size = 4260268, upload-time = "2026-01-18T13:22:59.295Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/d0/0b9d524d409c5b1b7466f32217cb809b997613a0d0b319caab0ceb1f664b/prek-0.2.30-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e69842fec298fc065dd2428e33a50bcd124d7ac22fc4d91c442b963450d5b14d", size = 4269718, upload-time = "2026-01-18T13:22:55.575Z" },
-    { url = "https://files.pythonhosted.org/packages/04/55/8e9ff2ff742174e49e2df5a14108f5997498662ff31ade35529ecea1812c/prek-0.2.30-py3-none-macosx_11_0_arm64.whl", hash = "sha256:910a370b718a128ef91e5f93baa76eeef205ac448774c491838f36511e95ce64", size = 3924968, upload-time = "2026-01-18T13:23:00.968Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/db/a130a32ae8c3de89efe20d11ec8d0730cd80319f0f9ca673ef4e5c8685b2/prek-0.2.30-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:5f9d50e0d95e5b7908299a59d6aee903ca422a032e2d9e0b5ba73c5a2911f469", size = 4254573, upload-time = "2026-01-18T13:23:09.713Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/ab/3b64dcf919c82bbac75c5cc8800932f3bfd2be33a60f0345b708b78b56aa/prek-0.2.30-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:801df0ecef3c3303dd1b5abe14edfe704b305c5bdca0b272bb3e317dbe3d29af", size = 4183080, upload-time = "2026-01-18T13:22:48.028Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/6d/4acdb306901d3b9e9c4da88b033264e5eed3b53f43a8111df25cd843f127/prek-0.2.30-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:03154e56a6956179e916ec3f564835af7a304473235fe837c3e504df1aa462c2", size = 4436996, upload-time = "2026-01-18T13:22:52.109Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/80/50e0e03dbfe93dbe94a79f1026e9c24eacd4a7228b27f650a2ee43ce4387/prek-0.2.30-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:77923501a247f94a93e272c3bacbfb7a4347aff3c57a4edb928624ddb8c65eb7", size = 4970022, upload-time = "2026-01-18T13:23:13.297Z" },
-    { url = "https://files.pythonhosted.org/packages/52/4f/c9cda78678275ce1bfa97c3ef6d9ad23ef1dac2cd2d4660ad277bbcd4ab2/prek-0.2.30-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cea2e2b1825f3e1d979492eed6d69f21d3e13cb4157212034badd01521b77b1d", size = 4494648, upload-time = "2026-01-18T13:23:08.08Z" },
-    { url = "https://files.pythonhosted.org/packages/38/78/14bbe113362702bb0dd34cdb8244f0b1bc37e7482592381a8cec4d725fc5/prek-0.2.30-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:77cb9c9218a5479e10e33449dec52886c6991f7b5dd5abb9c20856c1a1fae66a", size = 4268486, upload-time = "2026-01-18T13:22:57.762Z" },
-    { url = "https://files.pythonhosted.org/packages/52/17/78182dc4c4e4eed952558085b21046414c1b21e800a157d4a6f94d20bd1a/prek-0.2.30-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:c480dcbf459ea0dcf70f9d9f9f3709c11cbda06f81526b2e36430fa260ecf747", size = 4285924, upload-time = "2026-01-18T13:23:02.503Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/2d/ec39a4570dad4984f671a940df6078f97bb4fd993b32914358a0ed7b311a/prek-0.2.30-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:bdc5ae31543e77acf7d78fa51bf4f5cb870628856230763bc5173895ad84d327", size = 4161904, upload-time = "2026-01-18T13:23:16.397Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/63/e0488a50dbbeff2cf0b789d503f6425b9fd3fb3bd95e128634ee38a51f96/prek-0.2.30-py3-none-musllinux_1_1_i686.whl", hash = "sha256:859f870c823ecf1f5b28353e6ab53ae35bca2ee959c58a50a2e0100172fc2439", size = 4313514, upload-time = "2026-01-18T13:22:53.994Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/b4/e5fcb3d4e0275ccdb7d45494c8f628925ac05314b859ec74035ae487131a/prek-0.2.30-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:c086ae69d106abbfcb7f4b91c70e5cdf982d4485970b75b0057302b46f1708e2", size = 4599592, upload-time = "2026-01-18T13:22:50.483Z" },
-    { url = "https://files.pythonhosted.org/packages/33/2e/fb615b3026c96d10c0734fc2cb972b204e8fa52947e28f5e0eb6c24a0bd0/prek-0.2.30-py3-none-win32.whl", hash = "sha256:589c6277429424ce6e5a2e669c183efa55afb9adc9f1916a34c74211a63c7a35", size = 3888524, upload-time = "2026-01-18T13:23:04.005Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/b4/e1dc3447af01ad12956bd17185f21a874eb1b86787fb573e577fe4d602d6/prek-0.2.30-py3-none-win_amd64.whl", hash = "sha256:b651f0b392d92d6091c3fc5adb2b1a3819311a15e92bf3eb084cb8fd5df40272", size = 4237521, upload-time = "2026-01-18T13:23:06.42Z" },
-    { url = "https://files.pythonhosted.org/packages/93/ec/8150b29e7e00a9fbb70c67f35188fb8c95f1c46481427f57a30c200365f9/prek-0.2.30-py3-none-win_arm64.whl", hash = "sha256:75cd54c05d1941f1f3c12a2f4365d9429a700ad8c442ece03266b217b403941b", size = 3992917, upload-time = "2026-01-18T13:23:11.594Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/78/b4149c8913ced2e42debb49e261c4788a1ce431e84226921c2e1a7ea8545/prek-0.4.8-py3-none-linux_armv6l.whl", hash = "sha256:1f8f8cdc65836b571824c965daebb81b449f7e4a43894c58621f5708d5a185ed", size = 5668955, upload-time = "2026-07-04T12:04:41.588Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5f/7f54a0087b6b2f1751aeb41266d9c15e66fd0055492814798ab818cd0414/prek-0.4.8-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:bce1798e96d9e3a6e6abf435da7107e81452f69edb3ca7c6f90a457355ea46e2", size = 6030947, upload-time = "2026-07-04T12:04:43.8Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/d6/f2829fc3902920c36b764a386fa303e71a8219dac25cb3827c575e84199a/prek-0.4.8-py3-none-macosx_11_0_arm64.whl", hash = "sha256:ab3a52db17254d701c3cebb7eea58c8230aa7c1959aacfd5b5f25de18edb15d1", size = 5572593, upload-time = "2026-07-04T12:04:45.763Z" },
+    { url = "https://files.pythonhosted.org/packages/74/8c/c5589955bcd5e3e33b67d8bc3110818cecac82a38fd6bc8b5dfdc5de421c/prek-0.4.8-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:b3fcfd620523bbc3f51a21d7cd63449f659b9e2cf3582de12dd5949e23227b8f", size = 5847150, upload-time = "2026-07-04T12:04:47.419Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/9d/1f2dc91bdb79d2c4714b27eac9477a51490fba5b4731330dbbebc76bd345/prek-0.4.8-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:42e65bc8425e9d7f1691a13ca1da2e07807d1ba76c35740833354b945131689e", size = 5573738, upload-time = "2026-07-04T12:04:49.125Z" },
+    { url = "https://files.pythonhosted.org/packages/81/29/69a7b58e16ecbc5f3989bf4b028018d11a82dcdd320b93d6588d72f32aa7/prek-0.4.8-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f578492a8e0c9bc6b4bf6dfbba8716f647d4cd0769bf10ad6cf336e3096fd392", size = 5981054, upload-time = "2026-07-04T12:04:50.842Z" },
+    { url = "https://files.pythonhosted.org/packages/63/cc/9b9850a60c22ed18c7755ebd2d72c6eefb37fac58149d09f6adc4691c2cf/prek-0.4.8-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d4335f9d5beb123a3884a7fe34f57c9f0828f4fbb7666beab4298833459b104f", size = 6751350, upload-time = "2026-07-04T12:04:52.529Z" },
+    { url = "https://files.pythonhosted.org/packages/01/e5/c425aa7272b430630119e6757def3a2007555ba8cbeb2630e0448e7a8b7f/prek-0.4.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:18a8747df9c602e052881d3efb14dd7f7d62a59bd7277ae5171c9e7661d59d84", size = 6243881, upload-time = "2026-07-04T12:04:54.703Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/da/accd3ad07fd2891d3c2777eb42435439fdf11982c51d60f087c0b6b6e102/prek-0.4.8-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:4db639db481d5f854eff9b3d2108889e613b8c15868bcf6bdd777c7cee577436", size = 5848846, upload-time = "2026-07-04T12:04:56.402Z" },
+    { url = "https://files.pythonhosted.org/packages/15/00/3477704635249f21f5f98ce444cd7690c2aa9dc8d146a045db88ef2cd8c5/prek-0.4.8-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:c3890a6f92316d2cf44eb50584e8d2b23a596dd70487022e61186a71a2ac0900", size = 5713942, upload-time = "2026-07-04T12:04:58.311Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e6/3ca4fabaebeadc976d9a92d1d9130674265355ea3b728418bad61583b097/prek-0.4.8-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:fc7e15c24c591a37c6ffce5b25a021b16c299ac2649f183d812b67d665cd6551", size = 5554725, upload-time = "2026-07-04T12:04:59.96Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/46/2ab6aaaeff0cedb8955b2e4032071c8712382bdd423bb849718c3720180d/prek-0.4.8-py3-none-musllinux_1_1_i686.whl", hash = "sha256:36fe721704ff0c7624c1167639e23a5fe658bfd38c314f487219c9afd1eeb733", size = 5838595, upload-time = "2026-07-04T12:05:01.861Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8b/91398f2b6cd1629d5d8ca8c85b08eca500814a374313b0193f4aaf6ab6c4/prek-0.4.8-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:162e544abc394a8124f3a4ad68efee116bad09440e679dbd1675177335c2a432", size = 6357222, upload-time = "2026-07-04T12:05:03.845Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/2a/ce5cbfaad36866134a21754640a05ecdba641fcd7ad15aa74cf3443f34f6/prek-0.4.8-py3-none-win32.whl", hash = "sha256:2602e46c8c5da7dfa69f60fcf88c2b57132ac623f49fb08bfb3094298c5f07e3", size = 5354388, upload-time = "2026-07-04T12:05:05.587Z" },
+    { url = "https://files.pythonhosted.org/packages/df/03/3bc908bc5f7e430315553e47dfa055f19923a3888f9afe4da19f244b5cbf/prek-0.4.8-py3-none-win_amd64.whl", hash = "sha256:7cb22da60bee41b89c4978c0bea7126a3c0ccc003dae6748cf29b53947815edc", size = 5748221, upload-time = "2026-07-04T12:05:07.559Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a7/4295e6d5f5028171dfeb115ad38ab76bf3fe0c8df91b70d73c79aa760a94/prek-0.4.8-py3-none-win_arm64.whl", hash = "sha256:da70057f577b15d4bd121bf9dd29ee205fd4b4d75a0cafba062e84d7e8b4378b", size = 5574425, upload-time = "2026-07-04T12:05:09.595Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bump pinned minimums for the main dev tools, and switch the ty pre-commit hook to the upstream repo (no longer a local hook).

- numpydoc 1.9 → 1.11.0rc0
- prek 0.2 → 0.4
- pytest 8.4 → 9.1
- pytest-mpl 0.16 → 0.19
- ruff 0.8 → 0.15
- ty 0.0.10 → 0.0.57
- zensical 0.0.40 → 0.0.47
- mkdocstrings 1.0.3 → 1.0.4

Also expand the ty `src.include` from `src/` to `[src, tests]`, and update `uv.lock`, the gallery build (`tools/gallery/`), and the test suite to track the upstream changes (pytest 9 stricter collection, pytest-mpl default-style change, etc.). Pre-commit also runs the ty hook across `docs/images/` and `docs/examples/` now.

Includes typydoc-link cleanups in the 0.5.0 changelog entry and the ty fixes for the docs image generation scripts that the wider ty check exposed.