### PR TITLE
fix(registration): relabel motion params by dim

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,7 +12,12 @@ Current development version for the next ConfUSIus release.
 
 ### :bug: Fixes
 
-- Motion parameter tables from [`create_motion_dataframe`][confusius.registration.create_motion_dataframe] now label rotations and translations by the DataArray's named `x`/`y`/`z` axes even when the underlying spatial dims are stored in a different order such as `(z, y, x)` ([#301](https://github.com/confusius-tools/confusius/pull/301)).
+- Motion parameter tables from
+  [`create_motion_dataframe`][confusius.registration.create_motion_dataframe] now label
+  rotations and translations by the coordinate names `x`/`y`/`z` instead of by raw
+  transform-component order, so canonical ConfUSIus arrays stored as `(z, y, x)` no
+  longer mislabel in-plane motion
+  ([#301](https://github.com/confusius-tools/confusius/pull/301)).
 - Opening a `.scan` file that is not the legacy HDF5-based Iconeus format now raises a
   clear error that points users to newer SCAN v2 files and to converting them to NIfTI
   with Iconeus tools first ([#297](https://github.com/confusius-tools/confusius/pull/297)).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,7 @@ Current development version for the next ConfUSIus release.
 
 ### :bug: Fixes
 
+- Motion parameter tables from [`create_motion_dataframe`][confusius.registration.create_motion_dataframe] now label rotations and translations by the DataArray's named `x`/`y`/`z` axes even when the underlying spatial dims are stored in a different order such as `(z, y, x)` ([#301](https://github.com/confusius-tools/confusius/pull/301)).
 - Opening a `.scan` file that is not the legacy HDF5-based Iconeus format now raises a
   clear error that points users to newer SCAN v2 files and to converting them to NIfTI
   with Iconeus tools first ([#297](https://github.com/confusius-tools/confusius/pull/297)).

--- a/src/confusius/registration/motion.py
+++ b/src/confusius/registration/motion.py
@@ -294,18 +294,24 @@ def create_motion_dataframe(
         For 2D:
 
         - `rotation`: Rotation angle in radians.
-        - `trans_x`: Translation in x (mm).
-        - `trans_y`: Translation in y (mm).
+        - `trans_x`: Translation along the DataArray's `x` axis (mm).
+        - `trans_y`: Translation along the DataArray's `y` axis (mm).
 
         For 3D:
 
-        - `rot_x, rot_y, rot_z`: Rotation angles in radians.
-        - `trans_x, trans_y, trans_z`: Translations (mm).
+        - `rot_x, rot_y, rot_z`: Rotation angles around the DataArray's
+          `x`, `y`, and `z` axes, in radians.
+        - `trans_x, trans_y, trans_z`: Translations along the DataArray's
+          `x`, `y`, and `z` axes (mm).
 
         Both:
         - `mean_fd`: Mean framewise displacement (mm).
         - `max_fd`: Maximum framewise displacement (mm).
         - `rms_fd`: RMS framewise displacement (mm).
+
+        Motion columns are reported in named-axis order (`x`, `y`, `z`), even when
+        the input DataArray stores its spatial dimensions in a different order such as
+        `(z, y, x)`.
     """
     import pandas as pd
 
@@ -313,26 +319,30 @@ def create_motion_dataframe(
 
     fd_dict = compute_framewise_displacement(affines, reference, mask)
 
+    spatial_dims = tuple(str(dim) for dim in reference.dims)
+
     if params.shape[1] == 3:
+        axis_index = {dim: i for i, dim in enumerate(spatial_dims)}
         df = pd.DataFrame(
             {
                 "rotation": params[:, 0],
-                "trans_x": params[:, 1],
-                "trans_y": params[:, 2],
+                "trans_x": params[:, 1 + axis_index["x"]],
+                "trans_y": params[:, 1 + axis_index["y"]],
                 "mean_fd": fd_dict["mean_fd"],
                 "max_fd": fd_dict["max_fd"],
                 "rms_fd": fd_dict["rms_fd"],
             }
         )
     else:
+        axis_index = {dim: i for i, dim in enumerate(spatial_dims)}
         df = pd.DataFrame(
             {
-                "rot_x": params[:, 0],
-                "rot_y": params[:, 1],
-                "rot_z": params[:, 2],
-                "trans_x": params[:, 3],
-                "trans_y": params[:, 4],
-                "trans_z": params[:, 5],
+                "rot_x": params[:, axis_index["x"]],
+                "rot_y": params[:, axis_index["y"]],
+                "rot_z": params[:, axis_index["z"]],
+                "trans_x": params[:, 3 + axis_index["x"]],
+                "trans_y": params[:, 3 + axis_index["y"]],
+                "trans_z": params[:, 3 + axis_index["z"]],
                 "mean_fd": fd_dict["mean_fd"],
                 "max_fd": fd_dict["max_fd"],
                 "rms_fd": fd_dict["rms_fd"],

--- a/tests/unit/test_registration/test_motion.py
+++ b/tests/unit/test_registration/test_motion.py
@@ -10,28 +10,20 @@ from confusius.registration.motion import (
 )
 
 
-def _make_ref_da(size, spacing=1.0, ndim=2):
+def _make_ref_da(size, spacing=1.0, ndim=2, dims=None):
     """Create a spatial DataArray for FD reference."""
     import xarray as xr
 
     if ndim == 2:
-        return xr.DataArray(
-            np.zeros(size),
-            dims=("y", "x"),
-            coords={
-                "y": np.arange(size[0]) * spacing,
-                "x": np.arange(size[1]) * spacing,
-            },
-        )
-    return xr.DataArray(
-        np.zeros(size),
-        dims=("z", "y", "x"),
-        coords={
-            "z": np.arange(size[0]) * spacing,
-            "y": np.arange(size[1]) * spacing,
-            "x": np.arange(size[2]) * spacing,
-        },
-    )
+        if dims is None:
+            dims = ("y", "x")
+        coords = {dim: np.arange(size[i]) * spacing for i, dim in enumerate(dims)}
+        return xr.DataArray(np.zeros(size), dims=dims, coords=coords)
+
+    if dims is None:
+        dims = ("z", "y", "x")
+    coords = {dim: np.arange(size[i]) * spacing for i, dim in enumerate(dims)}
+    return xr.DataArray(np.zeros(size), dims=dims, coords=coords)
 
 
 def _translation_affine_2d(tx, ty):
@@ -45,9 +37,22 @@ def _translation_affine_2d(tx, ty):
 def _translation_affine_3d(tx, ty, tz):
     """Return a (4, 4) 3D translation affine."""
     A = np.eye(4)
-    A[0, 2] = tx
-    A[1, 2] = ty
-    A[2, 2] = tz
+    A[:3, 3] = [tx, ty, tz]
+    return A
+
+
+def _rotation_affine_3d_first_axis(angle):
+    """Return a (4, 4) 3D rotation affine around the first axis."""
+    A = np.eye(4)
+    c = np.cos(angle)
+    s = np.sin(angle)
+    A[:3, :3] = np.array(
+        [
+            [1.0, 0.0, 0.0],
+            [0.0, c, -s],
+            [0.0, s, c],
+        ]
+    )
     return A
 
 
@@ -202,6 +207,37 @@ class TestCreateMotionDataframe:
         ]
         assert list(df.columns) == expected_cols
 
+    def test_2d_dataframe_reorders_translations_to_named_axes(self):
+        """2D translations follow x/y names, not raw axis order."""
+        ref = _make_ref_da((10, 10), spacing=1.0, dims=("y", "x"))
+        df = create_motion_dataframe([np.eye(3), _translation_affine_2d(2.0, 3.0)], ref)
+
+        assert_allclose(df.iloc[1]["trans_x"], 3.0, atol=1e-6)
+        assert_allclose(df.iloc[1]["trans_y"], 2.0, atol=1e-6)
+
+    def test_3d_dataframe_reorders_translations_to_named_axes(self):
+        """3D translations follow x/y/z names, not raw axis order."""
+        ref = _make_ref_da((8, 8, 8), spacing=1.0, ndim=3, dims=("z", "y", "x"))
+        df = create_motion_dataframe(
+            [np.eye(4), _translation_affine_3d(1.0, 2.0, 3.0)], ref
+        )
+
+        assert_allclose(df.iloc[1]["trans_x"], 3.0, atol=1e-6)
+        assert_allclose(df.iloc[1]["trans_y"], 2.0, atol=1e-6)
+        assert_allclose(df.iloc[1]["trans_z"], 1.0, atol=1e-6)
+
+    def test_3d_dataframe_reorders_rotations_to_named_axes(self):
+        """3D rotations follow x/y/z names, not raw axis order."""
+        ref = _make_ref_da((8, 8, 8), spacing=1.0, ndim=3, dims=("z", "y", "x"))
+        angle = 0.1
+        df = create_motion_dataframe(
+            [np.eye(4), _rotation_affine_3d_first_axis(angle)], ref
+        )
+
+        assert_allclose(df.iloc[1]["rot_x"], 0.0, atol=1e-6)
+        assert_allclose(df.iloc[1]["rot_y"], 0.0, atol=1e-6)
+        assert_allclose(df.iloc[1]["rot_z"], angle, atol=1e-6)
+
     def test_time_coords_as_index(self):
         """Time coordinates are used as DataFrame index."""
         ref = _make_ref_da((10, 10), spacing=1.0)
@@ -220,7 +256,7 @@ class TestCreateMotionDataframe:
 
     def test_motion_values_correct(self):
         """Motion parameter values are correctly populated."""
-        ref = _make_ref_da((10, 10), spacing=1.0)
+        ref = _make_ref_da((10, 10), spacing=1.0, dims=("x", "y"))
         affines = [np.eye(3), _translation_affine_2d(2.0, 3.0)]
         df = create_motion_dataframe(affines, ref)
 

--- a/tests/unit/test_registration/test_motion.py
+++ b/tests/unit/test_registration/test_motion.py
@@ -10,20 +10,9 @@ from confusius.registration.motion import (
 )
 
 
-def _make_ref_da(size, spacing=1.0, ndim=2, dims=None):
-    """Create a spatial DataArray for FD reference."""
-    import xarray as xr
-
-    if ndim == 2:
-        if dims is None:
-            dims = ("y", "x")
-        coords = {dim: np.arange(size[i]) * spacing for i, dim in enumerate(dims)}
-        return xr.DataArray(np.zeros(size), dims=dims, coords=coords)
-
-    if dims is None:
-        dims = ("z", "y", "x")
-    coords = {dim: np.arange(size[i]) * spacing for i, dim in enumerate(dims)}
-    return xr.DataArray(np.zeros(size), dims=dims, coords=coords)
+def _with_spatial_dims(reference, dims):
+    """Return `reference` with reordered spatial dim names and matching coords."""
+    return reference.rename(dict(zip(reference.dims, dims, strict=True))).transpose(*dims)
 
 
 def _translation_affine_2d(tx, ty):
@@ -110,22 +99,20 @@ class TestExtractMotionParameters:
 class TestComputeFramewiseDisplacement:
     """Tests for compute_framewise_displacement function."""
 
-    def test_identical_transforms_zero_fd(self):
+    def test_identical_transforms_zero_fd(self, sample_2d_dataarray_spatial):
         """Identical affines produce zero framewise displacement."""
-        ref = _make_ref_da((10, 10), spacing=1.0)
         affines = [np.eye(3), np.eye(3)]
-        fd = compute_framewise_displacement(affines, ref)
+        fd = compute_framewise_displacement(affines, sample_2d_dataarray_spatial)
 
         assert_allclose(fd["mean_fd"], [0.0, 0.0])
         assert_allclose(fd["max_fd"], [0.0, 0.0])
         assert_allclose(fd["rms_fd"], [0.0, 0.0])
 
-    def test_known_translation_displacement_2d(self):
+    def test_known_translation_displacement_2d(self, sample_2d_dataarray_spatial):
         """Known 2D translation produces correct FD (Euclidean distance)."""
-        ref = _make_ref_da((10, 10), spacing=1.0)
         t1 = np.eye(3)
         t2 = _translation_affine_2d(3.0, 4.0)  # distance = 5.0
-        fd = compute_framewise_displacement([t1, t2], ref)
+        fd = compute_framewise_displacement([t1, t2], sample_2d_dataarray_spatial)
 
         # Pure translation: all voxels displace equally.
         assert_allclose(fd["mean_fd"][0], 5.0, atol=1e-6)
@@ -133,35 +120,32 @@ class TestComputeFramewiseDisplacement:
         assert_allclose(fd["rms_fd"][0], 5.0, atol=1e-6)
         assert fd["mean_fd"][-1] == 0.0
 
-    def test_known_translation_displacement_3d(self):
+    def test_known_translation_displacement_3d(self, sample_3d_dataarray_spatial):
         """Known 3D translation produces correct FD."""
-        ref = _make_ref_da((8, 8, 8), spacing=1.0, ndim=3)
         t1 = np.eye(4)
         t2 = np.eye(4)
         t2[:3, 3] = [1.0, 2.0, 2.0]  # distance = 3.0
-        fd = compute_framewise_displacement([t1, t2], ref)
+        fd = compute_framewise_displacement([t1, t2], sample_3d_dataarray_spatial)
 
         assert_allclose(fd["mean_fd"][0], 3.0, atol=1e-6)
         assert_allclose(fd["max_fd"][0], 3.0, atol=1e-6)
 
-    def test_with_mask(self):
+    def test_with_mask(self, sample_2d_dataarray_spatial):
         """Mask restricts FD computation to masked voxels."""
-        ref = _make_ref_da((10, 10), spacing=1.0)
         t1 = np.eye(3)
         t2 = _translation_affine_2d(3.0, 4.0)  # distance = 5.0
-        mask = np.zeros((10, 10), dtype=bool)
+        mask = np.zeros(sample_2d_dataarray_spatial.shape, dtype=bool)
         mask[2:8, 2:8] = True
-        fd = compute_framewise_displacement([t1, t2], ref, mask=mask)
+        fd = compute_framewise_displacement([t1, t2], sample_2d_dataarray_spatial, mask=mask)
 
         # Pure translation: same displacement regardless of mask.
         assert_allclose(fd["mean_fd"][0], 5.0, atol=1e-6)
 
-    def test_none_affine_treated_as_identity(self):
+    def test_none_affine_treated_as_identity(self, sample_2d_dataarray_spatial):
         """None affine treated as identity: displacement equals the other transform."""
-        ref = _make_ref_da((10, 10), spacing=1.0)
         t1 = None  # identity
         t2 = _translation_affine_2d(3.0, 4.0)  # distance = 5.0
-        fd = compute_framewise_displacement([t1, t2], ref)
+        fd = compute_framewise_displacement([t1, t2], sample_2d_dataarray_spatial)
 
         assert_allclose(fd["mean_fd"][0], 5.0, atol=1e-6)
 
@@ -169,11 +153,10 @@ class TestComputeFramewiseDisplacement:
 class TestCreateMotionDataframe:
     """Tests for create_motion_dataframe function."""
 
-    def test_2d_dataframe_columns(self):
+    def test_2d_dataframe_columns(self, sample_2d_dataarray_spatial):
         """2D affines produce DataFrame with correct columns."""
-        ref = _make_ref_da((10, 10), spacing=1.0)
         affines = [np.eye(3), _translation_affine_2d(2.0, 3.0)]
-        df = create_motion_dataframe(affines, ref)
+        df = create_motion_dataframe(affines, sample_2d_dataarray_spatial)
 
         expected_cols = [
             "rotation",
@@ -186,13 +169,12 @@ class TestCreateMotionDataframe:
         assert list(df.columns) == expected_cols
         assert len(df) == 2
 
-    def test_3d_dataframe_columns(self):
+    def test_3d_dataframe_columns(self, sample_3d_dataarray_spatial):
         """3D affines produce DataFrame with correct columns."""
-        ref = _make_ref_da((8, 8, 8), spacing=1.0, ndim=3)
         t1 = np.eye(4)
         t2 = np.eye(4)
         t2[:3, 3] = [1.0, 2.0, 3.0]
-        df = create_motion_dataframe([t1, t2], ref)
+        df = create_motion_dataframe([t1, t2], sample_3d_dataarray_spatial)
 
         expected_cols = [
             "rot_x",
@@ -207,17 +189,21 @@ class TestCreateMotionDataframe:
         ]
         assert list(df.columns) == expected_cols
 
-    def test_2d_dataframe_reorders_translations_to_named_axes(self):
+    def test_2d_dataframe_reorders_translations_to_named_axes(
+        self, sample_2d_dataarray_spatial
+    ):
         """2D translations follow x/y names, not raw axis order."""
-        ref = _make_ref_da((10, 10), spacing=1.0, dims=("y", "x"))
+        ref = _with_spatial_dims(sample_2d_dataarray_spatial, ("y", "x"))
         df = create_motion_dataframe([np.eye(3), _translation_affine_2d(2.0, 3.0)], ref)
 
         assert_allclose(df.iloc[1]["trans_x"], 3.0, atol=1e-6)
         assert_allclose(df.iloc[1]["trans_y"], 2.0, atol=1e-6)
 
-    def test_3d_dataframe_reorders_translations_to_named_axes(self):
+    def test_3d_dataframe_reorders_translations_to_named_axes(
+        self, sample_3d_dataarray_spatial
+    ):
         """3D translations follow x/y/z names, not raw axis order."""
-        ref = _make_ref_da((8, 8, 8), spacing=1.0, ndim=3, dims=("z", "y", "x"))
+        ref = _with_spatial_dims(sample_3d_dataarray_spatial, ("z", "y", "x"))
         df = create_motion_dataframe(
             [np.eye(4), _translation_affine_3d(1.0, 2.0, 3.0)], ref
         )
@@ -226,9 +212,11 @@ class TestCreateMotionDataframe:
         assert_allclose(df.iloc[1]["trans_y"], 2.0, atol=1e-6)
         assert_allclose(df.iloc[1]["trans_z"], 1.0, atol=1e-6)
 
-    def test_3d_dataframe_reorders_rotations_to_named_axes(self):
+    def test_3d_dataframe_reorders_rotations_to_named_axes(
+        self, sample_3d_dataarray_spatial
+    ):
         """3D rotations follow x/y/z names, not raw axis order."""
-        ref = _make_ref_da((8, 8, 8), spacing=1.0, ndim=3, dims=("z", "y", "x"))
+        ref = _with_spatial_dims(sample_3d_dataarray_spatial, ("z", "y", "x"))
         angle = 0.1
         df = create_motion_dataframe(
             [np.eye(4), _rotation_affine_3d_first_axis(angle)], ref
@@ -238,25 +226,25 @@ class TestCreateMotionDataframe:
         assert_allclose(df.iloc[1]["rot_y"], 0.0, atol=1e-6)
         assert_allclose(df.iloc[1]["rot_z"], angle, atol=1e-6)
 
-    def test_time_coords_as_index(self):
+    def test_time_coords_as_index(self, sample_2d_dataarray_spatial):
         """Time coordinates are used as DataFrame index."""
-        ref = _make_ref_da((10, 10), spacing=1.0)
         affines = [np.eye(3), np.eye(3)]
         time_coords = np.array([0.0, 0.5])
-        df = create_motion_dataframe(affines, ref, time_coords=time_coords)
+        df = create_motion_dataframe(
+            affines, sample_2d_dataarray_spatial, time_coords=time_coords
+        )
 
         assert df.index.name == "time"
         assert_array_equal(df.index, time_coords)
 
-    def test_no_time_coords_uses_frame_index(self):
+    def test_no_time_coords_uses_frame_index(self, sample_2d_dataarray_spatial):
         """Without time coords, index is named 'frame'."""
-        ref = _make_ref_da((10, 10), spacing=1.0)
-        df = create_motion_dataframe([np.eye(3)], ref)
+        df = create_motion_dataframe([np.eye(3)], sample_2d_dataarray_spatial)
         assert df.index.name == "frame"
 
-    def test_motion_values_correct(self):
+    def test_motion_values_correct(self, sample_2d_dataarray_spatial):
         """Motion parameter values are correctly populated."""
-        ref = _make_ref_da((10, 10), spacing=1.0, dims=("x", "y"))
+        ref = _with_spatial_dims(sample_2d_dataarray_spatial, ("x", "y"))
         affines = [np.eye(3), _translation_affine_2d(2.0, 3.0)]
         df = create_motion_dataframe(affines, ref)
 


### PR DESCRIPTION
Fixes #300.

Maps `rot_*` and `trans_*` columns onto the DataArray's named spatial axes instead of raw transform-component order.