### PR TITLE
feat(docs): run individual gallery examples and wrap long output

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -74,7 +74,7 @@ Current development version for the next ConfUSIus release.
   ([#235](https://github.com/confusius-tools/confusius/pull/235)).
 - Long output in gallery examples — warnings, text reprs, tracebacks, and rich-rendered
   text such as the dataset citation banner — now wraps instead of showing a horizontal
-  scrollbar ([#284](https://github.com/confusius-tools/confusius/pull/284)).
+  scrollbar ([#285](https://github.com/confusius-tools/confusius/pull/285)).
 
 ### :wrench: Maintenance
 
@@ -84,7 +84,7 @@ Current development version for the next ConfUSIus release.
   (`uv run python tools/build_gallery.py docs/examples/01_io/01_confusius_xarray_101.py`),
   running only those; the rest of the gallery is still rendered, taken from cache if
   present or built without outputs
-  ([#284](https://github.com/confusius-tools/confusius/pull/284)).
+  ([#285](https://github.com/confusius-tools/confusius/pull/285)).
 
 ## 0.5.0
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -72,11 +72,19 @@ Current development version for the next ConfUSIus release.
   the rigid registration step with a B-spline refinement, showing the extra local
   correction it adds and how its parameters differ from the rigid step's
   ([#235](https://github.com/confusius-tools/confusius/pull/235)).
+- Long output in gallery examples — warnings, text reprs, tracebacks, and rich-rendered
+  text such as the dataset citation banner — now wraps instead of showing a horizontal
+  scrollbar ([#284](https://github.com/confusius-tools/confusius/pull/284)).
 
 ### :wrench: Maintenance
 
 - Raised the minimum supported versions to **napari 0.7.1** and
   **matplotlib 3.11**.
+- The example-gallery build tool now accepts specific example scripts as arguments
+  (`uv run python tools/build_gallery.py docs/examples/01_io/01_confusius_xarray_101.py`),
+  running only those; the rest of the gallery is still rendered, taken from cache if
+  present or built without outputs
+  ([#284](https://github.com/confusius-tools/confusius/pull/284)).
 
 ## 0.5.0
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -83,8 +83,8 @@ Current development version for the next ConfUSIus release.
   the rigid registration step with a B-spline refinement, showing the extra local
   correction it adds and how its parameters differ from the rigid step's
   ([#235](https://github.com/confusius-tools/confusius/pull/235)).
-- Long output in gallery examples — warnings, text reprs, tracebacks, and rich-rendered
-  text such as the dataset citation banner — now wraps instead of showing a horizontal
+- Long output in gallery examples—warnings, text reprs, tracebacks, and rich-rendered
+  text such as the dataset citation banner—now wraps instead of showing a horizontal
   scrollbar ([#285](https://github.com/confusius-tools/confusius/pull/285)).
 
 ### :wrench: Maintenance
@@ -166,7 +166,7 @@ Released 2026-07-07.
 - [`plot_volume`][confusius.plotting.plot_volume] and
   [`plot_stat_map`][confusius.plotting.plot_stat_map] (and their `data.fusi.plot.*`
   accessors) now accept `cbar_kwargs`, forwarded to
-  [`matplotlib.figure.Figure.colorbar`][matplotlib.figure.Figure.colorbar] — useful to
+  [`matplotlib.figure.Figure.colorbar`][matplotlib.figure.Figure.colorbar]—useful to
   shrink a shared colorbar down to size on a multi-panel grid
   ([#242](https://github.com/confusius-tools/confusius/pull/242)).
 - [`apply_affine`][confusius.xarray.affine.apply_affine] and the

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -449,3 +449,25 @@
   aspect-ratio: 4 / 3;
   object-fit: cover;
 }
+
+/* Rich-rendered text (e.g. the dataset citation banner the fetchers print) embeds
+   as a monospace block carrying inline `white-space:pre;overflow-x:auto`, which
+   produces a horizontal scrollbar on narrow columns. Wrap it instead. Scoped by
+   rich's inline `font-family:Menlo…` so xarray HTML reprs, which should keep
+   scrolling horizontally, are left untouched. `overflow-wrap:anywhere` breaks a
+   long unbreakable token (e.g. a DOI URL) that has no natural wrap point. */
+.gallery-rich-output [style*="Menlo"] {
+  white-space: pre-wrap !important;
+  overflow-x: hidden !important;
+  overflow-wrap: anywhere;
+}
+
+/* Plain-text example output (warnings, reprs, tracebacks) is wrapped in a
+   `.gallery-output` container by the gallery builder. Wrap long lines instead of
+   showing a horizontal scrollbar. Scoped to that container so authored code
+   blocks and xarray text reprs elsewhere in the docs keep scrolling. */
+.gallery-output .highlight pre,
+.gallery-output .highlight code {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}

--- a/tests/integration/test_gallery/test_build_gallery.py
+++ b/tests/integration/test_gallery/test_build_gallery.py
@@ -101,6 +101,66 @@ def test_build_gallery_prints_progress_when_non_interactive(
 
 
 @pytest.mark.slow
+def test_build_gallery_runs_only_selected_and_stubs_the_rest(
+    gallery_paths: GalleryPaths,
+) -> None:
+    examples_root, built_dir, cache_root = gallery_paths
+
+    wanted = _seed_example(
+        examples_root,
+        "io",
+        "hello",
+        "# %% [markdown]\n# # Hello\n\n# %%\nprint('hi')\n",
+    )
+    _seed_example(
+        examples_root,
+        "misc",
+        "skipme",
+        "# %% [markdown]\n# # Skip\n\n# %%\nprint('bye')\n",
+    )
+
+    build_gallery(
+        examples_root=examples_root,
+        built_dir=built_dir,
+        cache_root=cache_root,
+        deps_fingerprint="testdeps==1.0",
+        only=[wanted],
+    )
+
+    # The selected example is executed: its output is rendered.
+    hello = (built_dir / "io" / "hello.md").read_text()
+    assert '<div class="gallery-output" markdown>' in hello
+    # The rest are rendered without running: the source is there, but no outputs.
+    skip = (built_dir / "misc" / "skipme.md").read_text()
+    assert "print('bye')" in skip
+    assert "gallery-output" not in skip
+    # It is not cached, so a later run would still execute it.
+    assert not list(cache_root.glob("**/misc/skipme"))
+    # The index still lists the full gallery.
+    index_md = (examples_root / "index.md").read_text()
+    assert "Hello" in index_md
+    assert "Skip" in index_md
+
+
+def test_build_gallery_raises_for_unknown_only_path(
+    gallery_paths: GalleryPaths,
+) -> None:
+    examples_root, built_dir, cache_root = gallery_paths
+    _seed_example(
+        examples_root, "io", "hello", "# %% [markdown]\n# # Hi\n\n# %%\nx = 1\n"
+    )
+
+    with pytest.raises(ValueError, match="Not discoverable"):
+        build_gallery(
+            examples_root=examples_root,
+            built_dir=built_dir,
+            cache_root=cache_root,
+            deps_fingerprint="testdeps==1.0",
+            only=[examples_root / "io" / "ghost.py"],
+        )
+
+
+@pytest.mark.slow
 def test_build_gallery_embeds_binder_launch_url(gallery_paths: GalleryPaths) -> None:
     examples_root, built_dir, cache_root = gallery_paths
     repo_root = examples_root.parent.parent

--- a/tests/unit/test_gallery/test_render.py
+++ b/tests/unit/test_gallery/test_render.py
@@ -56,8 +56,10 @@ def test_render_writes_markdown_with_code_and_output(tmp_path: Path) -> None:
 
     md = md_path.read_text()
     assert md.startswith("# Hello")
+    # Input code stays a bare highlighted block; output is wrapped so docs CSS can
+    # wrap long lines instead of scrolling.
     assert "```python\nprint('hi')\n```" in md
-    assert "```\nhi\n```" in md
+    assert '<div class="gallery-output" markdown>\n\n```\nhi\n```\n\n</div>' in md
     assert "ex_output_light/cell_03_0_light.png#only-light" in md
     assert "ex_output_dark/cell_03_0_dark.png#only-dark" in md
     assert "**Total running time:** 4.3 s" in md

--- a/tools/build_gallery.py
+++ b/tools/build_gallery.py
@@ -3,10 +3,18 @@
 Run as::
 
     uv run python tools/build_gallery.py
+
+to run every example, or pass specific example scripts to run only those::
+
+    uv run python tools/build_gallery.py docs/examples/01_io/01_confusius_xarray_101.py
+
+The whole gallery is still rendered either way; the examples you do not name are
+restored from cache if present, or rendered without outputs (code only).
 """
 
 from __future__ import annotations
 
+import argparse
 import os
 import sys
 from pathlib import Path
@@ -50,20 +58,38 @@ def _deps_fingerprint() -> str:
 
 def main() -> int:
     """Run the gallery builder end-to-end."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "examples",
+        nargs="*",
+        type=Path,
+        help=(
+            "Example scripts to run (paths under docs/examples/). The whole gallery "
+            "is still rendered; unnamed examples are taken from cache if present, or "
+            "rendered without outputs. If not provided, all examples are run."
+        ),
+    )
+    args = parser.parse_args()
+
     if not EXAMPLES_ROOT.is_dir():
         print(f"No examples directory at {EXAMPLES_ROOT}", file=sys.stderr)
         return 1
 
     binder_ref = os.environ.get("CONFUSIUS_BINDER_REF", "main")
-    build_gallery(
-        examples_root=EXAMPLES_ROOT,
-        built_dir=BUILT_DIR,
-        cache_root=CACHE_ROOT,
-        deps_fingerprint=_deps_fingerprint(),
-        repo_root=REPO_ROOT,
-        binder_repo=BINDER_REPO,
-        binder_ref=binder_ref,
-    )
+    try:
+        build_gallery(
+            examples_root=EXAMPLES_ROOT,
+            built_dir=BUILT_DIR,
+            cache_root=CACHE_ROOT,
+            deps_fingerprint=_deps_fingerprint(),
+            repo_root=REPO_ROOT,
+            binder_repo=BINDER_REPO,
+            binder_ref=binder_ref,
+            only=args.examples or None,
+        )
+    except ValueError as exc:
+        print(exc, file=sys.stderr)
+        return 1
     return 0
 
 

--- a/tools/gallery/_pipeline.py
+++ b/tools/gallery/_pipeline.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 import shutil
 import sys
+from collections.abc import Sequence
 from pathlib import Path
 
 import nbformat
@@ -156,8 +157,36 @@ def _build_one(
     progress: Progress,
     interactive: bool,
     binder_url: str | None = None,
+    run: bool = True,
 ) -> RenderedExample:
-    """Build one example and return its rendered metadata."""
+    """Build one example and return its rendered metadata.
+
+    Parameters
+    ----------
+    spec : ExampleSpec
+        The example to build.
+    built_dir : pathlib.Path
+        Directory where rendered pages and assets are written.
+    cache_root : pathlib.Path
+        Directory holding the execution/render cache.
+    deps_fingerprint : str
+        String identifying the execution/render inputs, used in the cache key.
+    progress : rich.progress.Progress
+        Progress instance the build reports into.
+    interactive : bool
+        Whether stdout is a TTY. When `False`, plain progress lines are printed.
+    binder_url : str, optional
+        Binder launch URL to stamp into the page. If not provided, no button is added.
+    run : bool, default: True
+        Whether to execute the example. When `False`, a cached result is still
+        restored if present; otherwise the page is rendered from the source with no
+        outputs (code and markdown only) and is not cached.
+
+    Returns
+    -------
+    RenderedExample
+        The rendered example's metadata.
+    """
     base_name = spec.base_name
     out_dir = built_dir / spec.section
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -190,6 +219,33 @@ def _build_one(
             md_path=out_dir / f"{base_name}.md",
             thumbnail_light=thumb[0] if thumb is not None else None,
             thumbnail_dark=thumb[1] if thumb is not None else None,
+        )
+
+    if not run:
+        # Render from the source without executing: code and markdown cells appear,
+        # but there are no outputs. Deliberately not cached, so a later full or
+        # targeted build that does run this example still executes it.
+        progress.add_task(f"{spec.section}/{base_name} [not run]", total=1, completed=1)
+        if not interactive:
+            print(f"-> {spec.section}/{base_name} [not run]", flush=True)
+        render.render_notebook(
+            source_notebook,
+            source_notebook,
+            source_notebook,
+            out_dir=out_dir,
+            base_name=base_name,
+            runtime_seconds=0.0,
+            binder_url=binder_url,
+        )
+        shutil.copyfile(spec.source, out_dir / f"{base_name}.py")
+        nbformat.write(source_notebook, out_dir / f"{base_name}.ipynb")
+        return RenderedExample(
+            spec=spec,
+            title=title,
+            summary=summary,
+            md_path=out_dir / f"{base_name}.md",
+            thumbnail_light=None,
+            thumbnail_dark=None,
         )
 
     if not interactive:
@@ -266,9 +322,46 @@ def build_gallery(
     repo_root: Path | None = None,
     binder_repo: str | None = None,
     binder_ref: str = "main",
+    only: Sequence[Path] | None = None,
 ) -> None:
-    """Run the full pipeline and write the gallery to disk."""
+    """Run the full pipeline and write the gallery to disk.
+
+    Parameters
+    ----------
+    examples_root : pathlib.Path
+        Directory containing the example sections and scripts.
+    built_dir : pathlib.Path
+        Directory where rendered pages and assets are written.
+    cache_root : pathlib.Path
+        Directory holding the execution/render cache.
+    deps_fingerprint : str
+        String identifying the execution/render inputs, used in cache keys.
+    repo_root : pathlib.Path, optional
+        Repository root, needed to compute Binder URLs. If not provided, no
+        Binder buttons are rendered.
+    binder_repo : str, optional
+        `owner/repo` slug used for Binder URLs. If not provided, no Binder
+        buttons are rendered.
+    binder_ref : str, default: "main"
+        Git ref stamped into Binder URLs.
+    only : Sequence[pathlib.Path], optional
+        Example scripts to execute. Every discovered example is still rendered
+        into the gallery (so `index.md` lists them all), but only these are run;
+        the rest are restored from cache if present, or rendered without outputs
+        (code and markdown only). If not provided, every example is executed.
+
+    Raises
+    ------
+    ValueError
+        If a path in `only` does not match any discovered example.
+    """
     specs = discover.discover(examples_root)
+    run_paths = {path.resolve() for path in only} if only is not None else None
+    if run_paths is not None:
+        missing = run_paths - {spec.source.resolve() for spec in specs}
+        if missing:
+            listing = "\n".join(f"  {path}" for path in sorted(missing))
+            raise ValueError(f"Not discoverable as example scripts:\n{listing}")
     cache_root.mkdir(parents=True, exist_ok=True)
 
     rendered: list[RenderedExample] = []
@@ -288,6 +381,7 @@ def build_gallery(
             rendered.append(
                 _build_one(
                     spec,
+                    run=run_paths is None or spec.source.resolve() in run_paths,
                     built_dir=built_dir,
                     cache_root=cache_root,
                     deps_fingerprint=deps_fingerprint,

--- a/tools/gallery/render.py
+++ b/tools/gallery/render.py
@@ -56,6 +56,31 @@ def _html_block(html: str) -> str:
     return '<div class="gallery-rich-output">' + html.rstrip() + "</div>\n"
 
 
+def _output_code_block(text: str) -> str:
+    """Return a fenced code block for plain-text cell output.
+
+    The block is wrapped in a ``gallery-output`` container so docs CSS can wrap long
+    output lines (warnings, reprs, tracebacks) instead of showing a horizontal
+    scrollbar, without affecting the syntax-highlighted input code cells. The
+    ``markdown`` attribute lets Zensical still render the fence as a highlighted block.
+
+    Parameters
+    ----------
+    text : str
+        The plain-text output to display.
+
+    Returns
+    -------
+    str
+        The Markdown for the wrapped, fenced output block.
+    """
+    return (
+        '<div class="gallery-output" markdown>\n\n```\n'
+        + text.rstrip("\n")
+        + "\n```\n\n</div>\n"
+    )
+
+
 def _normalize_html_output(html: str) -> str:
     """Normalize rich HTML reprs for static docs rendering.
 
@@ -316,7 +341,7 @@ def render_notebook(
             if output_type == "stream":
                 stream_text = _clean_stream_text(str(light_output.get("text", "")))
                 if stream_text:
-                    parts.append("```\n" + stream_text + "\n```\n")
+                    parts.append(_output_code_block(stream_text))
                 continue
 
             if output_type in {"execute_result", "display_data"}:
@@ -359,14 +384,12 @@ def render_notebook(
                     parts.append(_html_block(_normalize_html_output(str(html))))
                     continue
                 if isinstance(light_data, dict) and "text/plain" in light_data:
-                    parts.append(
-                        "```\n" + str(light_data["text/plain"]).rstrip("\n") + "\n```\n"
-                    )
+                    parts.append(_output_code_block(str(light_data["text/plain"])))
                 continue
 
             if output_type == "error":
                 traceback = "\n".join(light_output.get("traceback", []))
-                parts.append("```\n" + traceback + "\n```\n")
+                parts.append(_output_code_block(traceback))
 
     parts.append("\n---\n")
     parts.append(f"**Total running time:** {runtime_seconds:.1f} s\n\n")


### PR DESCRIPTION
Closes #280.

## Summary

Adds arguments to the gallery builder so you can iterate on individual examples without paying the full-gallery build time, and fixes two cases where long example output showed a horizontal scrollbar instead of wrapping.

## Run individual examples

`tools/build_gallery.py` now accepts optional example paths. With no arguments it runs every example as before; with paths it runs only those:

```
uv run python tools/build_gallery.py docs/examples/01_io/01_confusius_xarray_101.py docs/examples/03_decomposition/01_pca_single_recording.py
```

The whole gallery is still rendered either way, so `index.md` keeps listing everything. For each example not named on the command line:

1. if it is already in the cache, it is restored from cache (full page with outputs);
2. otherwise it is rendered from source **without running** — code and markdown cells only, no outputs — and is deliberately **not** cached, so a later full or targeted build still executes it.

Unknown paths fail fast with a message listing them.

## Wrap long output instead of scrolling

- Rich-rendered text — e.g. the dataset citation banner the fetchers print — embeds as a monospace block with an inline `white-space:pre; overflow-x:auto`. A CSS rule scoped to rich's inline `font-family:Menlo…` wraps it and breaks long unbreakable tokens such as DOI URLs. xarray HTML reprs (which should keep scrolling) are untouched.
- Plain-text output — warnings, `text/plain` reprs, tracebacks — is now wrapped in a `<div class="gallery-output" markdown>` container (Zensical's `md_in_html` keeps the highlighted code-block styling), and CSS wraps its lines. Input `python` code cells and xarray text reprs elsewhere in the docs still scroll.

## Testing

- New/updated tests: builds only selected examples while stubbing the rest (asserts the selected example has output, the rest have code but no `gallery-output`, aren't cached, and the index lists both); unknown-path validation; render test asserting output is wrapped while input code stays a bare highlighted block.
- Verified end-to-end against the real examples: running one example executes it, reuses a cached example, stubs the rest, and lists all seven in the index. Confirmed the citation-banner CSS selector against the pr-279 preview page (matches the one rich-text block, leaves the three xarray reprs alone).
