### PR TITLE
fix: clarify SCAN v2 load error

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,9 @@ Current development version for the next ConfUSIus release.
 
 ### :bug: Fixes
 
+- Opening a `.scan` file that is not the legacy HDF5-based Iconeus format now raises a
+  clear error that points users to newer SCAN v2 files and to converting them to NIfTI
+  with Iconeus tools first ([#297](https://github.com/confusius-tools/confusius/pull/297)).
 - Plotting functions now accept a slice dimension reduced to a scalar coordinate by a
   single-index selection, so `plot_contours(atlas.annotation.sel(z=6))` works like
   `sel(z=[6])` ([#296](https://github.com/confusius-tools/confusius/pull/296)).

--- a/src/confusius/io/scan.py
+++ b/src/confusius/io/scan.py
@@ -288,8 +288,9 @@ def load_scan(
     Raises
     ------
     ValueError
-        If `path` does not exist or is not a file, or if the `acquisitionMode` stored in
-        the file is not one of `"2Dscan"`, `"3Dscan"`, or `"4Dscan"`.
+        If `path` does not exist or is not a file, if the file is not an HDF5-based
+        SCAN file supported by ConfUSIus, or if the `acquisitionMode` stored in the
+        file is not one of `"2Dscan"`, `"3Dscan"`, or `"4Dscan"`.
 
     Notes
     -----
@@ -310,6 +311,13 @@ def load_scan(
     `iconeus_project`, `iconeus_date`).
     """
     path = check_path(path, type="file")
+
+    if not h5py.is_hdf5(path):
+        raise ValueError(
+            f"{path.name!r} is not an HDF5-based SCAN file supported by ConfUSIus. "
+            "It may be an Iconeus SCAN v2 file; convert it to NIfTI with Iconeus "
+            "tools first."
+        )
 
     h5 = h5py.File(path, "r")
 

--- a/tests/unit/test_io/test_scan.py
+++ b/tests/unit/test_io/test_scan.py
@@ -522,6 +522,17 @@ class TestLoadScanErrors:
         with pytest.raises(ValueError, match="Unknown acquisitionMode"):
             load_scan(path)
 
+    def test_non_hdf5_scan_raises_useful_error(self, tmp_path: Path) -> None:
+        """load_scan points users to SCAN v2 conversion for non-HDF5 `.scan` files."""
+        path = tmp_path / "scan_v2.scan"
+        path.write_bytes(b"not an hdf5 file")
+
+        with pytest.raises(
+            ValueError,
+            match="HDF5-based SCAN file supported by ConfUSIus|SCAN v2|NIfTI",
+        ):
+            load_scan(path)
+
 
 # ---------------------------------------------------------------------------
 # Tests: physical_to_lab correctness


### PR DESCRIPTION
Closes #297.

Adds a clear error for non-HDF5 \.scan files and points users to Iconeus conversion to NIfTI.