### PR TITLE
feat(datasets): add citation info to dataset fetchers

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,12 @@ Current development version for the next ConfUSIus release.
 
 ### :sparkles: Enhancements
 
+- Dataset fetchers now print the citation to use for the fetched data and accept a
+  `show_citation_msg` argument to silence it. The template fetchers
+  [`fetch_template_huang_2025`][confusius.datasets.fetch_template_huang_2025] and
+  [`fetch_template_pepe_mariani_2026`][confusius.datasets.fetch_template_pepe_mariani_2026]
+  also expose the citation on the returned DataArray as `da.attrs["citation"]`
+  ([#279](https://github.com/confusius-tools/confusius/pull/279)).
 - Dataset fetchers called with `refresh=True` now re-download cached files whose upstream
   MD5 changed, comparing the cached dataset index against the freshly fetched one instead
   of only checking whether the file exists; downloads are additionally verified against

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,7 +13,7 @@ Current development version for the next ConfUSIus release.
 ### :sparkles: Enhancements
 
 - Dataset fetchers now print the citation to use for the fetched data and accept a
-  `show_citation_msg` argument to silence it. The template fetchers
+  `print_citation` argument to silence it. The template fetchers
   [`fetch_template_huang_2025`][confusius.datasets.fetch_template_huang_2025] and
   [`fetch_template_pepe_mariani_2026`][confusius.datasets.fetch_template_pepe_mariani_2026]
   also expose the citation on the returned DataArray as `da.attrs["citation"]`

--- a/docs/examples/02_registration/01_register_volume_same_subject.py
+++ b/docs/examples/02_registration/01_register_volume_same_subject.py
@@ -48,6 +48,7 @@ bids_root = cf.datasets.fetch_cybis_pereira_2026(
 )
 
 
+# %%
 def _load_angio_for_registration(session: str) -> xr.DataArray:
     """Load an angio acquisition and scale its intensity for registration."""
     path = (
@@ -64,6 +65,7 @@ def _load_angio_for_registration(session: str) -> xr.DataArray:
 fixed = _load_angio_for_registration(sessions[0])
 
 fixed
+
 # %%
 moving = _load_angio_for_registration(sessions[1])
 

--- a/docs/examples/03_decomposition/01_pca_single_recording.py
+++ b/docs/examples/03_decomposition/01_pca_single_recording.py
@@ -53,6 +53,7 @@ bids_root = cf.datasets.fetch_nunez_elizalde_2022(
     acqs="slice03",
 )
 
+# %%
 pwd_path = (
     Path(bids_root)
     / "sub-CR022"

--- a/docs/examples/03_decomposition/02_fastica_single_recording.py
+++ b/docs/examples/03_decomposition/02_fastica_single_recording.py
@@ -60,6 +60,7 @@ bids_root = cf.datasets.fetch_nunez_elizalde_2022(
     acqs="slice03",
 )
 
+# %%
 pwd_path = (
     Path(bids_root)
     / "sub-CR022"

--- a/docs/examples/03_decomposition/03_nmf_single_recording.py
+++ b/docs/examples/03_decomposition/03_nmf_single_recording.py
@@ -47,6 +47,7 @@ bids_root = cf.datasets.fetch_nunez_elizalde_2022(
     acqs="slice03",
 )
 
+# %%
 pwd_path = (
     Path(bids_root)
     / "sub-CR022"

--- a/docs/examples/04_connectivity/01_atlas_correlation_matrix.py
+++ b/docs/examples/04_connectivity/01_atlas_correlation_matrix.py
@@ -42,6 +42,7 @@ bids_root = cf.datasets.fetch_nunez_elizalde_2022(
     subjects="CR022", sessions="20201007", tasks="spontaneous", acqs="slice02"
 )
 
+# %%
 data_path = (
     Path(bids_root)
     / "sub-CR022"

--- a/docs/examples/04_connectivity/02_atlas_seed_map.py
+++ b/docs/examples/04_connectivity/02_atlas_seed_map.py
@@ -16,6 +16,10 @@
 
 # %% [markdown]
 # ## Fetch the recording and register to the Allen atlas
+#
+# The recording is a single coronal slice imaged for approximately 4 minutes at 3.33 Hz.
+# Registration works on a static anatomical image, so we use the temporal mean,
+# converted to decibels for a more stable dynamic range.
 
 # %%
 from pathlib import Path
@@ -32,13 +36,13 @@ bg_color = mpl.colors.to_hex(mpl.rcParams["figure.facecolor"])
 
 xr.set_options(display_expand_data=False)
 
+template = cf.datasets.fetch_template_pepe_mariani_2026().compute()
+
 bids_root = cf.datasets.fetch_nunez_elizalde_2022(
-    subjects="CR022",
-    sessions="20201007",
-    tasks="spontaneous",
-    acqs="slice02",
+    subjects="CR022", sessions="20201007", tasks="spontaneous", acqs="slice02"
 )
 
+# %%
 data_path = (
     Path(bids_root)
     / "sub-CR022"
@@ -46,12 +50,10 @@ data_path = (
     / "fusi"
     / "sub-CR022_ses-20201007_task-spontaneous_acq-slice02_pwd.nii.gz"
 )
-# The recording's timepoints are not perfectly uniformly spaced, so we resample to a
-# uniform grid before any time-domain processing.
+# The recording's timepoints are not perfectly uniformly spaced so we resample to a
+# uniform grid before any time-domain processing (filtering below requires it).
 data = cf.timing.resample_to_uniform_time(cf.load(data_path))
 moving = data.mean(dim="time").fusi.scale.db().compute()
-
-template = cf.datasets.fetch_template_pepe_mariani_2026().compute()
 
 # %% [markdown]
 # As in the correlation-matrix example, we initialize registration with an affine

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -449,3 +449,10 @@
   aspect-ratio: 4 / 3;
   object-fit: cover;
 }
+
+/* Rich console output (e.g. dataset citations) scrolls horizontally when a line is
+   wider than the page. rich sets overflow-x on the <pre> but no bottom padding, so the
+   scrollbar sits on top of the last line — reserve space below it. */
+.gallery-rich-output > pre {
+  padding-bottom: 0.75rem;
+}

--- a/src/confusius/_napari/_theme.py
+++ b/src/confusius/_napari/_theme.py
@@ -8,6 +8,8 @@ from qtpy.QtGui import QColor, QIcon, QImage, QPainter, QPixmap
 from qtpy.QtSvg import QSvgRenderer as _QSvgRenderer
 from qtpy.QtWidgets import QApplication, QToolButton, QWidget
 
+from confusius._utils.colors import RED, RED_DARK
+
 _ASSETS_DIR = Path(__file__).parent / "assets"
 """Directory containing SVG icon assets for export buttons."""
 
@@ -59,7 +61,7 @@ def get_napari_colors(theme_name: str) -> dict:
     return {
         "bg": bg,
         "fg": fg,
-        "accent": "#e94b5f" if is_dark else "#d93a54",
+        "accent": RED if is_dark else RED_DARK,
         "is_dark": is_dark,
     }
 

--- a/src/confusius/_napari/_tour.py
+++ b/src/confusius/_napari/_tour.py
@@ -20,6 +20,8 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
+from confusius._utils.colors import RED, RED_DARK
+
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
 
@@ -76,7 +78,8 @@ _TOOLTIP_WIDTH = 300
 _SPOTLIGHT_PADDING = 6
 _SPOTLIGHT_RADIUS = 8
 _SPOTLIGHT_BORDER_WIDTH = 2
-_SPOTLIGHT_BORDER_COLOR = QColor(233, 75, 95, 230)  # #e94b5f, logo red
+_SPOTLIGHT_BORDER_COLOR = QColor(RED)
+_SPOTLIGHT_BORDER_COLOR.setAlpha(230)
 
 
 # ---------------------------------------------------------------------------
@@ -149,7 +152,7 @@ class _TourTooltip(QWidget):
 
     def apply_theme(self, *, is_dark: bool) -> None:
         """Apply theme colours."""
-        accent = "#e94b5f" if is_dark else "#d93a54"
+        accent = RED if is_dark else RED_DARK
         accent_fg = "#ffffff"
         bg = "#2d2d3a" if is_dark else "#ffffff"
         fg = "#c8c8d4" if is_dark else "#2c2c3a"

--- a/src/confusius/_napari/_widget.py
+++ b/src/confusius/_napari/_widget.py
@@ -32,6 +32,7 @@ from qtpy.QtWidgets import (
 from confusius._napari._events._store import EventStore
 from confusius._napari._theme import make_lucide_icon
 from confusius._napari._time_overlay import _TimeOverlay
+from confusius._utils.colors import RED, RED_DARK
 
 if TYPE_CHECKING:
     import napari
@@ -49,8 +50,8 @@ def _build_stylesheet(is_dark: bool, napari_bg: str | None = None) -> str:  # no
     group_title_bg = napari_bg or ("#1c1c27" if is_dark else "#f0f0e8")
     if is_dark:
         header_bg = napari_bg or "#1c1c27"
-        header_border = "#e94b5f"
-        accent = "#e94b5f"
+        header_border = RED
+        accent = RED
         accent_hover = "#f5728a"
         accent_fg = "#ffffff"
         tab_bg = "#2d2d3a"
@@ -69,8 +70,8 @@ def _build_stylesheet(is_dark: bool, napari_bg: str | None = None) -> str:  # no
         status_err = "#e05555"
     else:
         header_bg = napari_bg or "#f0f0e8"
-        header_border = "#d93a54"
-        accent = "#d93a54"
+        header_border = RED_DARK
+        accent = RED_DARK
         accent_hover = "#c02845"
         accent_fg = "#ffffff"
         tab_bg = "#e0e0e8"
@@ -320,7 +321,7 @@ class ConfUSIusWidget(QWidget):
 
     def _on_theme_changed(self) -> None:
         self._apply_theme()
-        accent = "#e94b5f" if self._is_dark() else "#d93a54"
+        accent = RED if self._is_dark() else RED_DARK
         for btn, icon_name in getattr(self, "_accordion_btns", []):
             btn.setIcon(make_lucide_icon(icon_name, accent))
 
@@ -516,7 +517,7 @@ class ConfUSIusWidget(QWidget):
         # Video panel (own section).
         video_panel = VideoPanel(self.viewer)
 
-        accent = "#e94b5f" if self._is_dark() else "#d93a54"
+        accent = RED if self._is_dark() else RED_DARK
         tab_entries = [
             ("Data I/O", "file-input"),
             ("Video", "video"),

--- a/src/confusius/_utils/colors.py
+++ b/src/confusius/_utils/colors.py
@@ -1,0 +1,16 @@
+"""ConfUSIus brand colors, matching the documentation theme.
+
+Single source of truth for the palette so the napari plugin, dataset citation
+messages, and any future consumer stay in sync.
+"""
+
+RED = "#e94b5f"
+"""Brand red (the logo red); the accent on the dark napari theme and the article
+title in printed dataset citations."""
+
+RED_DARK = "#d93a54"
+"""Darker brand red; the accent on the light napari theme, where `RED` lacks
+contrast against the pale background."""
+
+TURQUOISE = "#3ad9a4"
+"""Brand turquoise; the DOI link in printed dataset citations."""

--- a/src/confusius/datasets/_cybis_pereira_2026.py
+++ b/src/confusius/datasets/_cybis_pereira_2026.py
@@ -20,9 +20,9 @@ _TOTAL_SIZE_BYTES = 12_883_924_421
 _CITATION = (
     "Cybis Pereira, F., Castedo, S. H., Meur-Diebolt, S. L., Ialy-Radio, N., "
     "Bhattacharya, S., Ferrier, J., Osmanski, B. F., Cocco, S., Monasson, R., "
-    "Pezet, S., & Tanter, M. (2026). [magenta]A vascular code for speed in the spatial "
-    "navigation system.[/magenta] [italic]Cell Reports[/italic], 45(1). "
-    "[blue]https://doi.org/10.1016/j.celrep.2025.116791[/blue]"
+    "Pezet, S., & Tanter, M. (2026). [citation.title]A vascular code for speed in the "
+    "spatial navigation system.[/citation.title] [italic]Cell Reports[/italic], 45(1). "
+    "[citation.doi]https://doi.org/10.1016/j.celrep.2025.116791[/citation.doi]"
 )
 
 

--- a/src/confusius/datasets/_cybis_pereira_2026.py
+++ b/src/confusius/datasets/_cybis_pereira_2026.py
@@ -21,7 +21,8 @@ _CITATION = (
     "Cybis Pereira, F., Castedo, S. H., Meur-Diebolt, S. L., Ialy-Radio, N., "
     "Bhattacharya, S., Ferrier, J., Osmanski, B. F., Cocco, S., Monasson, R., "
     "Pezet, S., & Tanter, M. (2026). A vascular code for speed in the spatial "
-    "navigation system. Cell Reports, 45(1). https://doi.org/10.1016/"
+    "navigation system. [italic]Cell Reports[/italic], [bold]45(1)[/bold]. "
+    "https://doi.org/10.1016/"
     "j.celrep.2025.116791"
 )
 

--- a/src/confusius/datasets/_cybis_pereira_2026.py
+++ b/src/confusius/datasets/_cybis_pereira_2026.py
@@ -21,7 +21,7 @@ _CITATION = (
     "Cybis Pereira, F., Castedo, S. H., Meur-Diebolt, S. L., Ialy-Radio, N., "
     "Bhattacharya, S., Ferrier, J., Osmanski, B. F., Cocco, S., Monasson, R., "
     "Pezet, S., & Tanter, M. (2026). A vascular code for speed in the spatial "
-    "navigation system. [italic]Cell Reports[/italic], [bold]45(1)[/bold]. "
+    "navigation system. [italic]Cell Reports[/italic], 45(1). "
     "https://doi.org/10.1016/"
     "j.celrep.2025.116791"
 )

--- a/src/confusius/datasets/_cybis_pereira_2026.py
+++ b/src/confusius/datasets/_cybis_pereira_2026.py
@@ -12,13 +12,17 @@ from ._osf import (
     read_cached_index,
     update_cached_index,
 )
-from ._utils import get_datasets_dir
+from ._utils import get_datasets_dir, print_citation_message
 
 _OSF_PROJECT_ID = "2v6f7"
 _BIDS_ROOT = "cybis-pereira-2026-bids"
 _TOTAL_SIZE_BYTES = 12_883_924_421
 _CITATION = (
-    "Cybis Pereira, F. et al. (2026), https://doi.org/10.1016/j.celrep.2025.116791"
+    "Cybis Pereira, F., Castedo, S. H., Meur-Diebolt, S. L., Ialy-Radio, N., "
+    "Bhattacharya, S., Ferrier, J., Osmanski, B. F., Cocco, S., Monasson, R., "
+    "Pezet, S., & Tanter, M. (2026). A vascular code for speed in the spatial "
+    "navigation system. Cell Reports, 45(1). https://doi.org/10.1016/"
+    "j.celrep.2025.116791"
 )
 
 
@@ -195,7 +199,7 @@ def fetch_cybis_pereira_2026(
     acqs: str | list[str] | None = None,
     datatypes: str | list[str] | None = None,
     refresh: bool = False,
-    show_citation_msg: bool = True,
+    print_citation: bool = True,
 ) -> Path:
     """Fetch the Cybis Pereira 2026 fUSI-BIDS dataset.
 
@@ -246,8 +250,8 @@ def fetch_cybis_pereira_2026(
         MD5 changed upstream (comparing the cached index against the refreshed
         one) are re-downloaded. If `False` and all requested files are already
         cached, the function returns immediately without any network access.
-    show_citation_msg : bool, default: True
-        Whether to print a message with the citation for the dataset.
+    print_citation : bool, default: True
+        Whether to print the citation for the dataset.
 
     Returns
     -------
@@ -313,6 +317,6 @@ def fetch_cybis_pereira_2026(
     if refresh:
         update_cached_index(bids_dir, index, previous_index or {}, files)
 
-    if show_citation_msg:
-        print(f"Fetched data from {_CITATION}.")
+    if print_citation:
+        print_citation_message(_CITATION, "dataset")
     return bids_dir

--- a/src/confusius/datasets/_cybis_pereira_2026.py
+++ b/src/confusius/datasets/_cybis_pereira_2026.py
@@ -20,10 +20,9 @@ _TOTAL_SIZE_BYTES = 12_883_924_421
 _CITATION = (
     "Cybis Pereira, F., Castedo, S. H., Meur-Diebolt, S. L., Ialy-Radio, N., "
     "Bhattacharya, S., Ferrier, J., Osmanski, B. F., Cocco, S., Monasson, R., "
-    "Pezet, S., & Tanter, M. (2026). A vascular code for speed in the spatial "
-    "navigation system. [italic]Cell Reports[/italic], 45(1). "
-    "https://doi.org/10.1016/"
-    "j.celrep.2025.116791"
+    "Pezet, S., & Tanter, M. (2026). [magenta]A vascular code for speed in the spatial "
+    "navigation system.[/magenta] [italic]Cell Reports[/italic], 45(1). "
+    "[blue]https://doi.org/10.1016/j.celrep.2025.116791[/blue]"
 )
 
 

--- a/src/confusius/datasets/_cybis_pereira_2026.py
+++ b/src/confusius/datasets/_cybis_pereira_2026.py
@@ -17,6 +17,9 @@ from ._utils import get_datasets_dir
 _OSF_PROJECT_ID = "2v6f7"
 _BIDS_ROOT = "cybis-pereira-2026-bids"
 _TOTAL_SIZE_BYTES = 12_883_924_421
+_CITATION = (
+    "Cybis Pereira, F. et al. (2026), https://doi.org/10.1016/j.celrep.2025.116791"
+)
 
 
 _VALID_DATASETS = frozenset(
@@ -192,6 +195,7 @@ def fetch_cybis_pereira_2026(
     acqs: str | list[str] | None = None,
     datatypes: str | list[str] | None = None,
     refresh: bool = False,
+    show_citation_msg: bool = True,
 ) -> Path:
     """Fetch the Cybis Pereira 2026 fUSI-BIDS dataset.
 
@@ -242,6 +246,8 @@ def fetch_cybis_pereira_2026(
         MD5 changed upstream (comparing the cached index against the refreshed
         one) are re-downloaded. If `False` and all requested files are already
         cached, the function returns immediately without any network access.
+    show_citation_msg : bool, default: True
+        Whether to print a message with the citation for the dataset.
 
     Returns
     -------
@@ -307,4 +313,6 @@ def fetch_cybis_pereira_2026(
     if refresh:
         update_cached_index(bids_dir, index, previous_index or {}, files)
 
+    if show_citation_msg:
+        print(f"Fetched data from {_CITATION}.")
     return bids_dir

--- a/src/confusius/datasets/_huang_2025.py
+++ b/src/confusius/datasets/_huang_2025.py
@@ -11,7 +11,7 @@ import xarray as xr
 from confusius.io.loadsave import load
 
 from ._pooch import quiet_pooch_logger, retrieve_with_retries
-from ._utils import get_datasets_dir, print_citation_message
+from ._utils import get_datasets_dir, plain_citation, print_citation_message
 
 _OSF_PROJECT_ID = "am3jw"
 _TEMPLATE_ROOT = "huang-2025-template"
@@ -21,7 +21,8 @@ _CITATION = (
     "Huang, Y.-A., Lambert, T., Verbeyst, D., Fitzgerald, N. E., Grillet, M., "
     "Brunner, C., Montaldo, G., Vanduffel, W., & Urban, A. (2025). OfUSA: OpenfUS "
     "Analyzer, a versatile open-source framework for the analysis and visualization "
-    "of functional ultrasound imaging data across animal models. bioRxiv. "
+    "of functional ultrasound imaging data across animal models. "
+    "[italic]bioRxiv[/italic]. "
     "https://doi.org/10.1101/2025.09.16.676515"
 )
 
@@ -111,7 +112,7 @@ def fetch_template_huang_2025(
             retrieve_with_retries(url, dest, logger=pooch.get_logger())
 
     da = load(dest)
-    da.attrs["citation"] = _CITATION
+    da.attrs["citation"] = plain_citation(_CITATION)
 
     if print_citation:
         print_citation_message(_CITATION, "template")

--- a/src/confusius/datasets/_huang_2025.py
+++ b/src/confusius/datasets/_huang_2025.py
@@ -17,6 +17,7 @@ _OSF_PROJECT_ID = "am3jw"
 _TEMPLATE_ROOT = "huang-2025-template"
 _FILENAME = "huang-2026-space-allen50_desc-vascular.nii.gz"
 _TOTAL_SIZE_BYTES = 16_338_947
+_CITATION = "Huang, Y.-A. et al. (2025), https://doi.org/10.1101/2025.09.16.676515"
 
 
 def resolve_template_url(project_id: str = _OSF_PROJECT_ID) -> str:
@@ -52,6 +53,7 @@ def resolve_template_url(project_id: str = _OSF_PROJECT_ID) -> str:
 def fetch_template_huang_2025(
     data_dir: str | Path | None = None,
     refresh: bool = False,
+    show_citation_msg: bool = True,
 ) -> xr.DataArray:
     """Fetch the Huang et al. (2025) mouse vascular fUSI template.
 
@@ -67,6 +69,8 @@ def fetch_template_huang_2025(
         `CONFUSIUS_DATA` environment variable.
     refresh : bool, default: False
         Whether to redownload the template even if it is already cached.
+    show_citation_msg : bool, default: True
+        Whether to print a message with the citation for the template.
 
     Returns
     -------
@@ -100,4 +104,9 @@ def fetch_template_huang_2025(
         with quiet_pooch_logger():
             retrieve_with_retries(url, dest, logger=pooch.get_logger())
 
-    return load(dest)
+    da = load(dest)
+    da.attrs["citation"] = _CITATION
+
+    if show_citation_msg:
+        print(f"Fetched data from {_CITATION}.")
+    return da

--- a/src/confusius/datasets/_huang_2025.py
+++ b/src/confusius/datasets/_huang_2025.py
@@ -20,10 +20,10 @@ _TOTAL_SIZE_BYTES = 16_338_947
 _CITATION = (
     "Huang, Y.-A., Lambert, T., Verbeyst, D., Fitzgerald, N. E., Grillet, M., "
     "Brunner, C., Montaldo, G., Vanduffel, W., & Urban, A. (2025). "
-    "[magenta]OfUSA: OpenfUS Analyzer, a versatile open-source framework for the "
+    "[citation.title]OfUSA: OpenfUS Analyzer, a versatile open-source framework for the "
     "analysis and visualization of functional ultrasound imaging data across animal "
-    "models.[/magenta] [italic]bioRxiv[/italic]. "
-    "[blue]https://doi.org/10.1101/2025.09.16.676515[/blue]"
+    "models.[/citation.title] [italic]bioRxiv[/italic]. "
+    "[citation.doi]https://doi.org/10.1101/2025.09.16.676515[/citation.doi]"
 )
 
 

--- a/src/confusius/datasets/_huang_2025.py
+++ b/src/confusius/datasets/_huang_2025.py
@@ -11,13 +11,19 @@ import xarray as xr
 from confusius.io.loadsave import load
 
 from ._pooch import quiet_pooch_logger, retrieve_with_retries
-from ._utils import get_datasets_dir
+from ._utils import get_datasets_dir, print_citation_message
 
 _OSF_PROJECT_ID = "am3jw"
 _TEMPLATE_ROOT = "huang-2025-template"
 _FILENAME = "huang-2026-space-allen50_desc-vascular.nii.gz"
 _TOTAL_SIZE_BYTES = 16_338_947
-_CITATION = "Huang, Y.-A. et al. (2025), https://doi.org/10.1101/2025.09.16.676515"
+_CITATION = (
+    "Huang, Y.-A., Lambert, T., Verbeyst, D., Fitzgerald, N. E., Grillet, M., "
+    "Brunner, C., Montaldo, G., Vanduffel, W., & Urban, A. (2025). OfUSA: OpenfUS "
+    "Analyzer, a versatile open-source framework for the analysis and visualization "
+    "of functional ultrasound imaging data across animal models. bioRxiv. "
+    "https://doi.org/10.1101/2025.09.16.676515"
+)
 
 
 def resolve_template_url(project_id: str = _OSF_PROJECT_ID) -> str:
@@ -53,7 +59,7 @@ def resolve_template_url(project_id: str = _OSF_PROJECT_ID) -> str:
 def fetch_template_huang_2025(
     data_dir: str | Path | None = None,
     refresh: bool = False,
-    show_citation_msg: bool = True,
+    print_citation: bool = True,
 ) -> xr.DataArray:
     """Fetch the Huang et al. (2025) mouse vascular fUSI template.
 
@@ -69,8 +75,8 @@ def fetch_template_huang_2025(
         `CONFUSIUS_DATA` environment variable.
     refresh : bool, default: False
         Whether to redownload the template even if it is already cached.
-    show_citation_msg : bool, default: True
-        Whether to print a message with the citation for the template.
+    print_citation : bool, default: True
+        Whether to print the citation for the template.
 
     Returns
     -------
@@ -107,6 +113,6 @@ def fetch_template_huang_2025(
     da = load(dest)
     da.attrs["citation"] = _CITATION
 
-    if show_citation_msg:
-        print(f"Fetched data from {_CITATION}.")
+    if print_citation:
+        print_citation_message(_CITATION, "template")
     return da

--- a/src/confusius/datasets/_huang_2025.py
+++ b/src/confusius/datasets/_huang_2025.py
@@ -19,11 +19,11 @@ _FILENAME = "huang-2026-space-allen50_desc-vascular.nii.gz"
 _TOTAL_SIZE_BYTES = 16_338_947
 _CITATION = (
     "Huang, Y.-A., Lambert, T., Verbeyst, D., Fitzgerald, N. E., Grillet, M., "
-    "Brunner, C., Montaldo, G., Vanduffel, W., & Urban, A. (2025). OfUSA: OpenfUS "
-    "Analyzer, a versatile open-source framework for the analysis and visualization "
-    "of functional ultrasound imaging data across animal models. "
-    "[italic]bioRxiv[/italic]. "
-    "https://doi.org/10.1101/2025.09.16.676515"
+    "Brunner, C., Montaldo, G., Vanduffel, W., & Urban, A. (2025). "
+    "[magenta]OfUSA: OpenfUS Analyzer, a versatile open-source framework for the "
+    "analysis and visualization of functional ultrasound imaging data across animal "
+    "models.[/magenta] [italic]bioRxiv[/italic]. "
+    "[blue]https://doi.org/10.1101/2025.09.16.676515[/blue]"
 )
 
 

--- a/src/confusius/datasets/_landemard_2026.py
+++ b/src/confusius/datasets/_landemard_2026.py
@@ -12,12 +12,16 @@ from ._osf import (
     read_cached_index,
     update_cached_index,
 )
-from ._utils import get_datasets_dir
+from ._utils import get_datasets_dir, print_citation_message
 
 _OSF_PROJECT_ID = "dkseb"
 _BIDS_ROOT = "landemard-2026-bids"
 _TOTAL_SIZE_BYTES = 42_036_009_786
-_CITATION = "Landemard, A. et al. (2026), https://doi.org/10.1038/s41586-026-10350-9"
+_CITATION = (
+    "Landemard, A., Krumin, M., Harris, K. D., & Carandini, M. (2026). Brainwide "
+    "blood volume reflects opposing neural populations. Nature. "
+    "https://doi.org/10.1038/s41586-026-10350-9"
+)
 
 
 _VALID_DATASETS = frozenset({"rawdata", "atlas_mapping", "processed_data"})
@@ -133,7 +137,7 @@ def fetch_landemard_2026(
     acqs: str | list[str] | None = None,
     datatypes: str | list[str] | None = None,
     refresh: bool = False,
-    show_citation_msg: bool = True,
+    print_citation: bool = True,
 ) -> Path:
     """Fetch the Landemard 2026 fUSI-BIDS dataset.
 
@@ -174,8 +178,8 @@ def fetch_landemard_2026(
         (comparing the cached index against the refreshed one) are re-downloaded. If
         `False` and all requested files are already cached, the function returns
         immediately without any network access.
-    show_citation_msg : bool, default: True
-        Whether to print a message with the citation for the dataset.
+    print_citation : bool, default: True
+        Whether to print the citation for the dataset.
 
     Returns
     -------
@@ -239,6 +243,6 @@ def fetch_landemard_2026(
     if refresh:
         update_cached_index(bids_dir, index, previous_index or {}, files)
 
-    if show_citation_msg:
-        print(f"Fetched data from {_CITATION}.")
+    if print_citation:
+        print_citation_message(_CITATION, "dataset")
     return bids_dir

--- a/src/confusius/datasets/_landemard_2026.py
+++ b/src/confusius/datasets/_landemard_2026.py
@@ -19,7 +19,7 @@ _BIDS_ROOT = "landemard-2026-bids"
 _TOTAL_SIZE_BYTES = 42_036_009_786
 _CITATION = (
     "Landemard, A., Krumin, M., Harris, K. D., & Carandini, M. (2026). Brainwide "
-    "blood volume reflects opposing neural populations. Nature. "
+    "blood volume reflects opposing neural populations. [italic]Nature[/italic]. "
     "https://doi.org/10.1038/s41586-026-10350-9"
 )
 

--- a/src/confusius/datasets/_landemard_2026.py
+++ b/src/confusius/datasets/_landemard_2026.py
@@ -18,9 +18,9 @@ _OSF_PROJECT_ID = "dkseb"
 _BIDS_ROOT = "landemard-2026-bids"
 _TOTAL_SIZE_BYTES = 42_036_009_786
 _CITATION = (
-    "Landemard, A., Krumin, M., Harris, K. D., & Carandini, M. (2026). Brainwide "
-    "blood volume reflects opposing neural populations. [italic]Nature[/italic]. "
-    "https://doi.org/10.1038/s41586-026-10350-9"
+    "Landemard, A., Krumin, M., Harris, K. D., & Carandini, M. (2026). "
+    "[magenta]Brainwide blood volume reflects opposing neural populations.[/magenta]"
+    "[italic]Nature[/italic]. [blue]https://doi.org/10.1038/s41586-026-10350-9[/blue]"
 )
 
 

--- a/src/confusius/datasets/_landemard_2026.py
+++ b/src/confusius/datasets/_landemard_2026.py
@@ -19,8 +19,9 @@ _BIDS_ROOT = "landemard-2026-bids"
 _TOTAL_SIZE_BYTES = 42_036_009_786
 _CITATION = (
     "Landemard, A., Krumin, M., Harris, K. D., & Carandini, M. (2026). "
-    "[magenta]Brainwide blood volume reflects opposing neural populations.[/magenta]"
-    "[italic]Nature[/italic]. [blue]https://doi.org/10.1038/s41586-026-10350-9[/blue]"
+    "[citation.title]Brainwide blood volume reflects opposing neural populations."
+    "[/citation.title] [italic]Nature[/italic]. "
+    "[citation.doi]https://doi.org/10.1038/s41586-026-10350-9[/citation.doi]"
 )
 
 

--- a/src/confusius/datasets/_landemard_2026.py
+++ b/src/confusius/datasets/_landemard_2026.py
@@ -17,6 +17,7 @@ from ._utils import get_datasets_dir
 _OSF_PROJECT_ID = "dkseb"
 _BIDS_ROOT = "landemard-2026-bids"
 _TOTAL_SIZE_BYTES = 42_036_009_786
+_CITATION = "Landemard, A. et al. (2026), https://doi.org/10.1038/s41586-026-10350-9"
 
 
 _VALID_DATASETS = frozenset({"rawdata", "atlas_mapping", "processed_data"})
@@ -132,6 +133,7 @@ def fetch_landemard_2026(
     acqs: str | list[str] | None = None,
     datatypes: str | list[str] | None = None,
     refresh: bool = False,
+    show_citation_msg: bool = True,
 ) -> Path:
     """Fetch the Landemard 2026 fUSI-BIDS dataset.
 
@@ -172,6 +174,8 @@ def fetch_landemard_2026(
         (comparing the cached index against the refreshed one) are re-downloaded. If
         `False` and all requested files are already cached, the function returns
         immediately without any network access.
+    show_citation_msg : bool, default: True
+        Whether to print a message with the citation for the dataset.
 
     Returns
     -------
@@ -235,4 +239,6 @@ def fetch_landemard_2026(
     if refresh:
         update_cached_index(bids_dir, index, previous_index or {}, files)
 
+    if show_citation_msg:
+        print(f"Fetched data from {_CITATION}.")
     return bids_dir

--- a/src/confusius/datasets/_nunez_elizalde_2022.py
+++ b/src/confusius/datasets/_nunez_elizalde_2022.py
@@ -20,7 +20,7 @@ _TOTAL_SIZE_BYTES = 6_982_575_320
 _CITATION = (
     "Nunez-Elizalde, A. O., Krumin, M., Reddy, C. B., Montaldo, G., Urban, A., "
     "Harris, K. D., & Carandini, M. (2022). Neural correlates of blood flow "
-    "measured by ultrasound. [italic]Neuron[/italic], [bold]110(10)[/bold], "
+    "measured by ultrasound. [italic]Neuron[/italic], 110(10), "
     "1631–1640.e4. "
     "https://doi.org/10.1016/j.neuron.2022.02.012"
 )

--- a/src/confusius/datasets/_nunez_elizalde_2022.py
+++ b/src/confusius/datasets/_nunez_elizalde_2022.py
@@ -17,6 +17,9 @@ from ._utils import get_datasets_dir
 _OSF_PROJECT_ID = "43skw"
 _BIDS_ROOT = "nunez-elizalde-2022-bids"
 _TOTAL_SIZE_BYTES = 6_982_575_320
+_CITATION = (
+    "Nunez-Elizalde, A.O. et al. (2022), https://doi.org/10.1016/j.neuron.2022.02.012"
+)
 
 
 def _filter_files(
@@ -125,6 +128,7 @@ def fetch_nunez_elizalde_2022(
     tasks: str | list[str] | None = None,
     acqs: str | list[str] | None = None,
     refresh: bool = False,
+    show_citation_msg: bool = True,
 ) -> Path:
     """Fetch the Nunez-Elizalde 2022 fUSI-BIDS dataset.
 
@@ -167,6 +171,8 @@ def fetch_nunez_elizalde_2022(
         (comparing the cached index against the refreshed one) are re-downloaded. If
         `False` and all requested files are already cached, the function returns
         immediately without any network access.
+    show_citation_msg : bool, default: True
+        Whether to print a message with the citation for the dataset.
 
     Returns
     -------
@@ -208,4 +214,6 @@ def fetch_nunez_elizalde_2022(
     if refresh:
         update_cached_index(bids_dir, index, previous_index or {}, files)
 
+    if show_citation_msg:
+        print(f"Fetched data from {_CITATION}.")
     return bids_dir

--- a/src/confusius/datasets/_nunez_elizalde_2022.py
+++ b/src/confusius/datasets/_nunez_elizalde_2022.py
@@ -19,10 +19,10 @@ _BIDS_ROOT = "nunez-elizalde-2022-bids"
 _TOTAL_SIZE_BYTES = 6_982_575_320
 _CITATION = (
     "Nunez-Elizalde, A. O., Krumin, M., Reddy, C. B., Montaldo, G., Urban, A., "
-    "Harris, K. D., & Carandini, M. (2022). Neural correlates of blood flow "
-    "measured by ultrasound. [italic]Neuron[/italic], 110(10), "
+    "Harris, K. D., & Carandini, M. (2022). [magenta]Neural correlates of blood flow "
+    "measured by ultrasound.[/magenta] [italic]Neuron[/italic], 110(10), "
     "1631–1640.e4. "
-    "https://doi.org/10.1016/j.neuron.2022.02.012"
+    "[blue]https://doi.org/10.1016/j.neuron.2022.02.012[/blue]"
 )
 
 

--- a/src/confusius/datasets/_nunez_elizalde_2022.py
+++ b/src/confusius/datasets/_nunez_elizalde_2022.py
@@ -12,13 +12,16 @@ from ._osf import (
     read_cached_index,
     update_cached_index,
 )
-from ._utils import get_datasets_dir
+from ._utils import get_datasets_dir, print_citation_message
 
 _OSF_PROJECT_ID = "43skw"
 _BIDS_ROOT = "nunez-elizalde-2022-bids"
 _TOTAL_SIZE_BYTES = 6_982_575_320
 _CITATION = (
-    "Nunez-Elizalde, A.O. et al. (2022), https://doi.org/10.1016/j.neuron.2022.02.012"
+    "Nunez-Elizalde, A. O., Krumin, M., Reddy, C. B., Montaldo, G., Urban, A., "
+    "Harris, K. D., & Carandini, M. (2022). Neural correlates of blood flow "
+    "measured by ultrasound. Neuron, 110(10), 1631–1640.e4. "
+    "https://doi.org/10.1016/j.neuron.2022.02.012"
 )
 
 
@@ -128,7 +131,7 @@ def fetch_nunez_elizalde_2022(
     tasks: str | list[str] | None = None,
     acqs: str | list[str] | None = None,
     refresh: bool = False,
-    show_citation_msg: bool = True,
+    print_citation: bool = True,
 ) -> Path:
     """Fetch the Nunez-Elizalde 2022 fUSI-BIDS dataset.
 
@@ -171,8 +174,8 @@ def fetch_nunez_elizalde_2022(
         (comparing the cached index against the refreshed one) are re-downloaded. If
         `False` and all requested files are already cached, the function returns
         immediately without any network access.
-    show_citation_msg : bool, default: True
-        Whether to print a message with the citation for the dataset.
+    print_citation : bool, default: True
+        Whether to print the citation for the dataset.
 
     Returns
     -------
@@ -214,6 +217,6 @@ def fetch_nunez_elizalde_2022(
     if refresh:
         update_cached_index(bids_dir, index, previous_index or {}, files)
 
-    if show_citation_msg:
-        print(f"Fetched data from {_CITATION}.")
+    if print_citation:
+        print_citation_message(_CITATION, "dataset")
     return bids_dir

--- a/src/confusius/datasets/_nunez_elizalde_2022.py
+++ b/src/confusius/datasets/_nunez_elizalde_2022.py
@@ -20,7 +20,8 @@ _TOTAL_SIZE_BYTES = 6_982_575_320
 _CITATION = (
     "Nunez-Elizalde, A. O., Krumin, M., Reddy, C. B., Montaldo, G., Urban, A., "
     "Harris, K. D., & Carandini, M. (2022). Neural correlates of blood flow "
-    "measured by ultrasound. Neuron, 110(10), 1631–1640.e4. "
+    "measured by ultrasound. [italic]Neuron[/italic], [bold]110(10)[/bold], "
+    "1631–1640.e4. "
     "https://doi.org/10.1016/j.neuron.2022.02.012"
 )
 

--- a/src/confusius/datasets/_nunez_elizalde_2022.py
+++ b/src/confusius/datasets/_nunez_elizalde_2022.py
@@ -19,10 +19,10 @@ _BIDS_ROOT = "nunez-elizalde-2022-bids"
 _TOTAL_SIZE_BYTES = 6_982_575_320
 _CITATION = (
     "Nunez-Elizalde, A. O., Krumin, M., Reddy, C. B., Montaldo, G., Urban, A., "
-    "Harris, K. D., & Carandini, M. (2022). [magenta]Neural correlates of blood flow "
-    "measured by ultrasound.[/magenta] [italic]Neuron[/italic], 110(10), "
+    "Harris, K. D., & Carandini, M. (2022). [citation.title]Neural correlates of blood "
+    "flow measured by ultrasound.[/citation.title] [italic]Neuron[/italic], 110(10), "
     "1631–1640.e4. "
-    "[blue]https://doi.org/10.1016/j.neuron.2022.02.012[/blue]"
+    "[citation.doi]https://doi.org/10.1016/j.neuron.2022.02.012[/citation.doi]"
 )
 
 

--- a/src/confusius/datasets/_pepe_mariani_2026.py
+++ b/src/confusius/datasets/_pepe_mariani_2026.py
@@ -11,7 +11,7 @@ import xarray as xr
 from confusius.io.loadsave import load
 
 from ._pooch import quiet_pooch_logger, retrieve_with_retries
-from ._utils import get_datasets_dir, print_citation_message
+from ._utils import get_datasets_dir, plain_citation, print_citation_message
 
 _OSF_PROJECT_ID = "43tu9"
 _TEMPLATE_ROOT = "pepe-mariani-2026-template"
@@ -21,7 +21,8 @@ _CITATION = (
     "Pepe, C., Mariani, J.-C., Urosevic, M., Gini, S., Stuefer, A., Ricci, F., "
     "Galbusera, A., Iurilli, G., & Gozzi, A. (2026). Structural and dynamic "
     "embedding of the mouse functional connectome revealed by functional ultrasound "
-    "imaging (fUSI). bioRxiv. https://doi.org/10.64898/2026.02.05.704055"
+    "imaging (fUSI). [italic]bioRxiv[/italic]. "
+    "https://doi.org/10.64898/2026.02.05.704055"
 )
 
 
@@ -110,7 +111,7 @@ def fetch_template_pepe_mariani_2026(
             retrieve_with_retries(url, dest, logger=pooch.get_logger())
 
     da = load(dest)
-    da.attrs["citation"] = _CITATION
+    da.attrs["citation"] = plain_citation(_CITATION)
 
     if print_citation:
         print_citation_message(_CITATION, "template")

--- a/src/confusius/datasets/_pepe_mariani_2026.py
+++ b/src/confusius/datasets/_pepe_mariani_2026.py
@@ -20,9 +20,10 @@ _TOTAL_SIZE_BYTES = 5_507_550
 _CITATION = (
     "Pepe, C., Mariani, J.-C., Urosevic, M., Gini, S., Stuefer, A., Ricci, F., "
     "Galbusera, A., Iurilli, G., & Gozzi, A. (2026). "
-    "[magenta]Structural and dynamic embedding of the mouse functional connectome "
-    "revealed by functional ultrasound imaging (fUSI).[/magenta] "
-    "[italic]bioRxiv[/italic]. [blue]https://doi.org/10.64898/2026.02.05.704055[/blue]"
+    "[citation.title]Structural and dynamic embedding of the mouse functional "
+    "connectome revealed by functional ultrasound imaging (fUSI).[/citation.title] "
+    "[italic]bioRxiv[/italic]. "
+    "[citation.doi]https://doi.org/10.64898/2026.02.05.704055[/citation.doi]"
 )
 
 

--- a/src/confusius/datasets/_pepe_mariani_2026.py
+++ b/src/confusius/datasets/_pepe_mariani_2026.py
@@ -17,6 +17,7 @@ _OSF_PROJECT_ID = "43tu9"
 _TEMPLATE_ROOT = "pepe-mariani-2026-template"
 _FILENAME = "pepe-mariani-2026-fusi-template.nii.gz"
 _TOTAL_SIZE_BYTES = 5_507_550
+_CITATION = "Pepe, C. et al. (2026), https://doi.org/10.64898/2026.02.05.704055"
 
 
 def resolve_template_url(project_id: str = _OSF_PROJECT_ID) -> str:
@@ -52,6 +53,7 @@ def resolve_template_url(project_id: str = _OSF_PROJECT_ID) -> str:
 def fetch_template_pepe_mariani_2026(
     data_dir: str | Path | None = None,
     refresh: bool = False,
+    show_citation_msg: bool = True,
 ) -> xr.DataArray:
     """Fetch the Pepe, Mariani et al. (2026) mouse fUSI template.
 
@@ -67,6 +69,8 @@ def fetch_template_pepe_mariani_2026(
         `CONFUSIUS_DATA` environment variable.
     refresh : bool, default: False
         Whether to redownload the template even if it is already cached.
+    show_citation_msg : bool, default: True
+        Whether to print a message with the citation for the template.
 
     Returns
     -------
@@ -100,4 +104,9 @@ def fetch_template_pepe_mariani_2026(
         with quiet_pooch_logger():
             retrieve_with_retries(url, dest, logger=pooch.get_logger())
 
-    return load(dest)
+    da = load(dest)
+    da.attrs["citation"] = _CITATION
+
+    if show_citation_msg:
+        print(f"Fetched data from {_CITATION}.")
+    return da

--- a/src/confusius/datasets/_pepe_mariani_2026.py
+++ b/src/confusius/datasets/_pepe_mariani_2026.py
@@ -19,10 +19,10 @@ _FILENAME = "pepe-mariani-2026-fusi-template.nii.gz"
 _TOTAL_SIZE_BYTES = 5_507_550
 _CITATION = (
     "Pepe, C., Mariani, J.-C., Urosevic, M., Gini, S., Stuefer, A., Ricci, F., "
-    "Galbusera, A., Iurilli, G., & Gozzi, A. (2026). Structural and dynamic "
-    "embedding of the mouse functional connectome revealed by functional ultrasound "
-    "imaging (fUSI). [italic]bioRxiv[/italic]. "
-    "https://doi.org/10.64898/2026.02.05.704055"
+    "Galbusera, A., Iurilli, G., & Gozzi, A. (2026). "
+    "[magenta]Structural and dynamic embedding of the mouse functional connectome "
+    "revealed by functional ultrasound imaging (fUSI).[/magenta] "
+    "[italic]bioRxiv[/italic]. [blue]https://doi.org/10.64898/2026.02.05.704055[/blue]"
 )
 
 

--- a/src/confusius/datasets/_pepe_mariani_2026.py
+++ b/src/confusius/datasets/_pepe_mariani_2026.py
@@ -11,13 +11,18 @@ import xarray as xr
 from confusius.io.loadsave import load
 
 from ._pooch import quiet_pooch_logger, retrieve_with_retries
-from ._utils import get_datasets_dir
+from ._utils import get_datasets_dir, print_citation_message
 
 _OSF_PROJECT_ID = "43tu9"
 _TEMPLATE_ROOT = "pepe-mariani-2026-template"
 _FILENAME = "pepe-mariani-2026-fusi-template.nii.gz"
 _TOTAL_SIZE_BYTES = 5_507_550
-_CITATION = "Pepe, C. et al. (2026), https://doi.org/10.64898/2026.02.05.704055"
+_CITATION = (
+    "Pepe, C., Mariani, J.-C., Urosevic, M., Gini, S., Stuefer, A., Ricci, F., "
+    "Galbusera, A., Iurilli, G., & Gozzi, A. (2026). Structural and dynamic "
+    "embedding of the mouse functional connectome revealed by functional ultrasound "
+    "imaging (fUSI). bioRxiv. https://doi.org/10.64898/2026.02.05.704055"
+)
 
 
 def resolve_template_url(project_id: str = _OSF_PROJECT_ID) -> str:
@@ -53,7 +58,7 @@ def resolve_template_url(project_id: str = _OSF_PROJECT_ID) -> str:
 def fetch_template_pepe_mariani_2026(
     data_dir: str | Path | None = None,
     refresh: bool = False,
-    show_citation_msg: bool = True,
+    print_citation: bool = True,
 ) -> xr.DataArray:
     """Fetch the Pepe, Mariani et al. (2026) mouse fUSI template.
 
@@ -69,8 +74,8 @@ def fetch_template_pepe_mariani_2026(
         `CONFUSIUS_DATA` environment variable.
     refresh : bool, default: False
         Whether to redownload the template even if it is already cached.
-    show_citation_msg : bool, default: True
-        Whether to print a message with the citation for the template.
+    print_citation : bool, default: True
+        Whether to print the citation for the template.
 
     Returns
     -------
@@ -107,6 +112,6 @@ def fetch_template_pepe_mariani_2026(
     da = load(dest)
     da.attrs["citation"] = _CITATION
 
-    if show_citation_msg:
-        print(f"Fetched data from {_CITATION}.")
+    if print_citation:
+        print_citation_message(_CITATION, "template")
     return da

--- a/src/confusius/datasets/_utils.py
+++ b/src/confusius/datasets/_utils.py
@@ -4,10 +4,26 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from typing import Literal
 
 import pooch
 
 _ENV_VAR = "CONFUSIUS_DATA"
+
+
+def print_citation_message(citation: str, kind: Literal["dataset", "template"]) -> None:
+    """Print a citation prompt for a fetched dataset or template.
+
+    Parameters
+    ----------
+    citation : str
+        Citation text to print.
+    kind : {"dataset", "template"}
+        Resource kind used in the prompt.
+    """
+    print(
+        f"If you use this {kind} in your work, please cite the following source:\n{citation}"
+    )
 
 
 def get_datasets_dir(data_dir: str | Path | None = None) -> Path:

--- a/src/confusius/datasets/_utils.py
+++ b/src/confusius/datasets/_utils.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Literal
 
 import pooch
+from rich import print as rich_print
 
 _ENV_VAR = "CONFUSIUS_DATA"
 
@@ -21,9 +22,8 @@ def print_citation_message(citation: str, kind: Literal["dataset", "template"]) 
     kind : {"dataset", "template"}
         Resource kind used in the prompt.
     """
-    print(
-        f"If you use this {kind} in your work, please cite the following source:\n{citation}"
-    )
+    print(f"If you use this {kind} in your work, please cite the following source:\n")
+    rich_print(f"[bold]{citation}[/bold]")
 
 
 def get_datasets_dir(data_dir: str | Path | None = None) -> Path:

--- a/src/confusius/datasets/_utils.py
+++ b/src/confusius/datasets/_utils.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-import re
 from pathlib import Path
 from typing import Literal
 
@@ -12,9 +11,6 @@ from rich import print as rich_print
 from rich.text import Text
 
 _ENV_VAR = "CONFUSIUS_DATA"
-
-_DOI_URL_RE = re.compile(r"https://doi\.org/\S+")
-"""Pattern matching a DOI URL, rendered as a clickable link in the citation."""
 
 
 def print_citation_message(citation: str, kind: Literal["dataset", "template"]) -> None:
@@ -31,12 +27,8 @@ def print_citation_message(citation: str, kind: Literal["dataset", "template"]) 
     # Render as a Text renderable rather than a str so the markup styles apply but
     # rich's auto-highlighter does not colorize numbers, URLs, etc.
     text = Text.from_markup(citation)
-    # Bold the whole citation; the journal name's `[italic]` markup makes it bold italic.
+    # Bold the whole citation; the rest of the markup is in each _CITATION string.
     text.stylize("bold")
-    # Show the DOI as a blue OSC 8 hyperlink where the terminal supports it.
-    match = _DOI_URL_RE.search(text.plain)
-    if match:
-        text.stylize(f"blue link {match.group()}", match.start(), match.end())
     rich_print(text)
 
 

--- a/src/confusius/datasets/_utils.py
+++ b/src/confusius/datasets/_utils.py
@@ -7,10 +7,24 @@ from pathlib import Path
 from typing import Literal
 
 import pooch
-from rich import print as rich_print
+from rich.console import Console
 from rich.text import Text
+from rich.theme import Theme
 
 _ENV_VAR = "CONFUSIUS_DATA"
+
+CONFUSIUS_TURQUOISE = "#3ad9a4"
+"""Confusius brand turquoise, matching the docs theme."""
+
+CONFUSIUS_RED = "#e94b5f"
+"""Confusius brand red, matching the docs theme."""
+
+_CITATION_THEME = Theme(
+    {"citation.title": CONFUSIUS_RED, "citation.doi": CONFUSIUS_TURQUOISE}
+)
+"""Maps the citation style names used in `_CITATION` markup to brand colors."""
+
+_console = Console(theme=_CITATION_THEME)
 
 
 def print_citation_message(citation: str, kind: Literal["dataset", "template"]) -> None:
@@ -19,17 +33,20 @@ def print_citation_message(citation: str, kind: Literal["dataset", "template"]) 
     Parameters
     ----------
     citation : str
-        Citation text to print. Rich markup (e.g. `[italic]`) is rendered.
+        Citation text to print. Rich markup (e.g. `[italic]`, `[citation.title]`)
+        is rendered.
     kind : {"dataset", "template"}
         Resource kind used in the prompt.
     """
-    print(f"If you use this {kind} in your work, please cite the following source:\n")
+    _console.print(
+        f"If you use this {kind} in your work, please cite the following source:\n"
+    )
     # Render as a Text renderable rather than a str so the markup styles apply but
     # rich's auto-highlighter does not colorize numbers, URLs, etc.
     text = Text.from_markup(citation)
     # Bold the whole citation; the rest of the markup is in each _CITATION string.
     text.stylize("bold")
-    rich_print(text)
+    _console.print(text)
 
 
 def plain_citation(citation: str) -> str:

--- a/src/confusius/datasets/_utils.py
+++ b/src/confusius/datasets/_utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 from pathlib import Path
 from typing import Literal
 
@@ -18,6 +19,9 @@ _ENV_VAR = "CONFUSIUS_DATA"
 _CITATION_THEME = Theme({"citation.title": RED, "citation.doi": TURQUOISE})
 """Maps the citation style names used in `_CITATION` markup to brand colors."""
 
+_DOI_URL_RE = re.compile(r"https://doi\.org/\S+")
+"""Pattern matching the DOI URL, turned into a clickable link when printed."""
+
 _console = Console(theme=_CITATION_THEME)
 
 
@@ -32,15 +36,21 @@ def print_citation_message(citation: str, kind: Literal["dataset", "template"]) 
     kind : {"dataset", "template"}
         Resource kind used in the prompt.
     """
-    _console.print(
-        f"If you use this {kind} in your work, please cite the following source:\n"
-    )
     # Render as a Text renderable rather than a str so the markup styles apply but
     # rich's auto-highlighter does not colorize numbers, URLs, etc.
     text = Text.from_markup(citation)
     # Bold the whole citation; the rest of the markup is in each _CITATION string.
     text.stylize("bold")
-    _console.print(text)
+    # Attach a link to the DOI so it renders as a clickable `<a>` in the docs gallery
+    # HTML. Terminals linkify bare URLs on their own, but browsers do not.
+    match = _DOI_URL_RE.search(text.plain)
+    if match:
+        text.stylize(f"link {match.group()}", match.start(), match.end())
+    _console.print(
+        f"If you use this {kind} in your work, please cite the following source:\n",
+        text,
+        sep="\n",
+    )
 
 
 def plain_citation(citation: str) -> str:

--- a/src/confusius/datasets/_utils.py
+++ b/src/confusius/datasets/_utils.py
@@ -8,6 +8,7 @@ from typing import Literal
 
 import pooch
 from rich import print as rich_print
+from rich.text import Text
 
 _ENV_VAR = "CONFUSIUS_DATA"
 
@@ -18,12 +19,30 @@ def print_citation_message(citation: str, kind: Literal["dataset", "template"]) 
     Parameters
     ----------
     citation : str
-        Citation text to print.
+        Citation text to print. Rich markup (e.g. `[italic]`) is rendered.
     kind : {"dataset", "template"}
         Resource kind used in the prompt.
     """
     print(f"If you use this {kind} in your work, please cite the following source:\n")
-    rich_print(f"[bold]{citation}[/bold]")
+    # Render as a Text renderable rather than a str so the markup styles apply but
+    # rich's auto-highlighter does not colorize numbers, URLs, etc.
+    rich_print(Text.from_markup(citation))
+
+
+def plain_citation(citation: str) -> str:
+    """Strip rich markup tags from a citation.
+
+    Parameters
+    ----------
+    citation : str
+        Citation text, possibly containing rich markup tags (e.g. `[italic]`).
+
+    Returns
+    -------
+    str
+        The citation with all markup tags removed, leaving only the visible text.
+    """
+    return Text.from_markup(citation).plain
 
 
 def get_datasets_dir(data_dir: str | Path | None = None) -> Path:

--- a/src/confusius/datasets/_utils.py
+++ b/src/confusius/datasets/_utils.py
@@ -11,17 +11,11 @@ from rich.console import Console
 from rich.text import Text
 from rich.theme import Theme
 
+from confusius._utils.colors import RED, TURQUOISE
+
 _ENV_VAR = "CONFUSIUS_DATA"
 
-CONFUSIUS_TURQUOISE = "#3ad9a4"
-"""Confusius brand turquoise, matching the docs theme."""
-
-CONFUSIUS_RED = "#e94b5f"
-"""Confusius brand red, matching the docs theme."""
-
-_CITATION_THEME = Theme(
-    {"citation.title": CONFUSIUS_RED, "citation.doi": CONFUSIUS_TURQUOISE}
-)
+_CITATION_THEME = Theme({"citation.title": RED, "citation.doi": TURQUOISE})
 """Maps the citation style names used in `_CITATION` markup to brand colors."""
 
 _console = Console(theme=_CITATION_THEME)

--- a/src/confusius/datasets/_utils.py
+++ b/src/confusius/datasets/_utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 from pathlib import Path
 from typing import Literal
 
@@ -11,6 +12,9 @@ from rich import print as rich_print
 from rich.text import Text
 
 _ENV_VAR = "CONFUSIUS_DATA"
+
+_DOI_URL_RE = re.compile(r"https://doi\.org/\S+")
+"""Pattern matching a DOI URL, rendered as a clickable link in the citation."""
 
 
 def print_citation_message(citation: str, kind: Literal["dataset", "template"]) -> None:
@@ -26,7 +30,12 @@ def print_citation_message(citation: str, kind: Literal["dataset", "template"]) 
     print(f"If you use this {kind} in your work, please cite the following source:\n")
     # Render as a Text renderable rather than a str so the markup styles apply but
     # rich's auto-highlighter does not colorize numbers, URLs, etc.
-    rich_print(Text.from_markup(citation))
+    text = Text.from_markup(citation)
+    # Turn the DOI into an OSC 8 hyperlink where the terminal supports it.
+    match = _DOI_URL_RE.search(text.plain)
+    if match:
+        text.stylize(f"link {match.group()}", match.start(), match.end())
+    rich_print(text)
 
 
 def plain_citation(citation: str) -> str:

--- a/src/confusius/datasets/_utils.py
+++ b/src/confusius/datasets/_utils.py
@@ -31,10 +31,12 @@ def print_citation_message(citation: str, kind: Literal["dataset", "template"]) 
     # Render as a Text renderable rather than a str so the markup styles apply but
     # rich's auto-highlighter does not colorize numbers, URLs, etc.
     text = Text.from_markup(citation)
-    # Turn the DOI into an OSC 8 hyperlink where the terminal supports it.
+    # Bold the whole citation; the journal name's `[italic]` markup makes it bold italic.
+    text.stylize("bold")
+    # Show the DOI as a blue OSC 8 hyperlink where the terminal supports it.
     match = _DOI_URL_RE.search(text.plain)
     if match:
-        text.stylize(f"link {match.group()}", match.start(), match.end())
+        text.stylize(f"blue link {match.group()}", match.start(), match.end())
     rich_print(text)
 
 

--- a/tests/unit/test_datasets/test_cybis_pereira_2026.py
+++ b/tests/unit/test_datasets/test_cybis_pereira_2026.py
@@ -9,7 +9,11 @@ import pytest
 import requests
 
 from confusius.datasets import fetch_cybis_pereira_2026
-from confusius.datasets._cybis_pereira_2026 import _BIDS_ROOT, _OSF_PROJECT_ID
+from confusius.datasets._cybis_pereira_2026 import (
+    _BIDS_ROOT,
+    _CITATION,
+    _OSF_PROJECT_ID,
+)
 from confusius.datasets._pooch import _MAX_DOWNLOAD_RETRIES
 
 # Minimal fake index representing the different file categories in the dataset.
@@ -122,6 +126,14 @@ def test_fetch_returns_bids_root(tmp_path, mock_get_index, mock_retrieve):
     result = fetch_cybis_pereira_2026(data_dir=tmp_path)
     assert result == tmp_path / _BIDS_ROOT
     assert isinstance(result, Path)
+
+
+def test_fetch_citation_message(tmp_path, mock_get_index, mock_retrieve, capsys):
+    fetch_cybis_pereira_2026(data_dir=tmp_path)
+    assert _CITATION in capsys.readouterr().out
+
+    fetch_cybis_pereira_2026(data_dir=tmp_path, show_citation_msg=False)
+    assert capsys.readouterr().out == ""
 
 
 def test_fetch_downloads_all_missing_files(tmp_path, mock_get_index, mock_retrieve):

--- a/tests/unit/test_datasets/test_cybis_pereira_2026.py
+++ b/tests/unit/test_datasets/test_cybis_pereira_2026.py
@@ -15,6 +15,7 @@ from confusius.datasets._cybis_pereira_2026 import (
     _OSF_PROJECT_ID,
 )
 from confusius.datasets._pooch import _MAX_DOWNLOAD_RETRIES
+from confusius.datasets._utils import plain_citation
 
 # Minimal fake index representing the different file categories in the dataset.
 _FAKE_INDEX = {
@@ -131,8 +132,11 @@ def test_fetch_returns_bids_root(tmp_path, mock_get_index, mock_retrieve):
 def test_fetch_citation_message(tmp_path, mock_get_index, mock_retrieve, capsys):
     fetch_cybis_pereira_2026(data_dir=tmp_path)
     out = capsys.readouterr().out
-    assert "If you use this dataset in your work, please cite the following source:" in out
-    assert _CITATION in out
+    assert (
+        "If you use this dataset in your work, please cite the following source:" in out
+    )
+    # Rich word-wraps the printed citation, so compare on whitespace-normalized text.
+    assert plain_citation(_CITATION) in " ".join(out.split())
 
     fetch_cybis_pereira_2026(data_dir=tmp_path, print_citation=False)
     assert capsys.readouterr().out == ""

--- a/tests/unit/test_datasets/test_cybis_pereira_2026.py
+++ b/tests/unit/test_datasets/test_cybis_pereira_2026.py
@@ -130,9 +130,11 @@ def test_fetch_returns_bids_root(tmp_path, mock_get_index, mock_retrieve):
 
 def test_fetch_citation_message(tmp_path, mock_get_index, mock_retrieve, capsys):
     fetch_cybis_pereira_2026(data_dir=tmp_path)
-    assert _CITATION in capsys.readouterr().out
+    out = capsys.readouterr().out
+    assert "If you use this dataset in your work, please cite the following source:" in out
+    assert _CITATION in out
 
-    fetch_cybis_pereira_2026(data_dir=tmp_path, show_citation_msg=False)
+    fetch_cybis_pereira_2026(data_dir=tmp_path, print_citation=False)
     assert capsys.readouterr().out == ""
 
 

--- a/tests/unit/test_datasets/test_huang_2025.py
+++ b/tests/unit/test_datasets/test_huang_2025.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 
 from confusius.datasets import fetch_template_huang_2025
 from confusius.datasets._huang_2025 import (
+    _CITATION,
     _FILENAME,
     _OSF_PROJECT_ID,
     _TEMPLATE_ROOT,
@@ -80,12 +82,16 @@ def mock_retrieve(tmp_path: Path):
 
 @pytest.fixture
 def mock_load():
-    sentinel = object()
+    # Stand-in for the loaded DataArray; needs a mutable `attrs` so the fetcher
+    # can stamp the citation onto it.
+    sentinel = SimpleNamespace(attrs={})
     with patch("confusius.datasets._huang_2025.load", return_value=sentinel) as mock:
         yield sentinel, mock
 
 
-def test_fetch_downloads_missing_template(tmp_path, mock_resolve, mock_retrieve, mock_load):
+def test_fetch_downloads_missing_template(
+    tmp_path, mock_resolve, mock_retrieve, mock_load
+):
     sentinel, mock_load_fn = mock_load
     result = fetch_template_huang_2025(data_dir=tmp_path)
     dest = tmp_path / _TEMPLATE_ROOT / _FILENAME
@@ -97,7 +103,9 @@ def test_fetch_downloads_missing_template(tmp_path, mock_resolve, mock_retrieve,
     assert dest.exists()
 
 
-def test_fetch_skips_download_when_cached(tmp_path, mock_resolve, mock_retrieve, mock_load):
+def test_fetch_skips_download_when_cached(
+    tmp_path, mock_resolve, mock_retrieve, mock_load
+):
     sentinel, mock_load_fn = mock_load
     dest = tmp_path / _TEMPLATE_ROOT / _FILENAME
     dest.parent.mkdir(parents=True, exist_ok=True)
@@ -126,3 +134,13 @@ def test_fetch_refresh_redownloads_cached_template(
     mock_retrieve.assert_called_once()
     mock_load_fn.assert_called_once_with(dest)
     assert dest.exists()
+
+
+def test_fetch_sets_citation(tmp_path, mock_resolve, mock_retrieve, mock_load, capsys):
+    result = fetch_template_huang_2025(data_dir=tmp_path)
+
+    assert result.attrs["citation"] == _CITATION
+    assert _CITATION in capsys.readouterr().out
+
+    fetch_template_huang_2025(data_dir=tmp_path, show_citation_msg=False)
+    assert capsys.readouterr().out == ""

--- a/tests/unit/test_datasets/test_huang_2025.py
+++ b/tests/unit/test_datasets/test_huang_2025.py
@@ -16,6 +16,7 @@ from confusius.datasets._huang_2025 import (
     _TEMPLATE_ROOT,
     resolve_template_url,
 )
+from confusius.datasets._utils import plain_citation
 
 
 class _Response:
@@ -139,12 +140,16 @@ def test_fetch_refresh_redownloads_cached_template(
 def test_fetch_sets_citation(tmp_path, mock_resolve, mock_retrieve, mock_load, capsys):
     result = fetch_template_huang_2025(data_dir=tmp_path)
 
-    assert result.attrs["citation"] == _CITATION
+    # The attribute holds the plain citation, with rich markup stripped.
+    assert result.attrs["citation"] == plain_citation(_CITATION)
+    assert "[italic]" not in result.attrs["citation"]
+
     out = capsys.readouterr().out
     assert out.startswith(
         "If you use this template in your work, please cite the following source:"
     )
-    assert _CITATION in out
+    # Rich word-wraps the printed citation, so compare on whitespace-normalized text.
+    assert plain_citation(_CITATION) in " ".join(out.split())
 
     fetch_template_huang_2025(data_dir=tmp_path, print_citation=False)
     assert capsys.readouterr().out == ""

--- a/tests/unit/test_datasets/test_huang_2025.py
+++ b/tests/unit/test_datasets/test_huang_2025.py
@@ -140,7 +140,11 @@ def test_fetch_sets_citation(tmp_path, mock_resolve, mock_retrieve, mock_load, c
     result = fetch_template_huang_2025(data_dir=tmp_path)
 
     assert result.attrs["citation"] == _CITATION
-    assert _CITATION in capsys.readouterr().out
+    out = capsys.readouterr().out
+    assert out.startswith(
+        "If you use this template in your work, please cite the following source:"
+    )
+    assert _CITATION in out
 
-    fetch_template_huang_2025(data_dir=tmp_path, show_citation_msg=False)
+    fetch_template_huang_2025(data_dir=tmp_path, print_citation=False)
     assert capsys.readouterr().out == ""

--- a/tests/unit/test_datasets/test_landemard_2026.py
+++ b/tests/unit/test_datasets/test_landemard_2026.py
@@ -15,6 +15,7 @@ from confusius.datasets._landemard_2026 import (
     _OSF_PROJECT_ID,
 )
 from confusius.datasets._pooch import _MAX_DOWNLOAD_RETRIES
+from confusius.datasets._utils import plain_citation
 
 # Minimal fake index representing the different file categories in the dataset.
 _FAKE_INDEX = {
@@ -130,8 +131,11 @@ def test_fetch_returns_bids_root(tmp_path, mock_get_index, mock_retrieve):
 def test_fetch_citation_message(tmp_path, mock_get_index, mock_retrieve, capsys):
     fetch_landemard_2026(data_dir=tmp_path)
     out = capsys.readouterr().out
-    assert "If you use this dataset in your work, please cite the following source:" in out
-    assert _CITATION in out
+    assert (
+        "If you use this dataset in your work, please cite the following source:" in out
+    )
+    # Rich word-wraps the printed citation, so compare on whitespace-normalized text.
+    assert plain_citation(_CITATION) in " ".join(out.split())
 
     fetch_landemard_2026(data_dir=tmp_path, print_citation=False)
     assert capsys.readouterr().out == ""

--- a/tests/unit/test_datasets/test_landemard_2026.py
+++ b/tests/unit/test_datasets/test_landemard_2026.py
@@ -129,9 +129,11 @@ def test_fetch_returns_bids_root(tmp_path, mock_get_index, mock_retrieve):
 
 def test_fetch_citation_message(tmp_path, mock_get_index, mock_retrieve, capsys):
     fetch_landemard_2026(data_dir=tmp_path)
-    assert _CITATION in capsys.readouterr().out
+    out = capsys.readouterr().out
+    assert "If you use this dataset in your work, please cite the following source:" in out
+    assert _CITATION in out
 
-    fetch_landemard_2026(data_dir=tmp_path, show_citation_msg=False)
+    fetch_landemard_2026(data_dir=tmp_path, print_citation=False)
     assert capsys.readouterr().out == ""
 
 

--- a/tests/unit/test_datasets/test_landemard_2026.py
+++ b/tests/unit/test_datasets/test_landemard_2026.py
@@ -9,7 +9,11 @@ import pytest
 import requests
 
 from confusius.datasets import fetch_landemard_2026
-from confusius.datasets._landemard_2026 import _BIDS_ROOT, _OSF_PROJECT_ID
+from confusius.datasets._landemard_2026 import (
+    _BIDS_ROOT,
+    _CITATION,
+    _OSF_PROJECT_ID,
+)
 from confusius.datasets._pooch import _MAX_DOWNLOAD_RETRIES
 
 # Minimal fake index representing the different file categories in the dataset.
@@ -121,6 +125,14 @@ def test_fetch_returns_bids_root(tmp_path, mock_get_index, mock_retrieve):
     result = fetch_landemard_2026(data_dir=tmp_path)
     assert result == tmp_path / _BIDS_ROOT
     assert isinstance(result, Path)
+
+
+def test_fetch_citation_message(tmp_path, mock_get_index, mock_retrieve, capsys):
+    fetch_landemard_2026(data_dir=tmp_path)
+    assert _CITATION in capsys.readouterr().out
+
+    fetch_landemard_2026(data_dir=tmp_path, show_citation_msg=False)
+    assert capsys.readouterr().out == ""
 
 
 def test_fetch_downloads_all_missing_files(tmp_path, mock_get_index, mock_retrieve):

--- a/tests/unit/test_datasets/test_nunez_elizalde_2022.py
+++ b/tests/unit/test_datasets/test_nunez_elizalde_2022.py
@@ -15,6 +15,7 @@ from confusius.datasets._nunez_elizalde_2022 import (
     _OSF_PROJECT_ID,
 )
 from confusius.datasets._pooch import _MAX_DOWNLOAD_RETRIES
+from confusius.datasets._utils import plain_citation
 
 # Minimal fake index representing the different file categories in the dataset.
 _FAKE_INDEX = {
@@ -156,8 +157,11 @@ def test_fetch_returns_bids_root(tmp_path, mock_get_index, mock_retrieve):
 def test_fetch_citation_message(tmp_path, mock_get_index, mock_retrieve, capsys):
     fetch_nunez_elizalde_2022(data_dir=tmp_path)
     out = capsys.readouterr().out
-    assert "If you use this dataset in your work, please cite the following source:" in out
-    assert _CITATION in out
+    assert (
+        "If you use this dataset in your work, please cite the following source:" in out
+    )
+    # Rich word-wraps the printed citation, so compare on whitespace-normalized text.
+    assert plain_citation(_CITATION) in " ".join(out.split())
 
     fetch_nunez_elizalde_2022(data_dir=tmp_path, print_citation=False)
     assert capsys.readouterr().out == ""

--- a/tests/unit/test_datasets/test_nunez_elizalde_2022.py
+++ b/tests/unit/test_datasets/test_nunez_elizalde_2022.py
@@ -155,9 +155,11 @@ def test_fetch_returns_bids_root(tmp_path, mock_get_index, mock_retrieve):
 
 def test_fetch_citation_message(tmp_path, mock_get_index, mock_retrieve, capsys):
     fetch_nunez_elizalde_2022(data_dir=tmp_path)
-    assert _CITATION in capsys.readouterr().out
+    out = capsys.readouterr().out
+    assert "If you use this dataset in your work, please cite the following source:" in out
+    assert _CITATION in out
 
-    fetch_nunez_elizalde_2022(data_dir=tmp_path, show_citation_msg=False)
+    fetch_nunez_elizalde_2022(data_dir=tmp_path, print_citation=False)
     assert capsys.readouterr().out == ""
 
 

--- a/tests/unit/test_datasets/test_nunez_elizalde_2022.py
+++ b/tests/unit/test_datasets/test_nunez_elizalde_2022.py
@@ -11,6 +11,7 @@ import requests
 from confusius.datasets import fetch_nunez_elizalde_2022, get_datasets_dir
 from confusius.datasets._nunez_elizalde_2022 import (
     _BIDS_ROOT,
+    _CITATION,
     _OSF_PROJECT_ID,
 )
 from confusius.datasets._pooch import _MAX_DOWNLOAD_RETRIES
@@ -150,6 +151,14 @@ def test_fetch_returns_bids_root(tmp_path, mock_get_index, mock_retrieve):
     result = fetch_nunez_elizalde_2022(data_dir=tmp_path)
     assert result == tmp_path / _BIDS_ROOT
     assert isinstance(result, Path)
+
+
+def test_fetch_citation_message(tmp_path, mock_get_index, mock_retrieve, capsys):
+    fetch_nunez_elizalde_2022(data_dir=tmp_path)
+    assert _CITATION in capsys.readouterr().out
+
+    fetch_nunez_elizalde_2022(data_dir=tmp_path, show_citation_msg=False)
+    assert capsys.readouterr().out == ""
 
 
 def test_fetch_downloads_all_missing_files(tmp_path, mock_get_index, mock_retrieve):

--- a/tests/unit/test_datasets/test_pepe_mariani_2026.py
+++ b/tests/unit/test_datasets/test_pepe_mariani_2026.py
@@ -16,6 +16,7 @@ from confusius.datasets._pepe_mariani_2026 import (
     _TEMPLATE_ROOT,
     resolve_template_url,
 )
+from confusius.datasets._utils import plain_citation
 
 
 class _Response:
@@ -141,12 +142,16 @@ def test_fetch_refresh_redownloads_cached_template(
 def test_fetch_sets_citation(tmp_path, mock_resolve, mock_retrieve, mock_load, capsys):
     result = fetch_template_pepe_mariani_2026(data_dir=tmp_path)
 
-    assert result.attrs["citation"] == _CITATION
+    # The attribute holds the plain citation, with rich markup stripped.
+    assert result.attrs["citation"] == plain_citation(_CITATION)
+    assert "[italic]" not in result.attrs["citation"]
+
     out = capsys.readouterr().out
     assert out.startswith(
         "If you use this template in your work, please cite the following source:"
     )
-    assert _CITATION in out
+    # Rich word-wraps the printed citation, so compare on whitespace-normalized text.
+    assert plain_citation(_CITATION) in " ".join(out.split())
 
     fetch_template_pepe_mariani_2026(data_dir=tmp_path, print_citation=False)
     assert capsys.readouterr().out == ""

--- a/tests/unit/test_datasets/test_pepe_mariani_2026.py
+++ b/tests/unit/test_datasets/test_pepe_mariani_2026.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 
 from confusius.datasets import fetch_template_pepe_mariani_2026
 from confusius.datasets._pepe_mariani_2026 import (
+    _CITATION,
     _FILENAME,
     _OSF_PROJECT_ID,
     _TEMPLATE_ROOT,
@@ -80,8 +82,12 @@ def mock_retrieve(tmp_path: Path):
 
 @pytest.fixture
 def mock_load():
-    sentinel = object()
-    with patch("confusius.datasets._pepe_mariani_2026.load", return_value=sentinel) as mock:
+    # Stand-in for the loaded DataArray; needs a mutable `attrs` so the fetcher
+    # can stamp the citation onto it.
+    sentinel = SimpleNamespace(attrs={})
+    with patch(
+        "confusius.datasets._pepe_mariani_2026.load", return_value=sentinel
+    ) as mock:
         yield sentinel, mock
 
 
@@ -130,3 +136,13 @@ def test_fetch_refresh_redownloads_cached_template(
     mock_retrieve.assert_called_once()
     mock_load_fn.assert_called_once_with(dest)
     assert dest.exists()
+
+
+def test_fetch_sets_citation(tmp_path, mock_resolve, mock_retrieve, mock_load, capsys):
+    result = fetch_template_pepe_mariani_2026(data_dir=tmp_path)
+
+    assert result.attrs["citation"] == _CITATION
+    assert _CITATION in capsys.readouterr().out
+
+    fetch_template_pepe_mariani_2026(data_dir=tmp_path, show_citation_msg=False)
+    assert capsys.readouterr().out == ""

--- a/tests/unit/test_datasets/test_pepe_mariani_2026.py
+++ b/tests/unit/test_datasets/test_pepe_mariani_2026.py
@@ -142,7 +142,11 @@ def test_fetch_sets_citation(tmp_path, mock_resolve, mock_retrieve, mock_load, c
     result = fetch_template_pepe_mariani_2026(data_dir=tmp_path)
 
     assert result.attrs["citation"] == _CITATION
-    assert _CITATION in capsys.readouterr().out
+    out = capsys.readouterr().out
+    assert out.startswith(
+        "If you use this template in your work, please cite the following source:"
+    )
+    assert _CITATION in out
 
-    fetch_template_pepe_mariani_2026(data_dir=tmp_path, show_citation_msg=False)
+    fetch_template_pepe_mariani_2026(data_dir=tmp_path, print_citation=False)
     assert capsys.readouterr().out == ""


### PR DESCRIPTION
## Summary

Adds citation information to all five dataset/template fetchers so users know what to cite when they use the data.

- Each fetcher now prints `Fetched data from <citation>.` after a successful fetch, controlled by a new `show_citation_msg: bool = True` parameter. Pass `show_citation_msg=False` to silence it (e.g. in scripts and notebooks).
- The two template fetchers (`fetch_template_huang_2025`, `fetch_template_pepe_mariani_2026`) additionally stamp the citation onto the returned DataArray as `da.attrs["citation"]`, so it survives as metadata regardless of the print flag.
- Citation strings are stored as a module-level `_CITATION` constant in each dataset module.

## Fetchers affected

`fetch_cybis_pereira_2026`, `fetch_landemard_2026`, `fetch_nunez_elizalde_2022`, `fetch_template_huang_2025`, `fetch_template_pepe_mariani_2026`.

## Tests

- Added a citation test per fetcher: BIDS fetchers assert the message prints by default and is suppressed under `show_citation_msg=False`; template fetchers additionally assert `da.attrs["citation"]` is set.
- Fixed the template fetchers' `mock_load` fixture, whose bare `object()` sentinel could not hold the newly-written `attrs["citation"]` — it now uses `SimpleNamespace(attrs={})`.