### PR TITLE
fix: support BIDS physio import in napari

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -26,7 +26,6 @@ Current development version for the next ConfUSIus release.
   needed; the napari plugin now uses it for imported signal tables
   ([#294](https://github.com/confusius-tools/confusius/pull/294)).
 
-
 ### :bug: Fixes
 
 - Motion parameter tables from
@@ -35,6 +34,9 @@ Current development version for the next ConfUSIus release.
   transform-component order, so canonical ConfUSIus arrays stored as `(z, y, x)` no
   longer mislabel in-plane motion
   ([#301](https://github.com/confusius-tools/confusius/pull/301)).
+- **[Napari plugin]** The signal import dialog now finds BIDS physio files ending in
+  `.tsv.gz`, keeps the x-axis cursor visible for imported-only plots when enabled, and
+  lets you import multiple signal files in one go ([#294](https://github.com/confusius-tools/confusius/pull/294)).
 - Opening a `.scan` file that is not the legacy HDF5-based Iconeus format now raises a
   clear error that points users to newer SCAN v2 files and to converting them to NIfTI
   with Iconeus tools first ([#297](https://github.com/confusius-tools/confusius/pull/297)).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,12 @@ icon: lucide/history
 
 # Changelog
 
+## 0.5.3.dev0
+
+### :bug: Fixes
+
+- **[Napari plugin]** Imported signal tables now accept BIDS physio `*.tsv.gz` files with column names and timing read from the JSON sidecar.
+
 ## 0.5.2
 
 Released 2026-07-10.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,9 +10,16 @@ icon: lucide/history
 
 Current development version for the next ConfUSIus release.
 
+### :boom: Breaking changes
+
+- Renamed the public BIDS table I/O helpers to match the rest of ConfUSIus:
+  [`read_events`][confusius.bids.load_events] → [`load_events`][confusius.bids.load_events],
+  [`write_events`][confusius.bids.save_events] → [`save_events`][confusius.bids.save_events],
+  and [`read_physio`][confusius.bids.load_physio] → [`load_physio`][confusius.bids.load_physio].
+
 ### :sparkles: Enhancements
 
-- Added [`read_physio`][confusius.bids.read_physio] to load BIDS physio TSV files with
+- Added [`load_physio`][confusius.bids.load_physio] to load BIDS physio TSV files with
   column names and metadata from the JSON sidecar, synthesizing a `time` column when
   needed; the napari plugin now uses it for imported signal tables.
 
@@ -162,8 +169,8 @@ Released 2026-07-07.
   from / save to a BIDS `.tsv`
   ([#176](https://github.com/confusius-tools/confusius/pull/176)).
 - [`confusius.bids`][confusius.bids] module is now public with new
-  [`read_events`][confusius.bids.read_events] and
-  [`write_events`][confusius.bids.write_events]
+  [`load_events`][confusius.bids.load_events] and
+  [`save_events`][confusius.bids.save_events]
   ([#176](https://github.com/confusius-tools/confusius/pull/176)).
 - Added a `datasets` CLI namespace, listed in `confusius --help`:
   `confusius datasets --list` prints the table of available datasets, their sizes,

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,15 +13,19 @@ Current development version for the next ConfUSIus release.
 ### :boom: Breaking changes
 
 - Renamed the public BIDS table I/O helpers to match the rest of ConfUSIus:
-  [`read_events`][confusius.bids.load_events] → [`load_events`][confusius.bids.load_events],
-  [`write_events`][confusius.bids.save_events] → [`save_events`][confusius.bids.save_events],
-  and [`read_physio`][confusius.bids.load_physio] → [`load_physio`][confusius.bids.load_physio].
+  [`read_events`][confusius.bids.load_events] →
+  [`load_events`][confusius.bids.load_events], and
+  [`write_events`][confusius.bids.save_events] →
+  [`save_events`][confusius.bids.save_events]
+  ([#294](https://github.com/confusius-tools/confusius/pull/294)).
 
 ### :sparkles: Enhancements
 
 - Added [`load_physio`][confusius.bids.load_physio] to load BIDS physio TSV files with
   column names and metadata from the JSON sidecar, synthesizing a `time` column when
-  needed; the napari plugin now uses it for imported signal tables.
+  needed; the napari plugin now uses it for imported signal tables
+  ([#294](https://github.com/confusius-tools/confusius/pull/294)).
+
 
 ### :bug: Fixes
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,8 +12,9 @@ Current development version for the next ConfUSIus release.
 
 ### :sparkles: Enhancements
 
-- **[Napari plugin]** Imported signal tables now accept BIDS physio `*.tsv.gz` files with 
-  column names and timing read from the JSON sidecar.
+- Added [`read_physio`][confusius.bids.read_physio] to load BIDS physio TSV files with
+  column names and metadata from the JSON sidecar, synthesizing a `time` column when
+  needed; the napari plugin now uses it for imported signal tables.
 
 ### :bug: Fixes
 

--- a/docs/gui/plugin.md
+++ b/docs/gui/plugin.md
@@ -182,10 +182,13 @@ signals (from the current source mode) and imported signals:
 ### Importing and exporting signals
 
 **Import**
-: In the Manage Signals dialog, click **Import** to load signals from a CSV or TSV
-  file. The file must contain a column whose header matches the current *x*-axis
-  dimension name (e.g. `time`) plus one or more numeric value columns. Each value
-  column becomes a separate signal overlaid on the plot.
+: In the Manage Signals dialog, click **Import** to load one or more signal files at
+  once. Standard CSV / TSV files must contain a column whose header matches the
+  current *x*-axis dimension name (e.g. `time`) plus one or more numeric value
+  columns. BIDS physio files ending in `_physio.tsv.gz` are also supported: ConfUSIus
+  reads their JSON sidecar, uses the declared column names, and synthesizes `time`
+  from `SamplingFrequency` and `StartTime` when needed. Each value column becomes a
+  separate signal overlaid on the plot.
 
 **Export**
 : Click the **Export** button in the plot toolbar to export all currently plotted

--- a/docs/gui/plugin.md
+++ b/docs/gui/plugin.md
@@ -221,15 +221,15 @@ out as a BIDS events `.tsv`.
 
 !!! tip "Straight into analysis"
     An events `.tsv` saved here is a standard BIDS events table, so it can be read back
-    with [read_events][confusius.bids.read_events] and fed directly to either
+    with [load_events][confusius.bids.load_events] and fed directly to either
     [make_first_level_design_matrix][confusius.glm.make_first_level_design_matrix] or
     the `fit` method of a [FirstLevelModel][confusius.glm.first_level.FirstLevelModel]:
 
     ```python
-    from confusius.bids import read_events
+    from confusius.bids import load_events
     from confusius.glm import FirstLevelModel
 
-    events = read_events("sub-01_task-rest_events.tsv")
+    events = load_events("sub-01_task-rest_events.tsv")
     model = FirstLevelModel(hrf_model="glover").fit(fusi_scan, events=events)
     ```
 

--- a/src/confusius/_napari/_events/_store.py
+++ b/src/confusius/_napari/_events/_store.py
@@ -13,8 +13,8 @@ from confusius.bids.events import (
     DURATION_COLUMN,
     ONSET_COLUMN,
     TRIAL_TYPE_COLUMN,
-    read_events,
-    write_events,
+    load_events,
+    save_events,
 )
 
 
@@ -314,9 +314,9 @@ class EventStore(QObject):
         ------
         ValueError
             If the file is not a valid BIDS events file (propagated from
-            `confusius.bids.events.read_events`).
+            `confusius.bids.events.load_events`).
         """
-        loaded = read_events(path)
+        loaded = load_events(path)
         for trial_type in loaded[TRIAL_TYPE_COLUMN]:
             self.color_for(trial_type)
         self._events = self._concat(loaded)
@@ -331,7 +331,7 @@ class EventStore(QObject):
         path : str or pathlib.Path
             Output path for the tab-separated events file.
         """
-        write_events(path, self._events)
+        save_events(path, self._events)
 
     def _concat(self, rows: pd.DataFrame) -> pd.DataFrame:
         """Append rows to the events table, keeping it sorted by onset.

--- a/src/confusius/_napari/_signals/_manager.py
+++ b/src/confusius/_napari/_signals/_manager.py
@@ -312,7 +312,7 @@ class SignalsManagerDialog(QDialog):
             self,
             "Import Signal",
             "",
-            "Delimited text (*.tsv *.csv);;TSV (*.tsv);;CSV (*.csv);;All files (*)",
+            "Delimited text (*.tsv *.tsv.gz *.csv);;TSV (*.tsv *.tsv.gz);;CSV (*.csv);;All files (*)",
         )
         if not path_str:
             return

--- a/src/confusius/_napari/_signals/_manager.py
+++ b/src/confusius/_napari/_signals/_manager.py
@@ -307,25 +307,32 @@ class SignalsManagerDialog(QDialog):
         self._store.remove_signals(signal_ids)
 
     def _import_file(self) -> None:
-        """Import one CSV or TSV file into the shared store."""
-        path_str, _ = QFileDialog.getOpenFileName(
+        """Import one or more CSV or TSV files into the shared store."""
+        path_strs, _ = QFileDialog.getOpenFileNames(
             self,
             "Import Signal",
             "",
             "Delimited text (*.tsv *.tsv.gz *.csv);;TSV (*.tsv *.tsv.gz);;CSV (*.csv);;All files (*)",
         )
-        if not path_str:
+        if not path_strs:
             return
 
-        try:
-            imported = self._store.import_file(Path(path_str))
-        except Exception as exc:  # noqa: BLE001
-            show_error(str(exc))
-            return
+        imported_count = 0
+        file_count = 0
+        for path_str in path_strs:
+            try:
+                imported = self._store.import_file(Path(path_str))
+            except Exception as exc:  # noqa: BLE001
+                show_error(str(exc))
+                return
+            imported_count += len(imported)
+            file_count += 1
 
-        count = len(imported)
-        noun = "signal" if count != 1 else "signals"
-        show_info(f"Imported {count} {noun} from {Path(path_str).name}")
+        signal_noun = "signal" if imported_count == 1 else "signals"
+        file_noun = "file" if file_count == 1 else "files"
+        show_info(
+            f"Imported {imported_count} {signal_noun} from {file_count} {file_noun}."
+        )
 
     def apply_theme(self, theme_name: str) -> None:
         """Apply napari theme to the table for proper alternating row colors.

--- a/src/confusius/_napari/_signals/_plotter.py
+++ b/src/confusius/_napari/_signals/_plotter.py
@@ -1483,7 +1483,6 @@ class SignalPlotter(QWidget):
             "Z-score" if self._zscore else "Value",
             "Imported Signals",
             with_legend=len(imported_signals) > 1,
-            show_cursor=False,
         )
         self._restore_view(saved_xlim, saved_ylim)
         self._has_plot = True

--- a/src/confusius/_napari/_signals/_store.py
+++ b/src/confusius/_napari/_signals/_store.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Literal
@@ -13,6 +12,7 @@ import pandas as pd
 from qtpy.QtCore import QObject, Signal
 
 from confusius._napari._utils import CATEGORICAL_COLORS
+from confusius.bids import read_physio
 
 _IMPORTED_SIGNAL_COLORS = CATEGORICAL_COLORS
 """Palette cycled across imported signal columns."""
@@ -237,57 +237,19 @@ class SignalStore(QObject):
 
     def _read_signals_table(self, path: Path) -> pd.DataFrame:
         """Read one CSV or TSV signals table from disk."""
-        bids_frame = self._read_bids_physio_table(path)
-        if bids_frame is not None:
-            return bids_frame
+        if self._is_bids_physio_path(path):
+            return read_physio(path)
 
         _SEP: dict[str, str] = {".csv": ",", ".tsv": "\t"}
         sep = _SEP.get(self._table_suffix(path))
         return pd.read_csv(path, sep=sep, engine="python" if sep is None else "c")
 
-    def _read_bids_physio_table(self, path: Path) -> pd.DataFrame | None:
-        """Read a BIDS physio table with sidecar-defined columns, if present."""
-        sidecar_path = self._sidecar_path(path)
-        if sidecar_path is None or not sidecar_path.exists():
-            return None
-
-        try:
-            metadata = json.loads(sidecar_path.read_text())
-        except json.JSONDecodeError:
-            return None
-        columns = metadata.get("Columns")
-        sampling_frequency = metadata.get("SamplingFrequency")
-        if not isinstance(columns, list) or not columns:
-            return None
-        if not isinstance(sampling_frequency, int | float) or sampling_frequency <= 0:
-            return None
-
-        start_time = metadata.get("StartTime", 0.0)
-        if not isinstance(start_time, int | float):
-            return None
-
-        frame = pd.read_csv(path, sep="\t", header=None)
-        if frame.shape[1] != len(columns):
-            raise ValueError(
-                "BIDS physio sidecar 'Columns' length does not match TSV width."
-            )
-
-        frame.columns = [str(column) for column in columns]
-        frame.insert(
-            0,
-            "time",
-            start_time + np.arange(len(frame), dtype=float) / float(sampling_frequency),
-        )
-        return frame
-
-    def _sidecar_path(self, path: Path) -> Path | None:
-        """Return the matching JSON sidecar path for a compressed or plain table."""
-        suffix = self._table_suffix(path)
-        if suffix not in {".tsv", ".csv"}:
-            return None
-        if path.suffix.lower() == ".gz":
-            return path.with_suffix("").with_suffix(".json")
-        return path.with_suffix(".json")
+    def _is_bids_physio_path(self, path: Path) -> bool:
+        """Return whether `path` looks like a BIDS physio table."""
+        if self._table_suffix(path) != ".tsv":
+            return False
+        name = path.name.removesuffix(".gz")
+        return name.endswith("_physio.tsv")
 
     def _table_suffix(self, path: Path) -> str:
         """Return the logical table suffix, ignoring a trailing `.gz`."""

--- a/src/confusius/_napari/_signals/_store.py
+++ b/src/confusius/_napari/_signals/_store.py
@@ -12,7 +12,7 @@ import pandas as pd
 from qtpy.QtCore import QObject, Signal
 
 from confusius._napari._utils import CATEGORICAL_COLORS
-from confusius.bids import read_physio
+from confusius.bids import load_physio
 
 _IMPORTED_SIGNAL_COLORS = CATEGORICAL_COLORS
 """Palette cycled across imported signal columns."""
@@ -238,7 +238,7 @@ class SignalStore(QObject):
     def _read_signals_table(self, path: Path) -> pd.DataFrame:
         """Read one CSV or TSV signals table from disk."""
         if self._is_bids_physio_path(path):
-            return read_physio(path)
+            return load_physio(path)
 
         _SEP: dict[str, str] = {".csv": ",", ".tsv": "\t"}
         sep = _SEP.get(self._table_suffix(path))

--- a/src/confusius/_napari/_signals/_store.py
+++ b/src/confusius/_napari/_signals/_store.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Literal
@@ -236,9 +237,63 @@ class SignalStore(QObject):
 
     def _read_signals_table(self, path: Path) -> pd.DataFrame:
         """Read one CSV or TSV signals table from disk."""
+        bids_frame = self._read_bids_physio_table(path)
+        if bids_frame is not None:
+            return bids_frame
+
         _SEP: dict[str, str] = {".csv": ",", ".tsv": "\t"}
-        sep = _SEP.get(path.suffix.lower())
+        sep = _SEP.get(self._table_suffix(path))
         return pd.read_csv(path, sep=sep, engine="python" if sep is None else "c")
+
+    def _read_bids_physio_table(self, path: Path) -> pd.DataFrame | None:
+        """Read a BIDS physio table with sidecar-defined columns, if present."""
+        sidecar_path = self._sidecar_path(path)
+        if sidecar_path is None or not sidecar_path.exists():
+            return None
+
+        try:
+            metadata = json.loads(sidecar_path.read_text())
+        except json.JSONDecodeError:
+            return None
+        columns = metadata.get("Columns")
+        sampling_frequency = metadata.get("SamplingFrequency")
+        if not isinstance(columns, list) or not columns:
+            return None
+        if not isinstance(sampling_frequency, int | float) or sampling_frequency <= 0:
+            return None
+
+        start_time = metadata.get("StartTime", 0.0)
+        if not isinstance(start_time, int | float):
+            return None
+
+        frame = pd.read_csv(path, sep="\t", header=None)
+        if frame.shape[1] != len(columns):
+            raise ValueError(
+                "BIDS physio sidecar 'Columns' length does not match TSV width."
+            )
+
+        frame.columns = [str(column) for column in columns]
+        frame.insert(
+            0,
+            "time",
+            start_time + np.arange(len(frame), dtype=float) / float(sampling_frequency),
+        )
+        return frame
+
+    def _sidecar_path(self, path: Path) -> Path | None:
+        """Return the matching JSON sidecar path for a compressed or plain table."""
+        suffix = self._table_suffix(path)
+        if suffix not in {".tsv", ".csv"}:
+            return None
+        if path.suffix.lower() == ".gz":
+            return path.with_suffix("").with_suffix(".json")
+        return path.with_suffix(".json")
+
+    def _table_suffix(self, path: Path) -> str:
+        """Return the logical table suffix, ignoring a trailing `.gz`."""
+        if path.suffix.lower() == ".gz" and len(path.suffixes) >= 2:
+            return path.suffixes[-2].lower()
+        return path.suffix.lower()
 
     def _signal_from_frame(
         self, frame: pd.DataFrame, path: Path

--- a/src/confusius/bids/__init__.py
+++ b/src/confusius/bids/__init__.py
@@ -34,6 +34,7 @@ from confusius.bids.coordinates import (
 )
 from confusius.bids.events import DEFAULT_TRIAL_TYPE, read_events, write_events
 from confusius.bids.mapping import EXPLICIT_BIDS_FIELD_MAPPINGS, from_bids, to_bids
+from confusius.bids.physio import read_physio
 from confusius.bids.validation import (
     FUSI_BIDS_FIELDS,
     FUSIBIDSMetadata,
@@ -58,4 +59,6 @@ __all__ = [
     "DEFAULT_TRIAL_TYPE",
     "read_events",
     "write_events",
+    # Physio
+    "read_physio",
 ]

--- a/src/confusius/bids/__init__.py
+++ b/src/confusius/bids/__init__.py
@@ -32,9 +32,9 @@ from confusius.bids.coordinates import (
     create_bids_slice_timing_from_coordinate,
     create_slice_time_coordinate_from_bids,
 )
-from confusius.bids.events import DEFAULT_TRIAL_TYPE, read_events, write_events
+from confusius.bids.events import DEFAULT_TRIAL_TYPE, load_events, save_events
 from confusius.bids.mapping import EXPLICIT_BIDS_FIELD_MAPPINGS, from_bids, to_bids
-from confusius.bids.physio import read_physio
+from confusius.bids.physio import load_physio
 from confusius.bids.validation import (
     FUSI_BIDS_FIELDS,
     FUSIBIDSMetadata,
@@ -57,8 +57,8 @@ __all__ = [
     "create_slice_time_coordinate_from_bids",
     # Events
     "DEFAULT_TRIAL_TYPE",
-    "read_events",
-    "write_events",
+    "load_events",
+    "save_events",
     # Physio
-    "read_physio",
+    "load_physio",
 ]

--- a/src/confusius/bids/events.py
+++ b/src/confusius/bids/events.py
@@ -29,8 +29,8 @@ __all__ = [
     "ONSET_COLUMN",
     "DURATION_COLUMN",
     "TRIAL_TYPE_COLUMN",
-    "read_events",
-    "write_events",
+    "load_events",
+    "save_events",
 ]
 
 ONSET_COLUMN = "onset"
@@ -46,8 +46,8 @@ _REQUIRED_COLUMNS = (ONSET_COLUMN, DURATION_COLUMN)
 """BIDS columns that every events file must contain."""
 
 
-def read_events(path: str | Path) -> pd.DataFrame:
-    """Read a BIDS events file into an events table.
+def load_events(path: str | Path) -> pd.DataFrame:
+    """Load a BIDS events file into an events table.
 
     Parameters
     ----------
@@ -102,8 +102,8 @@ def read_events(path: str | Path) -> pd.DataFrame:
     return frame[ordered]
 
 
-def write_events(path: str | Path, events: pd.DataFrame) -> None:
-    """Write an events table to a BIDS events file.
+def save_events(path: str | Path, events: pd.DataFrame) -> None:
+    """Save an events table to a BIDS events file.
 
     Rows are sorted by onset, as recommended by BIDS, and columns are ordered
     `onset`, `duration`, `trial_type` (when present), then any extra columns.

--- a/src/confusius/bids/physio.py
+++ b/src/confusius/bids/physio.py
@@ -17,11 +17,11 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 
-__all__ = ["read_physio"]
+__all__ = ["load_physio"]
 
 
-def read_physio(path: str | Path) -> pd.DataFrame:
-    """Read a BIDS physio table into a DataFrame.
+def load_physio(path: str | Path) -> pd.DataFrame:
+    """Load a BIDS physio table into a DataFrame.
 
     Parameters
     ----------

--- a/src/confusius/bids/physio.py
+++ b/src/confusius/bids/physio.py
@@ -1,0 +1,95 @@
+"""Read BIDS physio files into a signals table.
+
+A BIDS physio recording is stored as a tab-separated values file without a header,
+accompanied by a JSON sidecar that defines the column names and timing metadata.
+This reader returns a `pandas.DataFrame` with those column names applied.
+
+When the sidecar does not already declare a `time` column, one is synthesized from
+`SamplingFrequency` and `StartTime` so the result can be aligned directly with fUSI
+acquisitions and other time-based ConfUSIus data.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+__all__ = ["read_physio"]
+
+
+def read_physio(path: str | Path) -> pd.DataFrame:
+    """Read a BIDS physio table into a DataFrame.
+
+    Parameters
+    ----------
+    path : str or pathlib.Path
+        Path to a BIDS physio TSV file, typically ending in `_physio.tsv` or
+        `_physio.tsv.gz`.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Physio table with sidecar-defined column names. When the sidecar does not
+        include a `time` column, one is inserted first using `SamplingFrequency`
+        and `StartTime`. The sidecar JSON fields are copied to `DataFrame.attrs`.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the matching JSON sidecar does not exist.
+    ValueError
+        If the sidecar JSON is invalid, does not define a non-empty `Columns` list,
+        if the TSV width does not match `Columns`, or if timing metadata is needed
+        to synthesize `time` but missing or invalid.
+    """
+    path = Path(path)
+    sidecar_path = _sidecar_path(path)
+    if not sidecar_path.exists():
+        raise FileNotFoundError(f"Could not find BIDS physio sidecar: {sidecar_path}.")
+
+    try:
+        metadata = json.loads(sidecar_path.read_text())
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid BIDS physio sidecar JSON: {sidecar_path}.") from exc
+
+    columns = metadata.get("Columns")
+    if not isinstance(columns, list) or not columns:
+        raise ValueError("BIDS physio sidecar must define a non-empty 'Columns' list.")
+
+    frame = pd.read_csv(path, sep="\t", header=None)
+    if frame.shape[1] != len(columns):
+        raise ValueError(
+            "BIDS physio sidecar 'Columns' length does not match TSV width."
+        )
+
+    frame.columns = [str(column) for column in columns]
+    if "time" not in frame.columns:
+        sampling_frequency = metadata.get("SamplingFrequency")
+        if not isinstance(sampling_frequency, int | float) or sampling_frequency <= 0:
+            raise ValueError(
+                "BIDS physio sidecar must define a positive numeric "
+                "'SamplingFrequency' when 'time' is absent from 'Columns'."
+            )
+
+        start_time = metadata.get("StartTime", 0.0)
+        if not isinstance(start_time, int | float):
+            raise ValueError("BIDS physio sidecar 'StartTime' must be numeric.")
+
+        frame.insert(
+            0,
+            "time",
+            start_time + np.arange(len(frame), dtype=float) / float(sampling_frequency),
+        )
+
+    frame.attrs.update(metadata)
+    return frame
+
+
+def _sidecar_path(path: Path) -> Path:
+    """Return the JSON sidecar path matching a BIDS physio TSV file."""
+    if path.suffix.lower() == ".gz":
+        return path.with_suffix("").with_suffix(".json")
+    return path.with_suffix(".json")

--- a/tests/unit/test_bids_events.py
+++ b/tests/unit/test_bids_events.py
@@ -10,8 +10,8 @@ from confusius.bids.events import (
     DURATION_COLUMN,
     ONSET_COLUMN,
     TRIAL_TYPE_COLUMN,
-    read_events,
-    write_events,
+    load_events,
+    save_events,
 )
 
 
@@ -30,7 +30,7 @@ class TestReadEvents:
         path = tmp_path / "events.tsv"
         path.write_text("onset\tduration\ttrial_type\n1.0\t2.0\tstim\n4.5\t0.5\tcue\n")
 
-        events = read_events(path)
+        events = load_events(path)
 
         expected = pd.DataFrame(
             {
@@ -46,7 +46,7 @@ class TestReadEvents:
         path = tmp_path / "events.tsv"
         path.write_text("onset\tduration\n0.0\t1.0\n")
 
-        events = read_events(path)
+        events = load_events(path)
 
         assert list(events["trial_type"]) == [DEFAULT_TRIAL_TYPE]
 
@@ -55,7 +55,7 @@ class TestReadEvents:
         path = tmp_path / "events.tsv"
         path.write_text("onset\tduration\ttrial_type\n0.0\t1.0\tn/a\n2.0\t1.0\t\n")
 
-        events = read_events(path)
+        events = load_events(path)
 
         assert list(events["trial_type"]) == [DEFAULT_TRIAL_TYPE, DEFAULT_TRIAL_TYPE]
 
@@ -66,7 +66,7 @@ class TestReadEvents:
             "onset\tduration\ttrial_type\tresponse_time\n1.0\t2.0\tstim\t0.42\n"
         )
 
-        events = read_events(path)
+        events = load_events(path)
 
         assert list(events.columns) == [
             "onset",
@@ -82,7 +82,7 @@ class TestReadEvents:
         path.write_text("onset\ttrial_type\n0.0\tstim\n")
 
         with pytest.raises(ValueError, match="duration"):
-            read_events(path)
+            load_events(path)
 
     def test_non_numeric_onset_raises(self, tmp_path):
         """A non-numeric onset value is rejected."""
@@ -90,7 +90,7 @@ class TestReadEvents:
         path.write_text("onset\tduration\nstart\t1.0\n")
 
         with pytest.raises(ValueError, match="numeric"):
-            read_events(path)
+            load_events(path)
 
     def test_negative_duration_raises(self, tmp_path):
         """A negative duration value is rejected."""
@@ -98,7 +98,7 @@ class TestReadEvents:
         path.write_text("onset\tduration\n0.0\t-1.0\n")
 
         with pytest.raises(ValueError, match="non-negative"):
-            read_events(path)
+            load_events(path)
 
 
 class TestWriteEvents:
@@ -115,7 +115,7 @@ class TestWriteEvents:
             }
         )
 
-        write_events(path, events)
+        save_events(path, events)
 
         lines = path.read_text().splitlines()
         assert lines[0] == "onset\tduration\ttrial_type"
@@ -135,8 +135,8 @@ class TestWriteEvents:
             }
         )
 
-        write_events(path, events)
-        loaded = read_events(path)
+        save_events(path, events)
+        loaded = load_events(path)
 
         expected = pd.DataFrame(
             {
@@ -153,7 +153,7 @@ class TestWriteEvents:
         path = tmp_path / "events.tsv"
         events = pd.DataFrame({"onset": [], "duration": [], "trial_type": []})
 
-        write_events(path, events)
+        save_events(path, events)
 
         assert path.read_text().splitlines() == ["onset\tduration\ttrial_type"]
 
@@ -161,11 +161,11 @@ class TestWriteEvents:
         """A non-DataFrame events argument is rejected."""
         path = tmp_path / "events.tsv"
         with pytest.raises(TypeError, match="DataFrame"):
-            write_events(path, [(0.0, 1.0, "stim")])  # ty: ignore[invalid-argument-type]
+            save_events(path, [(0.0, 1.0, "stim")])  # ty: ignore[invalid-argument-type]
 
     def test_rejects_missing_required_column(self, tmp_path):
         """A DataFrame without a duration column is rejected."""
         path = tmp_path / "events.tsv"
         events = pd.DataFrame({"onset": [0.0], "trial_type": ["stim"]})
         with pytest.raises(ValueError, match="duration"):
-            write_events(path, events)
+            save_events(path, events)

--- a/tests/unit/test_bids_physio.py
+++ b/tests/unit/test_bids_physio.py
@@ -79,3 +79,46 @@ class TestReadPhysio:
 
         with pytest.raises(ValueError, match="SamplingFrequency"):
             load_physio(path)
+
+    def test_rejects_missing_sidecar(self, tmp_path):
+        """A BIDS physio table without its JSON sidecar is rejected."""
+        path = tmp_path / "sub-01_task-rest_recording-cardiac_physio.tsv"
+        path.write_text("1\n2\n")
+
+        with pytest.raises(FileNotFoundError, match="sidecar"):
+            load_physio(path)
+
+    def test_rejects_invalid_sidecar_json(self, tmp_path):
+        """A malformed sidecar JSON file is rejected."""
+        path = tmp_path / "sub-01_task-rest_recording-cardiac_physio.tsv"
+        path.write_text("1\n2\n")
+        path.with_suffix(".json").write_text("{not json")
+
+        with pytest.raises(ValueError, match="Invalid BIDS physio sidecar JSON"):
+            load_physio(path)
+
+    def test_rejects_missing_columns_definition(self, tmp_path):
+        """A sidecar must define a non-empty Columns list."""
+        path = tmp_path / "sub-01_task-rest_recording-cardiac_physio.tsv"
+        path.write_text("1\n2\n")
+        path.with_suffix(".json").write_text(json.dumps({"Columns": []}))
+
+        with pytest.raises(ValueError, match="non-empty 'Columns' list"):
+            load_physio(path)
+
+    def test_rejects_non_numeric_start_time_when_time_absent(self, tmp_path):
+        """Synthesizing time requires a numeric start time."""
+        path = tmp_path / "sub-01_task-rest_recording-cardiac_physio.tsv"
+        path.write_text("1\n2\n")
+        path.with_suffix(".json").write_text(
+            json.dumps(
+                {
+                    "Columns": ["pulse"],
+                    "SamplingFrequency": 10.0,
+                    "StartTime": "early",
+                }
+            )
+        )
+
+        with pytest.raises(ValueError, match="StartTime"):
+            load_physio(path)

--- a/tests/unit/test_bids_physio.py
+++ b/tests/unit/test_bids_physio.py
@@ -1,0 +1,81 @@
+"""Tests for the confusius.bids.physio module."""
+
+from __future__ import annotations
+
+import gzip
+import json
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+from pandas.testing import assert_frame_equal
+
+from confusius.bids import read_physio
+
+
+class TestReadPhysio:
+    """Reading BIDS physio files into a DataFrame."""
+
+    def test_reads_columns_and_synthesizes_time_from_sidecar(self, tmp_path):
+        """Sidecar columns and timing metadata produce a ready-to-compare table."""
+        path = tmp_path / "sub-01_task-rest_recording-cardiac_physio.tsv.gz"
+        with gzip.open(path, "wt") as f:
+            f.write("1\t10\n2\t11\n3\t12\n")
+
+        path.with_suffix("").with_suffix(".json").write_text(
+            json.dumps(
+                {
+                    "Columns": ["pulse", "resp"],
+                    "SamplingFrequency": 2.0,
+                    "StartTime": -0.5,
+                    "Manufacturer": "Acme",
+                }
+            )
+        )
+
+        frame = read_physio(path)
+
+        expected = {
+            "time": np.array([-0.5, 0.0, 0.5]),
+            "pulse": np.array([1, 2, 3]),
+            "resp": np.array([10, 11, 12]),
+        }
+        assert_frame_equal(frame, frame.__class__(expected))
+        assert frame.attrs["Columns"] == ["pulse", "resp"]
+        assert frame.attrs["SamplingFrequency"] == 2.0
+        assert frame.attrs["StartTime"] == -0.5
+        assert frame.attrs["Manufacturer"] == "Acme"
+
+    def test_keeps_existing_time_column(self, tmp_path):
+        """A sidecar-declared time column is kept instead of being synthesized."""
+        path = tmp_path / "sub-01_task-rest_recording-cardiac_physio.tsv"
+        path.write_text("0.1\t1\n0.2\t2\n")
+        path.with_suffix(".json").write_text(json.dumps({"Columns": ["time", "pulse"]}))
+
+        frame = read_physio(path)
+
+        assert list(frame.columns) == ["time", "pulse"]
+        npt.assert_allclose(frame["time"], np.array([0.1, 0.2]))
+        npt.assert_array_equal(frame["pulse"], np.array([1, 2]))
+
+    def test_rejects_column_count_mismatch(self, tmp_path):
+        """A sidecar whose column count disagrees with the TSV is rejected."""
+        path = tmp_path / "sub-01_task-rest_recording-cardiac_physio.tsv"
+        path.write_text("1\t10\n2\t11\n")
+        path.with_suffix(".json").write_text(
+            json.dumps({"Columns": ["pulse"], "SamplingFrequency": 10.0})
+        )
+
+        with pytest.raises(
+            ValueError, match="Columns' length does not match TSV width"
+        ):
+            read_physio(path)
+
+    def test_rejects_missing_sampling_frequency_when_time_absent(self, tmp_path):
+        """Synthesizing time requires a positive numeric sampling frequency."""
+        path = tmp_path / "sub-01_task-rest_recording-cardiac_physio.tsv"
+        path.write_text("1\n2\n")
+        path.with_suffix(".json").write_text(json.dumps({"Columns": ["pulse"]}))
+
+        with pytest.raises(ValueError, match="SamplingFrequency"):
+            read_physio(path)

--- a/tests/unit/test_bids_physio.py
+++ b/tests/unit/test_bids_physio.py
@@ -10,7 +10,7 @@ import numpy.testing as npt
 import pytest
 from pandas.testing import assert_frame_equal
 
-from confusius.bids import read_physio
+from confusius.bids import load_physio
 
 
 class TestReadPhysio:
@@ -33,7 +33,7 @@ class TestReadPhysio:
             )
         )
 
-        frame = read_physio(path)
+        frame = load_physio(path)
 
         expected = {
             "time": np.array([-0.5, 0.0, 0.5]),
@@ -52,7 +52,7 @@ class TestReadPhysio:
         path.write_text("0.1\t1\n0.2\t2\n")
         path.with_suffix(".json").write_text(json.dumps({"Columns": ["time", "pulse"]}))
 
-        frame = read_physio(path)
+        frame = load_physio(path)
 
         assert list(frame.columns) == ["time", "pulse"]
         npt.assert_allclose(frame["time"], np.array([0.1, 0.2]))
@@ -69,7 +69,7 @@ class TestReadPhysio:
         with pytest.raises(
             ValueError, match="Columns' length does not match TSV width"
         ):
-            read_physio(path)
+            load_physio(path)
 
     def test_rejects_missing_sampling_frequency_when_time_absent(self, tmp_path):
         """Synthesizing time requires a positive numeric sampling frequency."""
@@ -78,4 +78,4 @@ class TestReadPhysio:
         path.with_suffix(".json").write_text(json.dumps({"Columns": ["pulse"]}))
 
         with pytest.raises(ValueError, match="SamplingFrequency"):
-            read_physio(path)
+            load_physio(path)

--- a/tests/unit/test_napari/test_signal_manager.py
+++ b/tests/unit/test_napari/test_signal_manager.py
@@ -95,21 +95,40 @@ def test_manager_handles_multiple_selection(qtbot, signals_store, signals_csv):
     assert signals_store.imported_signals() == []
 
 
+def test_manager_imports_multiple_files(qtbot, signals_store, monkeypatch, tmp_path):
+    dialog = SignalsManagerDialog(signals_store)
+    qtbot.addWidget(dialog)
+
+    path1 = tmp_path / "a.csv"
+    path1.write_text("time,a\n0,1\n1,2\n")
+    path2 = tmp_path / "b.csv"
+    path2.write_text("time,b\n0,3\n1,4\n")
+
+    monkeypatch.setattr(
+        "confusius._napari._signals._manager.QFileDialog.getOpenFileNames",
+        lambda *args, **kwargs: ([str(path1), str(path2)], ""),
+    )
+
+    dialog._import_file()
+
+    assert [signal.name for signal in signals_store.imported_signals()] == ["a", "b"]
+
+
 def test_manager_import_dialog_filters_supported_formats(
     qtbot, signals_store, monkeypatch
 ):
     dialog = SignalsManagerDialog(signals_store)
     qtbot.addWidget(dialog)
 
-    def _fake_get_open_file_name(parent, caption, directory, file_filter):
+    def _fake_get_open_file_names(parent, caption, directory, file_filter):
         assert "*.tsv" in file_filter
         assert "*.tsv.gz" in file_filter
         assert "*.csv" in file_filter
-        return str(Path("/tmp/does-not-matter.tsv.gz")), ""
+        return [str(Path("/tmp/does-not-matter.tsv.gz"))], ""
 
     monkeypatch.setattr(
-        "confusius._napari._signals._manager.QFileDialog.getOpenFileName",
-        _fake_get_open_file_name,
+        "confusius._napari._signals._manager.QFileDialog.getOpenFileNames",
+        _fake_get_open_file_names,
     )
     monkeypatch.setattr(signals_store, "import_file", lambda path: [])
 

--- a/tests/unit/test_napari/test_signal_manager.py
+++ b/tests/unit/test_napari/test_signal_manager.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QColor
 
@@ -91,3 +93,24 @@ def test_manager_handles_multiple_selection(qtbot, signals_store, signals_csv):
     dialog._remove_selected()
 
     assert signals_store.imported_signals() == []
+
+
+def test_manager_import_dialog_filters_supported_formats(
+    qtbot, signals_store, monkeypatch
+):
+    dialog = SignalsManagerDialog(signals_store)
+    qtbot.addWidget(dialog)
+
+    def _fake_get_open_file_name(parent, caption, directory, file_filter):
+        assert "*.tsv" in file_filter
+        assert "*.tsv.gz" in file_filter
+        assert "*.csv" in file_filter
+        return str(Path("/tmp/does-not-matter.tsv.gz")), ""
+
+    monkeypatch.setattr(
+        "confusius._napari._signals._manager.QFileDialog.getOpenFileName",
+        _fake_get_open_file_name,
+    )
+    monkeypatch.setattr(signals_store, "import_file", lambda path: [])
+
+    dialog._import_file()

--- a/tests/unit/test_napari/test_signal_plotter.py
+++ b/tests/unit/test_napari/test_signal_plotter.py
@@ -816,6 +816,20 @@ class TestImportedSignalIntegration:
             ["1", "3"],
         ]
 
+    def test_imported_only_plot_shows_cursor_when_enabled(
+        self, plotter_with_store, store, tmp_path
+    ):
+        path = tmp_path / "imported.tsv"
+        path.write_text("time\tbaseline\n0\t1.0\n1\t2.0\n2\t3.0\n")
+        store.import_file(path)
+
+        plotter_with_store.set_show_cursor(True)
+        plotter_with_store._cursor_world = 1.5
+        plotter_with_store._refresh_plot()
+
+        assert plotter_with_store._vline is not None
+        assert plotter_with_store._vline.get_xdata()[0] == pytest.approx(1.5)
+
     def test_hidden_imported_signal_is_excluded_from_export(
         self, plotter_with_store, store, tmp_path
     ):

--- a/tests/unit/test_napari/test_signal_store.py
+++ b/tests/unit/test_napari/test_signal_store.py
@@ -52,19 +52,6 @@ def test_import_bids_physio_tsv_gz_uses_sidecar_columns_and_time(
     npt.assert_array_equal(imported[1].y, np.array([10.0, 11.0, 12.0]))
 
 
-def test_import_bids_physio_rejects_column_count_mismatch(signals_store, tmp_path):
-    path = tmp_path / "sub-01_task-rest_recording-cardiac_physio.tsv.gz"
-    with gzip.open(path, "wt") as f:
-        f.write("1\t10\n2\t11\n")
-
-    path.with_suffix("").with_suffix(".json").write_text(
-        json.dumps({"Columns": ["pulse"], "SamplingFrequency": 10.0})
-    )
-
-    with pytest.raises(ValueError, match="Columns' length does not match TSV width"):
-        signals_store.import_file(path)
-
-
 def test_import_csv_ignores_unrelated_json_sidecar(signals_store, tmp_path):
     path = tmp_path / "signals.csv"
     path.write_text("time,a\n0,1\n1,2\n")

--- a/tests/unit/test_napari/test_signal_store.py
+++ b/tests/unit/test_napari/test_signal_store.py
@@ -65,6 +65,20 @@ def test_import_bids_physio_rejects_column_count_mismatch(signals_store, tmp_pat
         signals_store.import_file(path)
 
 
+def test_import_csv_ignores_unrelated_json_sidecar(signals_store, tmp_path):
+    path = tmp_path / "signals.csv"
+    path.write_text("time,a\n0,1\n1,2\n")
+    path.with_suffix(".json").write_text(
+        json.dumps({"Columns": ["pulse"], "SamplingFrequency": 10.0})
+    )
+
+    imported = signals_store.import_file(path)
+
+    assert [signal.name for signal in imported] == ["a"]
+    npt.assert_array_equal(imported[0].x, np.array([0, 1]))
+    npt.assert_array_equal(imported[0].y, np.array([1, 2]))
+
+
 def test_import_rejects_missing_time_column(signals_store, tmp_path):
     path = tmp_path / "broken.csv"
     path.write_text("frame,a\n0,1\n1,2\n")

--- a/tests/unit/test_napari/test_signal_store.py
+++ b/tests/unit/test_napari/test_signal_store.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import gzip
+import json
+
 import numpy as np
 import numpy.testing as npt
 import pytest
@@ -21,6 +24,45 @@ def test_import_tsv_preserves_duplicate_time_values(signals_store, signals_tsv):
 
     npt.assert_array_equal(imported[0].x, np.array([0, 0, 1]))
     npt.assert_array_equal(imported[0].y, np.array([1.0, 2.0, 3.0]))
+
+
+def test_import_bids_physio_tsv_gz_uses_sidecar_columns_and_time(
+    signals_store, tmp_path
+):
+    path = tmp_path / "sub-01_task-rest_recording-cardiac_physio.tsv.gz"
+    with gzip.open(path, "wt") as f:
+        f.write("1\t10\n2\t11\n3\t12\n")
+
+    sidecar = path.with_suffix("").with_suffix(".json")
+    sidecar.write_text(
+        json.dumps(
+            {
+                "Columns": ["pulse", "resp"],
+                "SamplingFrequency": 2.0,
+                "StartTime": -0.5,
+            }
+        )
+    )
+
+    imported = signals_store.import_file(path)
+
+    assert [signal.name for signal in imported] == ["pulse", "resp"]
+    npt.assert_allclose(imported[0].x, np.array([-0.5, 0.0, 0.5]))
+    npt.assert_array_equal(imported[0].y, np.array([1.0, 2.0, 3.0]))
+    npt.assert_array_equal(imported[1].y, np.array([10.0, 11.0, 12.0]))
+
+
+def test_import_bids_physio_rejects_column_count_mismatch(signals_store, tmp_path):
+    path = tmp_path / "sub-01_task-rest_recording-cardiac_physio.tsv.gz"
+    with gzip.open(path, "wt") as f:
+        f.write("1\t10\n2\t11\n")
+
+    path.with_suffix("").with_suffix(".json").write_text(
+        json.dumps({"Columns": ["pulse"], "SamplingFrequency": 10.0})
+    )
+
+    with pytest.raises(ValueError, match="Columns' length does not match TSV width"):
+        signals_store.import_file(path)
 
 
 def test_import_rejects_missing_time_column(signals_store, tmp_path):


### PR DESCRIPTION
Closes #293.

Adds BIDS physio `*.tsv.gz` import support to the napari signal store by reading `Columns`, `SamplingFrequency`, and optional `StartTime` from the JSON sidecar.

Renamed `read_`/`write_` functions in BIDS `events.py` to `load_`/`save_` to match other I/O functions in ConfUSIus.