### PR TITLE
fix(io): make Zarr saving handle non-serializable attrs

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -36,6 +36,11 @@ Current development version for the next ConfUSIus release.
 
 ### :bug: Fixes
 
+- Saving to Zarr (via [`save`][confusius.io.save] or `DataArray.fusi.save`) now works
+  for data carrying affines or other numpy-valued attributes: nested numpy arrays are
+  stored as lists and non-serializable attrs (e.g. matplotlib colormaps) are dropped
+  with a warning, matching the NIfTI sidecar behaviour
+  ([#283](https://github.com/confusius-tools/confusius/issues/283)).
 - B-spline control-point DataArrays returned by
   [`register_volume`][confusius.registration.register_volume] no longer have their
   per-axis grid geometry (spacing, origin, domain) swapped between axes on anisotropic

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -40,7 +40,7 @@ Current development version for the next ConfUSIus release.
   for data carrying affines or other numpy-valued attributes: nested numpy arrays are
   stored as lists and non-serializable attrs (e.g. matplotlib colormaps) are dropped
   with a warning, matching the NIfTI sidecar behaviour
-  ([#283](https://github.com/confusius-tools/confusius/issues/283)).
+  ([#284](https://github.com/confusius-tools/confusius/pull/284)).
 - B-spline control-point DataArrays returned by
   [`register_volume`][confusius.registration.register_volume] no longer have their
   per-axis grid geometry (spacing, origin, domain) swapped between axes on anisotropic

--- a/src/confusius/io/loadsave.py
+++ b/src/confusius/io/loadsave.py
@@ -1,13 +1,17 @@
 """Generic file loading and saving dispatcher."""
 
+import json
+import warnings
 from pathlib import Path
 from typing import Any
 
+import numpy as np
 import xarray as xr
 
 import confusius.io.nifti as _nifti
 import confusius.io.scan as _scan
 from confusius._utils.atlas import build_atlas_cmap_and_norm
+from confusius._utils.stack import find_stack_level
 from confusius.io.utils import check_path
 
 
@@ -67,7 +71,34 @@ def load(path: str | Path, variable: str | None = None, **kwargs: Any) -> xr.Dat
         )
 
     _restore_atlas_cmap_and_norm(data_array)
+    _restore_affines(data_array)
     return data_array
+
+
+def _restore_affines(data_array: xr.DataArray) -> None:
+    """Restore `attrs["affines"]` dict values to numpy arrays in place.
+
+    Zarr stores the affines as nested lists (see
+    [`save`][confusius.io.save]); this converts them back to numpy arrays so a
+    Zarr round-trip matches the NIfTI and SCAN loaders. A no-op when `affines` is
+    absent or its values are already arrays.
+
+    Parameters
+    ----------
+    data_array : xarray.DataArray
+        DataArray to update in place.
+
+    Returns
+    -------
+    None
+        This function mutates `data_array.attrs` and returns nothing.
+    """
+    affines = data_array.attrs.get("affines")
+    if not isinstance(affines, dict):
+        return
+    data_array.attrs["affines"] = {
+        key: np.asarray(value) for key, value in affines.items()
+    }
 
 
 def _restore_atlas_cmap_and_norm(data_array: xr.DataArray) -> None:
@@ -123,6 +154,8 @@ def save(data_array: xr.DataArray, path: str | Path, **kwargs: Any) -> None:
         _nifti.save_nifti(data_array, path, **kwargs)
         return
     if name.endswith(".zarr"):
+        data_array = data_array.copy(deep=False)
+        data_array.attrs = _zarr_safe_attrs(data_array.attrs)
         data_array.to_zarr(path, **kwargs)
         return
 
@@ -130,3 +163,70 @@ def save(data_array: xr.DataArray, path: str | Path, **kwargs: Any) -> None:
         f"Unsupported file extension in {name!r}. Supported"
         " extensions are: .nii, .nii.gz, .zarr."
     )
+
+
+def _to_json_serializable(value: Any) -> Any:
+    """Recursively convert numpy containers and scalars to native Python objects.
+
+    Parameters
+    ----------
+    value : Any
+        Attribute value, possibly a numpy array or scalar or a `dict`/`list`/`tuple`
+        nesting them.
+
+    Returns
+    -------
+    Any
+        Equivalent value with every `numpy.ndarray` replaced by a nested list and every
+        numpy scalar replaced by its Python counterpart. Non-numpy values are returned
+        unchanged.
+    """
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, dict):
+        return {key: _to_json_serializable(item) for key, item in value.items()}
+    if isinstance(value, list | tuple):
+        return [_to_json_serializable(item) for item in value]
+    return value
+
+
+def _zarr_safe_attrs(attrs: dict[str, Any]) -> dict[str, Any]:
+    """Make attributes safe to store as Zarr attributes.
+
+    Zarr stores attributes as JSON. Numpy arrays and scalars, including those nested
+    inside dicts or lists such as `attrs["affines"]`, are converted to native Python
+    objects. Any remaining value that cannot be JSON-encoded (e.g. the matplotlib
+    colormap and normalization objects on atlas-derived data) is dropped with a warning;
+    such `cmap`/`norm` attrs are rebuilt from `rgb_lookup` on load.
+
+    Parameters
+    ----------
+    attrs : dict[str, Any]
+        Attributes to sanitize.
+
+    Returns
+    -------
+    dict[str, Any]
+        Copy of `attrs` with numpy values converted to native Python and
+        non-JSON-serializable entries removed.
+    """
+    safe: dict[str, Any] = {}
+    dropped: list[str] = []
+    for key, value in attrs.items():
+        converted = _to_json_serializable(value)
+        try:
+            json.dumps(converted)
+        except TypeError:
+            dropped.append(key)
+        else:
+            safe[key] = converted
+
+    if dropped:
+        warnings.warn(
+            f"Dropping non-JSON-serializable attrs from Zarr store: {dropped}.",
+            stacklevel=find_stack_level(),
+        )
+
+    return safe

--- a/tests/unit/test_io/test_loadsave.py
+++ b/tests/unit/test_io/test_loadsave.py
@@ -148,6 +148,19 @@ class TestSaveZarrSanitizesAttrs:
             assert isinstance(restored, np.ndarray)
             npt.assert_array_equal(restored, expected)
 
+    def test_numpy_scalar_and_list_attrs_round_trip(self, tmp_path):
+        """Numpy scalars and lists containing numpy values are kept, not dropped."""
+        da = xr.DataArray(
+            np.zeros((2, 2)),
+            attrs={"code": np.int16(3), "angles": [np.float64(1.5), np.float64(-2.0)]},
+        )
+        path = tmp_path / "scalars.zarr"
+        save(da, path)
+
+        loaded = load(path)
+        assert loaded.attrs["code"] == 3
+        npt.assert_array_equal(loaded.attrs["angles"], [1.5, -2.0])
+
     def test_non_serializable_attr_dropped_with_warning(self, tmp_path):
         """Attrs that cannot be JSON-encoded are dropped, with a warning naming them."""
         da = xr.DataArray(np.zeros((2, 2)), attrs={"units": "dB", "cmap": object()})

--- a/tests/unit/test_io/test_loadsave.py
+++ b/tests/unit/test_io/test_loadsave.py
@@ -1,6 +1,6 @@
 """Unit tests for confusius.io.loadsave module."""
 
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import numpy.testing as npt
@@ -100,21 +100,19 @@ class TestSaveDispatch:
             save(da, path)
         mock.assert_called_once_with(da, path.resolve())
 
-    def test_zarr_dispatches_to_to_zarr(self, tmp_path):
-        """.zarr extension calls DataArray.to_zarr."""
+    def test_zarr_writes_readable_store(self, tmp_path):
+        """.zarr extension writes a store that reloads to the same data."""
         path = tmp_path / "data.zarr"
-        da = MagicMock(spec=xr.DataArray)
-        with patch("confusius.io.nifti.save_nifti") as mock:
-            save(da, path)
-        da.to_zarr.assert_called_once_with(path.resolve())
+        da = xr.DataArray(np.arange(12.0).reshape(4, 3))
+        save(da, path)
+        npt.assert_array_equal(load(path).values, da.values)
 
     def test_compound_zarr_extension(self, tmp_path):
-        """.source.zarr compound extension calls DataArray.to_zarr."""
+        """.source.zarr compound extension writes a readable store."""
         path = tmp_path / "data.source.zarr"
-        da = MagicMock(spec=xr.DataArray)
-        with patch("confusius.io.nifti.save_nifti") as mock:
-            save(da, path)
-        da.to_zarr.assert_called_once_with(path.resolve())
+        da = xr.DataArray(np.arange(12.0).reshape(4, 3))
+        save(da, path)
+        npt.assert_array_equal(load(path).values, da.values)
 
     def test_kwargs_forwarded_to_saver(self, tmp_path):
         """Extra kwargs are forwarded to the underlying saver."""
@@ -129,6 +127,43 @@ class TestSaveDispatch:
         da = MagicMock(spec=xr.DataArray)
         with pytest.raises(ValueError, match="Unsupported file extension"):
             save(da, tmp_path / "data.scan")
+
+
+class TestSaveZarrSanitizesAttrs:
+    """Non-JSON-serializable attrs are handled when saving to Zarr."""
+
+    def test_nested_numpy_affines_round_trip(self, tmp_path):
+        """`attrs["affines"]` numpy arrays survive a round-trip and reload as arrays."""
+        affines = {
+            "physical_to_world": np.eye(4),
+            "stack": np.arange(32.0).reshape(2, 4, 4),
+        }
+        da = xr.DataArray(np.zeros((2, 2)), attrs={"affines": affines})
+        path = tmp_path / "affines.zarr"
+        save(da, path)
+
+        loaded = load(path)
+        for key, expected in affines.items():
+            restored = loaded.attrs["affines"][key]
+            assert isinstance(restored, np.ndarray)
+            npt.assert_array_equal(restored, expected)
+
+    def test_non_serializable_attr_dropped_with_warning(self, tmp_path):
+        """Attrs that cannot be JSON-encoded are dropped, with a warning naming them."""
+        da = xr.DataArray(np.zeros((2, 2)), attrs={"units": "dB", "cmap": object()})
+        path = tmp_path / "drop.zarr"
+        with pytest.warns(UserWarning, match="cmap"):
+            save(da, path)
+
+        loaded = load(path)
+        assert loaded.attrs["units"] == "dB"
+        assert "cmap" not in loaded.attrs
+
+    def test_save_does_not_mutate_input_attrs(self, tmp_path):
+        """The caller's DataArray keeps its original numpy attrs after saving."""
+        da = xr.DataArray(np.zeros((2, 2)), attrs={"affines": {"m": np.eye(4)}})
+        save(da, tmp_path / "nomutate.zarr")
+        assert isinstance(da.attrs["affines"]["m"], np.ndarray)
 
 
 class TestLoadZarr:


### PR DESCRIPTION
## Summary

Closes #283.

Saving a fUSI DataArray to Zarr failed whenever its attrs held values Zarr can't JSON-encode — most commonly `attrs["affines"]` (a dict of numpy arrays) or matplotlib `cmap`/`norm` objects on atlas-derived data. `data.fusi.save("out.zarr")` raised `TypeError: Invalid attribute in Dataset.attrs.`

Root cause: Zarr stores attrs as JSON. It already tolerates *top-level* numpy arrays and scalars, but not numpy arrays nested inside a dict (exactly how affines are stored), nor arbitrary Python objects.

## Changes

`save()` now sanitizes a shallow copy of the DataArray's attrs before `to_zarr` (the caller's object is left untouched):

- Nested numpy arrays and scalars are recursively converted to native Python (JSON-storable) — so affines survive as lists.
- Any value still not JSON-encodable is dropped with a warning. Atlas `cmap`/`norm` fall in this bucket and are already rebuilt from `rgb_lookup` on load.

Unlike the NIfTI sidecar path, this deliberately skips the NIfTI-specific machinery: no BIDS field renaming, no `dim4`/`dim5` or timing metadata.

On load, `attrs["affines"]` dict values are restored to numpy arrays, so a Zarr round-trip matches the NIfTI and SCAN loaders' contract. This is a no-op for those loaders (their affines are already numpy arrays).

## Testing

- New round-trip tests: affines reload as numpy arrays with correct values; non-serializable attrs are dropped with a warning and the rest survive; the input DataArray is not mutated.
- Reworked the two zarr dispatch tests into real write-and-reload checks (the old ones asserted `to_zarr` was called on the raw object, which no longer holds now that we copy + sanitize first).
- Verified end-to-end against the issue's real `pwd.nii.gz -> .zarr` round-trip; confirmed NIfTI load is unchanged (affines stay `ndarray`/`float64`).
- All `tests/unit/test_io` pass; ruff, ty, codespell, and numpydoc-validation clean.
