### PR TITLE
fix(plotting): accept scalar slice dimension

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,12 @@ icon: lucide/history
 
 Current development version for the next ConfUSIus release.
 
+### :bug: Fixes
+
+- Plotting functions now accept a slice dimension reduced to a scalar coordinate by a
+  single-index selection, so `plot_contours(atlas.annotation.sel(z=6))` works like
+  `sel(z=[6])` ([#296](https://github.com/confusius-tools/confusius/pull/296)).
+
 ## 0.5.2
 
 Released 2026-07-10.

--- a/src/confusius/plotting/image.py
+++ b/src/confusius/plotting/image.py
@@ -362,6 +362,28 @@ def _format_coord(coord: Hashable) -> str:
     return str(coord)
 
 
+def _is_scalar_coord(data: xr.DataArray, name: Hashable) -> bool:
+    """Whether `name` is a scalar (0-dimensional) coordinate of `data`.
+
+    This is the state left after selecting a single index along a dimension
+    (e.g. `data.sel(z=6)`): the dimension is dropped and its coordinate becomes
+    scalar, so it can be promoted back to a size-1 dimension with `expand_dims`.
+
+    Parameters
+    ----------
+    data : xarray.DataArray
+        The DataArray whose coordinates are inspected.
+    name : hashable
+        The candidate coordinate name.
+
+    Returns
+    -------
+    bool
+        Whether `name` is a coordinate of `data` with zero dimensions.
+    """
+    return name in data.coords and data.coords[name].ndim == 0
+
+
 def _coords_match(
     stored_coord: Hashable, target_coord: Hashable, tolerance: float
 ) -> bool:
@@ -649,6 +671,10 @@ class VolumePlotter:
     def _prepare_slice_inputs(self, data: xr.DataArray, *, caller: str) -> xr.DataArray:
         """Coerce complex, squeeze, validate `slice_mode`/3D, and sort display coords."""
         data = coerce_complex_to_magnitude(data, caller=caller)
+        # A single-index selection (e.g. data.sel(z=6)) drops slice_mode to a scalar
+        # coordinate; promote it back to a size-1 dimension so it plots like data.sel(z=[6]).
+        if self.slice_mode not in data.dims and _is_scalar_coord(data, self.slice_mode):
+            data = data.expand_dims(self.slice_mode)
         squeeze_dims = [
             d for d in data.dims if d != self.slice_mode and data.sizes[d] == 1
         ]
@@ -1490,6 +1516,11 @@ class VolumePlotter:
                     **kwargs,
                 )
             return self
+
+        # A single-index selection (e.g. mask.sel(z=6)) drops slice_mode to a scalar
+        # coordinate; promote it back to a size-1 dimension so it plots like mask.sel(z=[6]).
+        if self.slice_mode not in mask.dims and _is_scalar_coord(mask, self.slice_mode):
+            mask = mask.expand_dims(self.slice_mode)
 
         squeeze_dims = [
             d for d in mask.dims if d != self.slice_mode and mask.sizes[d] == 1

--- a/tests/unit/test_plotting/test_image.py
+++ b/tests/unit/test_plotting/test_image.py
@@ -416,6 +416,20 @@ class TestPlotVolume:
         # Verify the slice was plotted
         assert len(_axes(plotter)[0, 0].collections) == 1
 
+    def test_scalar_slice_mode_from_selection(
+        self, sample_3d_volume, matplotlib_pyplot
+    ):
+        """plot_volume accepts a scalar slice_mode coordinate (issue #295).
+
+        Selecting a single index (isel(z=1)) drops z to a scalar coordinate; it
+        should plot like the size-1 z dimension from isel(z=[1]).
+        """
+        plotter = plot_volume(
+            sample_3d_volume.isel(z=1), slice_mode="z", show_colorbar=False
+        )
+        assert _axes(plotter).shape == (1, 1)
+        assert len(_axes(plotter)[0, 0].collections) == 1
+
     def test_non_monotonic_coords_are_sorted_before_plotting(
         self, sample_3d_volume, matplotlib_pyplot
     ):
@@ -783,6 +797,20 @@ class TestPlotContours:
         assert ax.xaxis.label.get_fontsize() == pytest.approx(14.4)
         assert ax.yaxis.label.get_fontsize() == pytest.approx(14.4)
         assert ax.get_xticklabels()[0].get_fontsize() == pytest.approx(13.6)
+
+    def test_scalar_slice_mode_from_selection(self, matplotlib_pyplot):
+        """plot_contours accepts a scalar slice_mode coordinate (issue #295).
+
+        Selecting a single index (sel(z=0.0)) drops z to a scalar coordinate; it
+        should plot like the size-1 z dimension it was selected from.
+        """
+        mask = xr.DataArray(
+            np.array([[[0, 0, 0, 0], [0, 1, 1, 0], [0, 1, 1, 0], [0, 0, 0, 0]]]),
+            dims=["z", "y", "x"],
+            coords={"z": [0.0], "y": [0.0, 0.5, 1.0, 1.5], "x": [0.0, 0.5, 1.0, 1.5]},
+        )
+        plotter = plot_contours(mask.sel(z=0.0), slice_mode="z")
+        assert _axes(plotter).shape == (1, 1)
 
 
 class TestVolumePlotterAddContours:


### PR DESCRIPTION
- Closes #295.

## Description

A scalar slice_mode coordinate is now promoted back to a size-1 dimension via expand_dims, so sel(z=6) plots identically to sel(z=[6]). This is applied at the two normalization sites: _prepare_slice_inputs (covers plot_volume/plot_image and plot_comparison) and the mask path in add_contours (covers plot_contours), via a shared _is_scalar_coord helper.

Invalid slice modes are unaffected: slice_mode="t" on data with no t coordinate still raises, because promotion only triggers when the name exists as a 0-dimensional coordinate.
