### PR TITLE
docs(docs): add motion correction example

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,17 +13,17 @@ Current development version for the next ConfUSIus release.
 ### :boom: Breaking changes
 
 - Motion diagnostics helpers now require actual affine matrices: [`extract_motion_parameters`][confusius.registration.extract_motion_parameters], [`compute_framewise_displacement`][confusius.registration.compute_framewise_displacement], and [`create_motion_dataframe`][confusius.registration.create_motion_dataframe] no longer accept `None` placeholders in their affine lists ([#302](https://github.com/confusius-tools/confusius/pull/302)).
-
-### :sparkles: Enhancements
-
-- Added [`plot_motion_diagnostics`][confusius.plotting.plot_motion_diagnostics] to visualize motion-correction summaries from `motion_params` tables returned by [`register_volumewise`][confusius.registration.register_volumewise] ([#302](https://github.com/confusius-tools/confusius/pull/302)).
-- [`create_motion_dataframe`][confusius.registration.create_motion_dataframe] now always reports all named rotation / translation axes exposed by the affine dimensionality, even when one spatial axis is singleton ([#302](https://github.com/confusius-tools/confusius/pull/302)).
 - Renamed the public BIDS table I/O helpers to match the rest of ConfUSIus:
   [`read_events`][confusius.bids.load_events] →
   [`load_events`][confusius.bids.load_events], and
   [`write_events`][confusius.bids.save_events] →
   [`save_events`][confusius.bids.save_events]
   ([#294](https://github.com/confusius-tools/confusius/pull/294)).
+
+### :sparkles: Enhancements
+
+- Added [`plot_motion_diagnostics`][confusius.plotting.plot_motion_diagnostics] to visualize motion-correction summaries from `motion_params` tables returned by [`register_volumewise`][confusius.registration.register_volumewise] ([#302](https://github.com/confusius-tools/confusius/pull/302)).
+- [`create_motion_dataframe`][confusius.registration.create_motion_dataframe] now always reports all named rotation / translation axes exposed by the affine dimensionality, even when one spatial axis is singleton ([#302](https://github.com/confusius-tools/confusius/pull/302)).
 - Added [`load_physio`][confusius.bids.load_physio] to load BIDS physio TSV files with
   column names and metadata from the JSON sidecar, synthesizing a `time` column when
   needed; the napari plugin now uses it for imported signal tables

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,7 +12,12 @@ Current development version for the next ConfUSIus release.
 
 ### :bug: Fixes
 
-- Motion parameter tables from [`create_motion_dataframe`][confusius.registration.create_motion_dataframe] now label rotations and translations by the DataArray's named `x`/`y`/`z` axes even when the underlying spatial dims are stored in a different order such as `(z, y, x)` ([#301](https://github.com/confusius-tools/confusius/pull/301)).
+- Motion parameter tables from
+  [`create_motion_dataframe`][confusius.registration.create_motion_dataframe] now label
+  rotations and translations by the coordinate names `x`/`y`/`z` instead of by raw
+  transform-component order, so canonical ConfUSIus arrays stored as `(z, y, x)` no
+  longer mislabel in-plane motion
+  ([#301](https://github.com/confusius-tools/confusius/pull/301)).
 - Opening a `.scan` file that is not the legacy HDF5-based Iconeus format now raises a
   clear error that points users to newer SCAN v2 files and to converting them to NIfTI
   with Iconeus tools first ([#297](https://github.com/confusius-tools/confusius/pull/297)).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,7 @@ Current development version for the next ConfUSIus release.
 
 ### :bug: Fixes
 
+- Motion parameter tables from [`create_motion_dataframe`][confusius.registration.create_motion_dataframe] now label rotations and translations by the DataArray's named `x`/`y`/`z` axes even when the underlying spatial dims are stored in a different order such as `(z, y, x)` ([#301](https://github.com/confusius-tools/confusius/pull/301)).
 - Opening a `.scan` file that is not the legacy HDF5-based Iconeus format now raises a
   clear error that points users to newer SCAN v2 files and to converting them to NIfTI
   with Iconeus tools first ([#297](https://github.com/confusius-tools/confusius/pull/297)).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,7 +17,7 @@ Current development version for the next ConfUSIus release.
 ### :sparkles: Enhancements
 
 - Added [`plot_motion_diagnostics`][confusius.plotting.plot_motion_diagnostics] to visualize motion-correction summaries from `motion_params` tables returned by [`register_volumewise`][confusius.registration.register_volumewise] ([#302](https://github.com/confusius-tools/confusius/pull/302)).
-- [`create_motion_dataframe`][confusius.registration.create_motion_dataframe] now treats any singleton spatial axis as effective 2D motion and returns only the relevant in-plane rotation / translation columns ([#302](https://github.com/confusius-tools/confusius/pull/302)).
+- [`create_motion_dataframe`][confusius.registration.create_motion_dataframe] now always reports all named rotation / translation axes exposed by the affine dimensionality, even when one spatial axis is singleton ([#302](https://github.com/confusius-tools/confusius/pull/302)).
 
 ### :bug: Fixes
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,10 @@ icon: lucide/history
 
 Current development version for the next ConfUSIus release.
 
+### :sparkles: Enhancements
+
+- Added [`plot_motion_diagnostics`][confusius.plotting.plot_motion_diagnostics] to visualize motion-correction summaries from `motion_params` tables returned by [`register_volumewise`][confusius.registration.register_volumewise] ([#302](https://github.com/confusius-tools/confusius/pull/302)).
+
 ### :bug: Fixes
 
 - Motion parameter tables from

--- a/docs/examples/02_registration/02_volumewise_motion_correction.py
+++ b/docs/examples/02_registration/02_volumewise_motion_correction.py
@@ -32,7 +32,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 import xarray as xr
 from IPython.display import HTML
-from PIL import Image, ImageDraw
+from matplotlib import font_manager
+from PIL import Image, ImageDraw, ImageFont
 
 import confusius as cf
 
@@ -52,6 +53,7 @@ bids_root = cf.datasets.fetch_cybis_pereira_2026(
     acqs=acq,
 )
 
+# %%
 pwd_path = (
     Path(bids_root)
     / f"sub-{subject}"
@@ -98,7 +100,7 @@ motion_df.head()
 # panel is a useful sanity check: frames that systematically hit the maximum iteration
 # count or converge to a much worse similarity metric deserve a closer look.
 
-# %%
+# %% tags=["thumbnail"]
 fig, axes = plt.subplots(4, 1, figsize=(9, 9), sharex=True, constrained_layout=True)
 fig.patch.set_facecolor(bg_color)
 
@@ -147,7 +149,7 @@ ax_iterations.spines["right"].set_color(iteration_color)
 # deviation in the unregistered excerpt. In practice that usually lands on a large
 # vessel, where motion-induced intensity changes are most visible.
 
-# %% tags=["thumbnail"]
+# %%
 std_map = data.squeeze("z", drop=True).std("time")
 voxel_y, voxel_x = np.unravel_index(np.nanargmax(std_map.values), std_map.shape)
 
@@ -163,10 +165,6 @@ ax.set_ylabel("Power Doppler intensity")
 ax.set_title(f"Voxel at y={voxel_y}, x={voxel_x}")
 _ = ax.legend(frameon=False)
 
-# %%
-data_db = data.fusi.scale.db()
-registered_db = registered.fusi.scale.db()
-
 # %% [markdown]
 # ## Build a before/after GIF
 #
@@ -175,31 +173,7 @@ registered_db = registered.fusi.scale.db()
 
 
 # %%
-def _to_uint8_frame(values: np.ndarray, vmin: float, vmax: float) -> np.ndarray:
-    """Convert one 2D image to a clipped 8-bit grayscale frame.
-
-    Parameters
-    ----------
-    values : numpy.ndarray
-        Two-dimensional image data.
-    vmin : float
-        Lower display bound.
-    vmax : float
-        Upper display bound.
-
-    Returns
-    -------
-    numpy.ndarray
-        Unsigned 8-bit image with shape `(y, x)`.
-    """
-    if vmax <= vmin:
-        vmax = vmin + 1.0
-    clipped = np.clip((values - vmin) / (vmax - vmin), 0, 1)
-    return (255 * clipped).astype(np.uint8)
-
-
-# %%
-def _movie_html(before: xr.DataArray, after: xr.DataArray) -> HTML:
+def _gif_html(before: xr.DataArray, after: xr.DataArray) -> HTML:
     """Return an inline HTML `<img>` tag for a side-by-side animated GIF.
 
     Parameters
@@ -214,28 +188,48 @@ def _movie_html(before: xr.DataArray, after: xr.DataArray) -> HTML:
     IPython.display.HTML
         HTML object embedding the GIF as a data URI.
     """
-    font = ImageDraw.Draw(Image.new("RGB", (1, 1))).getfont()
     vmin = float(np.nanpercentile(before, 2))
     vmax = float(np.nanpercentile(before, 99.8))
-    pad = 8
+    if vmax <= vmin:
+        vmax = vmin + 1.0
+
+    pad = 12
+    panel_size = (480, 390)
+    header_height = 56
+    try:
+        font = ImageFont.truetype(font_manager.findfont("DejaVu Sans"), 24)
+    except (OSError, ValueError):
+        font = ImageFont.load_default()
+
     frames: list[Image.Image] = []
 
     for i, t in enumerate(before["time"].values):
-        left = Image.fromarray(_to_uint8_frame(before.isel(time=i).values, vmin, vmax))
-        right = Image.fromarray(_to_uint8_frame(after.isel(time=i).values, vmin, vmax))
-        left = left.convert("RGB").resize((320, 260))
-        right = right.convert("RGB").resize((320, 260))
+        left = np.clip((before.isel(time=i).values - vmin) / (vmax - vmin), 0, 1)
+        right = np.clip((after.isel(time=i).values - vmin) / (vmax - vmin), 0, 1)
+        left = Image.fromarray((255 * left).astype(np.uint8)).convert("RGB")
+        right = Image.fromarray((255 * right).astype(np.uint8)).convert("RGB")
+        left = left.resize(panel_size, Image.Resampling.LANCZOS)
+        right = right.resize(panel_size, Image.Resampling.LANCZOS)
 
         canvas = Image.new(
-            "RGB", (left.width + right.width + 3 * pad, left.height + 40), "black"
+            "RGB",
+            (left.width + right.width + 3 * pad, left.height + header_height),
+            "black",
         )
-        canvas.paste(left, (pad, 28))
-        canvas.paste(right, (left.width + 2 * pad, 28))
+        canvas.paste(left, (pad, header_height))
+        canvas.paste(right, (left.width + 2 * pad, header_height))
 
         draw = ImageDraw.Draw(canvas)
-        draw.text((pad, 6), "Before", fill="white", font=font)
-        draw.text((left.width + 2 * pad, 6), "After", fill="white", font=font)
-        draw.text((canvas.width - 70, 6), f"{float(t):.1f}s", fill="white", font=font)
+        draw.text((pad, 14), "Before", fill="white", font=font)
+        draw.text((left.width + 2 * pad, 14), "After", fill="white", font=font)
+        timestamp = f"{float(t):.1f}s"
+        timestamp_width = draw.textlength(timestamp, font=font)
+        draw.text(
+            (canvas.width - pad - timestamp_width, 14),
+            timestamp,
+            fill="white",
+            font=font,
+        )
         frames.append(canvas)
 
     buffer = BytesIO()
@@ -253,12 +247,11 @@ def _movie_html(before: xr.DataArray, after: xr.DataArray) -> HTML:
     )
 
 
-movie_before = data_db.squeeze("z", drop=True)
-movie_after = registered_db.squeeze("z", drop=True)
-_movie_html(movie_before, movie_after)
+movie_before = data.fusi.scale.db().squeeze("z", drop=True)
+movie_after = registered.fusi.scale.db().squeeze("z", drop=True)
+_gif_html(movie_before, movie_after)
 
 # %% [markdown]
-# Even on this short excerpt, the registered movie is visibly more stable and the mean
-# image is slightly sharper. For a full preprocessing workflow, you would usually run
-# the same correction on the complete recording before downstream QC, decomposition, or
-# connectivity analysis.
+# Even on this short excerpt, the registered movie is visibly more stable. For a full
+# preprocessing workflow, you would usually run the same correction on the complete
+# recording before downstream QC, decomposition, or connectivity analysis.

--- a/docs/examples/02_registration/02_volumewise_motion_correction.py
+++ b/docs/examples/02_registration/02_volumewise_motion_correction.py
@@ -142,13 +142,13 @@ vmin = float(np.nanpercentile(raster_before, 2))
 vmax = float(np.nanpercentile(raster_before, 99.8))
 
 for ax, raster, title in [
-    (axes[0], raster_before, "Before"),
-    (axes[1], raster_after, "After"),
+    (axes[0], raster_before, "Before motion correction"),
+    (axes[1], raster_after, "After motion correction"),
 ]:
     ax.imshow(
         raster.T,
         aspect="auto",
-        origin="lower",
+        origin="upper",
         cmap="gray",
         vmin=vmin,
         vmax=vmax,

--- a/docs/examples/02_registration/02_volumewise_motion_correction.py
+++ b/docs/examples/02_registration/02_volumewise_motion_correction.py
@@ -23,17 +23,12 @@
 
 
 # %%
-from base64 import b64encode
-from io import BytesIO
 from pathlib import Path
 
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 import xarray as xr
-from IPython.display import HTML
-from matplotlib import font_manager
-from PIL import Image, ImageDraw, ImageFont
 
 import confusius as cf
 
@@ -166,92 +161,50 @@ ax.set_title(f"Voxel at y={voxel_y}, x={voxel_x}")
 _ = ax.legend(frameon=False)
 
 # %% [markdown]
-# ## Build a before/after GIF
+# ## Check the alignment over time
 #
-# A side-by-side movie is often the fastest qualitative check. We render the raw and
-# registered slices with a shared contrast scale so the residual jitter is easy to spot.
-
+# A compact way to inspect the correction inside the notebook is to follow one image
+# column across time. Motion appears as slanted or wobbling vessel traces in this
+# `y × time` raster, while a good correction makes those traces more horizontal and
+# stable.
 
 # %%
-def _gif_html(before: xr.DataArray, after: xr.DataArray) -> HTML:
-    """Return an inline HTML `<img>` tag for a side-by-side animated GIF.
+raster_before = data.fusi.scale.db().isel(z=0, x=voxel_x)
+raster_after = registered.fusi.scale.db().isel(z=0, x=voxel_x)
 
-    Parameters
-    ----------
-    before : xarray.DataArray
-        Unregistered movie with dims `(time, y, x)`.
-    after : xarray.DataArray
-        Registered movie with the same dims and coordinates as `before`.
+fig, axes = plt.subplots(1, 2, figsize=(10, 4), constrained_layout=True, sharey=True)
+fig.patch.set_facecolor(bg_color)
 
-    Returns
-    -------
-    IPython.display.HTML
-        HTML object embedding the GIF as a data URI.
-    """
-    vmin = float(np.nanpercentile(before, 2))
-    vmax = float(np.nanpercentile(before, 99.8))
-    if vmax <= vmin:
-        vmax = vmin + 1.0
+vmin = float(np.nanpercentile(raster_before, 2))
+vmax = float(np.nanpercentile(raster_before, 99.8))
 
-    pad = 12
-    panel_size = (480, 390)
-    header_height = 56
-    try:
-        font = ImageFont.truetype(font_manager.findfont("DejaVu Sans"), 24)
-    except (OSError, ValueError):
-        font = ImageFont.load_default()
-
-    frames: list[Image.Image] = []
-
-    for i, t in enumerate(before["time"].values):
-        left = np.clip((before.isel(time=i).values - vmin) / (vmax - vmin), 0, 1)
-        right = np.clip((after.isel(time=i).values - vmin) / (vmax - vmin), 0, 1)
-        left = Image.fromarray((255 * left).astype(np.uint8)).convert("RGB")
-        right = Image.fromarray((255 * right).astype(np.uint8)).convert("RGB")
-        left = left.resize(panel_size, Image.Resampling.LANCZOS)
-        right = right.resize(panel_size, Image.Resampling.LANCZOS)
-
-        canvas = Image.new(
-            "RGB",
-            (left.width + right.width + 3 * pad, left.height + header_height),
-            "black",
-        )
-        canvas.paste(left, (pad, header_height))
-        canvas.paste(right, (left.width + 2 * pad, header_height))
-
-        draw = ImageDraw.Draw(canvas)
-        draw.text((pad, 14), "Before", fill="white", font=font)
-        draw.text((left.width + 2 * pad, 14), "After", fill="white", font=font)
-        timestamp = f"{float(t):.1f}s"
-        timestamp_width = draw.textlength(timestamp, font=font)
-        draw.text(
-            (canvas.width - pad - timestamp_width, 14),
-            timestamp,
-            fill="white",
-            font=font,
-        )
-        frames.append(canvas)
-
-    buffer = BytesIO()
-    frames[0].save(
-        buffer,
-        format="GIF",
-        save_all=True,
-        append_images=frames[1:],
-        duration=100,
-        loop=0,
+for ax, raster, title in [
+    (axes[0], raster_before, "Before"),
+    (axes[1], raster_after, "After"),
+]:
+    ax.imshow(
+        raster.T,
+        aspect="auto",
+        origin="lower",
+        cmap="gray",
+        vmin=vmin,
+        vmax=vmax,
+        extent=[
+            float(raster["time"].values[0]),
+            float(raster["time"].values[-1]),
+            float(raster["y"].values[0]),
+            float(raster["y"].values[-1]),
+        ],
     )
-    gif_base64 = b64encode(buffer.getvalue()).decode("ascii")
-    return HTML(
-        f'<img src="data:image/gif;base64,{gif_base64}" alt="Before/after volumewise registration GIF" />'
-    )
+    ax.set_title(title)
+    ax.set_xlabel("Time (s)")
 
-
-movie_before = data.fusi.scale.db().squeeze("z", drop=True)
-movie_after = registered.fusi.scale.db().squeeze("z", drop=True)
-_gif_html(movie_before, movie_after)
+_ = axes[0].set_ylabel("y (mm)")
 
 # %% [markdown]
-# Even on this short excerpt, the registered movie is visibly more stable. For a full
+# For a full visual check of the corrected movie, open the result in napari with
+# [`plot_napari`][confusius.plotting.plot_napari] or inspect it in the ConfUSIus
+# plugin. We intentionally do not embed a full before/after GIF here because it would
+# make the rendered notebook unnecessarily heavy for the docs site. For a full
 # preprocessing workflow, you would usually run the same correction on the complete
 # recording before downstream QC, decomposition, or connectivity analysis.

--- a/docs/examples/02_registration/02_volumewise_motion_correction.py
+++ b/docs/examples/02_registration/02_volumewise_motion_correction.py
@@ -97,7 +97,7 @@ motion_df.head()
 # ## Plot the motion diagnostics
 #
 # ConfUSIus provides the function
-# [`plot_motion_diagnostics`][confusius.registration.plot_motion_diagnostics] to plot
+# [`plot_motion_diagnostics`][confusius.plotting.plot_motion_diagnostics] to plot
 # `motion_params` using four panels:
 #
 # - The first two panels show the rotations and translations found at each frame.
@@ -106,10 +106,11 @@ motion_df.head()
 #   summing the absolute temporal derivatives of the realignment parameters
 #   (translations and rotations)[^1].
 # - The fourth panel shows the final registration metric and iteration count for each
-#   volume. Volumes showing outlier metric values or eaching the maximum number of
-#   iteration configured in `register_volumewise` are likely to not be registered
-#   correctly. In that case, you might want to tweak the registration parameters, or
-#   remove the corresponding volumes from further analysis.
+#   volume. Volumes showing outlier metric values or reaching the maximum number of
+#   iteration configured in
+#   [`register_volumewise`][confusius.registration.register_volumewise] are likely to
+#   not be registered correctly. In that case, you might want to tweak the registration
+#   parameters, or remove the corresponding volumes from further analysis.
 
 # %% tags=["thumbnail"]
 fig, axes = cf.plotting.plot_motion_diagnostics(motion_df)
@@ -120,35 +121,51 @@ fig.patch.set_facecolor(bg_color)
 #
 # To highlight the effect of the volumewise registration, we pick the voxel with the
 # largest temporal standard deviation in the unregistered recording. In practice that
-# usually lands on a large vessel, where motion-induced intensity changes are most
-# visible.
+# usually lands on a large vessel or near the borders of the brain, where brain motion
+# can induce high intensity changes.
 
 # %%
-std_map = data.squeeze("z", drop=True).std("time")
-voxel_y, voxel_x = np.unravel_index(np.nanargmax(std_map.values), std_map.shape)
+std_map = data.std("time")
+highest_std_voxel = std_map.isel(std_map.argmax(dim=["x", "y", "z"]))
 
-voxel_before = data.isel(z=0, y=voxel_y, x=voxel_x)
-voxel_after = registered.isel(z=0, y=voxel_y, x=voxel_x)
+voxel_before = data.sel(highest_std_voxel.coords)
+voxel_after = registered.sel(highest_std_voxel.coords)
 
-fig, ax = plt.subplots(figsize=(9, 3.5), constrained_layout=True)
+x_value = highest_std_voxel.x.values
+y_value = highest_std_voxel.y.values
+units = highest_std_voxel.x.units
+xy_position = f"(x, y) = ({x_value:.2f}, {y_value:.2f}) {units}"
+
+fig, axs = plt.subplots(1, 2, figsize=(9, 3.5), constrained_layout=True)
 fig.patch.set_facecolor(bg_color)
-ax.plot(voxel_before["time"], voxel_before, label="Before", lw=1.6, alpha=0.8)
-ax.plot(voxel_after["time"], voxel_after, label="After", lw=1.6)
-ax.set_xlabel("Time (s)")
-ax.set_ylabel("Power Doppler intensity")
-ax.set_title(f"Voxel at y={voxel_y}, x={voxel_x}")
-_ = ax.legend(frameon=False)
+
+plotter = (
+    data.mean("time")
+    .fusi.scale.db()
+    .fusi.plot.volume(axes=axs[0], bg_color=bg_color, show_colorbar=False)
+)
+
+# explicitly show the high std voxel on the brain plot
+axs[0].scatter(highest_std_voxel.x, highest_std_voxel.y, color="r")
+
+axs[1].plot(voxel_before["time"], voxel_before, label="Before", lw=1.6, alpha=0.8)
+axs[1].plot(voxel_after["time"], voxel_after, label="After", lw=1.6)
+axs[1].set_xlabel("Time (s)")
+axs[1].set_ylabel("Power Doppler intensity")
+axs[1].set_title(f"Voxel at {xy_position}")
+_ = axs[1].legend(frameon=False, ncols=2)
 
 # %% [markdown]
 # ## Check the alignment over time
 #
 # A compact way to inspect the correction inside the notebook is to follow one column
 # across time. Motion appears as slanted or wobbling vessel traces in this `y × time`
-# raster, while a good correction makes those traces more horizontal and stable.
+# raster, while a good correction makes those traces more horizontal and stable (note
+# that this will only clearly capture translation mation in the y axis).
 
 # %%
-raster_before = data.fusi.scale.db().isel(z=0, x=voxel_x)
-raster_after = registered.fusi.scale.db().isel(z=0, x=voxel_x)
+raster_before = data.fusi.scale.db().sel(z=0, x=x_value)
+raster_after = registered.fusi.scale.db().sel(z=0, x=x_value)
 
 fig, axes = plt.subplots(1, 2, figsize=(10, 4), constrained_layout=True, sharey=True)
 fig.patch.set_facecolor(bg_color)

--- a/docs/examples/02_registration/02_volumewise_motion_correction.py
+++ b/docs/examples/02_registration/02_volumewise_motion_correction.py
@@ -1,5 +1,5 @@
 # %% [markdown]
-# # Volumewise motion correction
+# # Motion correction of a single recording
 #
 # This example shows how to correct frame-to-frame brain motion in one fUSI recording
 # with [`register_volumewise`][confusius.registration.register_volumewise]. We reuse
@@ -71,14 +71,11 @@ data
 # rigid transform, correlation metric, and a fixed `learning_rate=1.0`.
 
 # %%
-reference_time = data.sizes["time"] // 2
 registered = cf.registration.register_volumewise(
     data,
-    reference_time=reference_time,
     transform="rigid",
     metric="correlation",
     learning_rate=1.0,
-    n_jobs=-1,
     resample_interpolation="bspline",
     show_progress=False,
 )
@@ -164,7 +161,7 @@ ax.plot(voxel_after["time"], voxel_after, label="After", lw=1.6)
 ax.set_xlabel("Time (s)")
 ax.set_ylabel("Power Doppler intensity")
 ax.set_title(f"Voxel at y={voxel_y}, x={voxel_x}")
-ax.legend(frameon=False)
+_ = ax.legend(frameon=False)
 
 # %%
 data_db = data.fusi.scale.db()

--- a/docs/examples/02_registration/02_volumewise_motion_correction.py
+++ b/docs/examples/02_registration/02_volumewise_motion_correction.py
@@ -3,7 +3,7 @@
 #
 # This example shows how to correct volume-to-volume brain motion in one fUSI recording
 # with [`register_volumewise`][confusius.registration.register_volumewise]. For this
-# example, we use a short subset of an open-feild 2D+t recording from the [Cybis Pereira
+# example, we use a short subset of an open-field 2D+t recording from the [Cybis Pereira
 # 2026
 # dataset](https://doi.org/10.1016/j.celrep.2025.116791). After volumewise registration,
 # we inspect three things that are useful in practice:
@@ -107,7 +107,7 @@ motion_df.head()
 #   (translations and rotations)[^1].
 # - The fourth panel shows the final registration metric and iteration count for each
 #   volume. Volumes showing outlier metric values or reaching the maximum number of
-#   iteration configured in
+#   iterations configured in
 #   [`register_volumewise`][confusius.registration.register_volumewise] are likely to
 #   not be registered correctly. In that case, you might want to tweak the registration
 #   parameters, or remove the corresponding volumes from further analysis.
@@ -145,7 +145,7 @@ plotter = (
     .fusi.plot.volume(axes=axs[0], bg_color=bg_color, show_colorbar=False)
 )
 
-# explicitly show the high std voxel on the brain plot
+# Explicitly show the high std voxel on the brain plot.
 axs[0].scatter(highest_std_voxel.x, highest_std_voxel.y, color="r")
 
 axs[1].plot(voxel_before["time"], voxel_before, label="Before", lw=1.6, alpha=0.8)
@@ -161,7 +161,7 @@ _ = axs[1].legend(frameon=False, ncols=2)
 # A compact way to inspect the correction inside the notebook is to follow one column
 # across time. Motion appears as slanted or wobbling vessel traces in this `y × time`
 # raster, while a good correction makes those traces more horizontal and stable (note
-# that this will only clearly capture translation mation in the y axis).
+# that this will only clearly capture translation motion in the y axis).
 
 # %%
 raster_before = data.fusi.scale.db().sel(z=0, x=x_value)

--- a/docs/examples/02_registration/02_volumewise_motion_correction.py
+++ b/docs/examples/02_registration/02_volumewise_motion_correction.py
@@ -10,8 +10,8 @@
 #
 # - the motion diagnostics returned by
 #   [`create_motion_dataframe`][confusius.registration.create_motion_dataframe];
-# - a before/after GIF of the registered movie;
-# - the time series of one representative voxel before and after registration.
+# - a representative voxel trace before and after registration;
+# - a compact raster view showing how one image column stabilizes over time.
 #
 # As in the GUI GIF, we register a 120-frame excerpt rather than the full recording.
 
@@ -82,10 +82,11 @@ motion_df.head()
 
 # %% [markdown]
 # `motion_df` is the output of
-# [`create_motion_dataframe`][confusius.registration.create_motion_dataframe]. For this
-# 2D+t example we focus on the in-plane rotation (`rot_z`), the in-plane translations,
-# the framewise displacement summaries (`mean_fd`, `max_fd`, `rms_fd`), and the
-# optimizer summaries (`final_metric_value`, `n_iterations`) added by
+# [`create_motion_dataframe`][confusius.registration.create_motion_dataframe]. Because
+# this recording has a singleton `z` axis, it is summarized as effective 2D motion:
+# one in-plane `rotation`, in-plane translations (`trans_x`, `trans_y`), the
+# framewise displacement summaries (`mean_fd`, `max_fd`, `rms_fd`), and the optimizer
+# summaries (`final_metric_value`, `n_iterations`) added by
 # [`register_volumewise`][confusius.registration.register_volumewise].
 
 # %% [markdown]
@@ -96,46 +97,8 @@ motion_df.head()
 # count or converge to a much worse similarity metric deserve a closer look.
 
 # %% tags=["thumbnail"]
-fig, axes = plt.subplots(4, 1, figsize=(9, 9), sharex=True, constrained_layout=True)
+fig, axes = cf.plotting.plot_motion_diagnostics(motion_df)
 fig.patch.set_facecolor(bg_color)
-
-time = motion_df.index.to_numpy(dtype=float)
-
-axes[0].plot(time, np.rad2deg(motion_df["rot_z"]), color="#4c78a8", lw=1.6)
-axes[0].set_ylabel("Rotation (deg)")
-axes[0].set_title("In-plane motion estimates")
-
-axes[1].plot(time, motion_df["trans_x"], label="x", lw=1.6)
-axes[1].plot(time, motion_df["trans_y"], label="y", lw=1.6)
-axes[1].set_ylabel("Translation (mm)")
-axes[1].legend(frameon=False, ncol=2)
-
-axes[2].plot(time, motion_df["mean_fd"], label="Mean FD", lw=1.8)
-axes[2].plot(time, motion_df["max_fd"], label="Max FD", lw=1.2, alpha=0.8)
-axes[2].set_ylabel("Displacement (mm)")
-axes[2].legend(frameon=False, ncol=2)
-
-metric_color = "#d93a54"
-iteration_color = "#3ad9a4"
-ax_metric = axes[3]
-ax_metric.plot(time, motion_df["final_metric_value"], color=metric_color, lw=1.8)
-ax_metric.set_ylabel("Final metric", color=metric_color)
-ax_metric.tick_params(axis="y", colors=metric_color)
-ax_metric.spines["left"].set_color(metric_color)
-ax_metric.set_xlabel("Time (s)")
-ax_metric.set_title("Optimizer summary")
-
-ax_iterations = ax_metric.twinx()
-ax_iterations.plot(
-    time,
-    motion_df["n_iterations"],
-    color=iteration_color,
-    lw=1.2,
-    alpha=0.9,
-)
-ax_iterations.set_ylabel("Iterations", color=iteration_color)
-ax_iterations.tick_params(axis="y", colors=iteration_color)
-ax_iterations.spines["right"].set_color(iteration_color)
 
 # %% [markdown]
 # ## Compare a representative voxel before and after registration

--- a/docs/examples/02_registration/02_volumewise_motion_correction.py
+++ b/docs/examples/02_registration/02_volumewise_motion_correction.py
@@ -82,11 +82,11 @@ motion_df.head()
 
 # %% [markdown]
 # `motion_df` is the output of
-# [`create_motion_dataframe`][confusius.registration.create_motion_dataframe]. Because
-# this recording has a singleton `z` axis, it is summarized as effective 2D motion:
-# one in-plane `rotation`, in-plane translations (`trans_x`, `trans_y`), the
-# framewise displacement summaries (`mean_fd`, `max_fd`, `rms_fd`), and the optimizer
-# summaries (`final_metric_value`, `n_iterations`) added by
+# [`create_motion_dataframe`][confusius.registration.create_motion_dataframe]. Even
+# though this recording has a singleton `z` axis, the table keeps the full 3D motion
+# summary: rotations (`rot_x`, `rot_y`, `rot_z`), translations (`trans_x`, `trans_y`,
+# `trans_z`), the framewise displacement summaries (`mean_fd`, `max_fd`, `rms_fd`),
+# and the optimizer summaries (`final_metric_value`, `n_iterations`) added by
 # [`register_volumewise`][confusius.registration.register_volumewise].
 
 # %% [markdown]

--- a/docs/examples/02_registration/02_volumewise_motion_correction.py
+++ b/docs/examples/02_registration/02_volumewise_motion_correction.py
@@ -1,0 +1,267 @@
+# %% [markdown]
+# # Volumewise motion correction
+#
+# This example shows how to correct frame-to-frame brain motion in one fUSI recording
+# with [`register_volumewise`][confusius.registration.register_volumewise]. We reuse
+# the exact acquisition and rigid-registration settings from the
+# volumewise-registration GIF in the GUI guide: a short open-field excerpt from the
+# [Cybis Pereira 2026 dataset](https://doi.org/10.1016/j.celrep.2025.116791). We then
+# inspect three things that are useful in practice:
+#
+# - the motion diagnostics returned by
+#   [`create_motion_dataframe`][confusius.registration.create_motion_dataframe];
+# - a before/after GIF of the registered movie;
+# - the time series of one representative voxel before and after registration.
+#
+# As in the GUI GIF, we register a 120-frame excerpt rather than the full recording.
+
+# %% [markdown]
+# ## Fetch and load a short motion-corrupted window
+#
+# This is the same open-field recording used by the GUI registration demo. The selected
+# acquisition is a single 2D slice, so the data shape is `(time, z=1, y, x)`.
+
+
+# %%
+from base64 import b64encode
+from io import BytesIO
+from pathlib import Path
+
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+import numpy as np
+import xarray as xr
+from IPython.display import HTML
+from PIL import Image, ImageDraw
+
+import confusius as cf
+
+bg_color = mpl.colors.to_hex(mpl.rcParams["figure.facecolor"])
+xr.set_options(display_expand_data=False)
+
+subject = "rat75"
+session = "20220523"
+acq = "slice32"
+start_frame = 220
+n_frames = 120
+
+bids_root = cf.datasets.fetch_cybis_pereira_2026(
+    datasets="rawdata",
+    subjects=subject,
+    sessions=session,
+    acqs=acq,
+)
+
+pwd_path = (
+    Path(bids_root)
+    / f"sub-{subject}"
+    / f"ses-{session}"
+    / "fusi"
+    / f"sub-{subject}_ses-{session}_task-openfield_acq-{acq}_pwd.nii.gz"
+)
+
+data = cf.load(pwd_path).isel(time=slice(start_frame, start_frame + n_frames)).compute()
+data
+
+# %% [markdown]
+# ## Register every frame to the middle frame
+#
+# Registering to a central reference frame is a simple way to avoid anchoring the whole
+# excerpt to one edge of the motion trajectory. Here we match the GUI demo settings:
+# rigid transform, correlation metric, and a fixed `learning_rate=1.0`.
+
+# %%
+reference_time = data.sizes["time"] // 2
+registered = cf.registration.register_volumewise(
+    data,
+    reference_time=reference_time,
+    transform="rigid",
+    metric="correlation",
+    learning_rate=1.0,
+    n_jobs=-1,
+    resample_interpolation="bspline",
+    show_progress=False,
+)
+
+motion_df = registered.attrs["motion_params"]
+motion_df.head()
+
+# %% [markdown]
+# `motion_df` is the output of
+# [`create_motion_dataframe`][confusius.registration.create_motion_dataframe]. For this
+# 2D+t example we focus on the in-plane rotation (`rot_z`), the in-plane translations,
+# the framewise displacement summaries (`mean_fd`, `max_fd`, `rms_fd`), and the
+# optimizer summaries (`final_metric_value`, `n_iterations`) added by
+# [`register_volumewise`][confusius.registration.register_volumewise].
+
+# %% [markdown]
+# ## Plot the motion diagnostics
+#
+# The framewise displacement peak marks where the excerpt moves most strongly. The last
+# panel is a useful sanity check: frames that systematically hit the maximum iteration
+# count or converge to a much worse similarity metric deserve a closer look.
+
+# %%
+fig, axes = plt.subplots(4, 1, figsize=(9, 9), sharex=True, constrained_layout=True)
+fig.patch.set_facecolor(bg_color)
+
+time = motion_df.index.to_numpy(dtype=float)
+
+axes[0].plot(time, np.rad2deg(motion_df["rot_z"]), color="#4c78a8", lw=1.6)
+axes[0].set_ylabel("Rotation (deg)")
+axes[0].set_title("In-plane motion estimates")
+
+axes[1].plot(time, motion_df["trans_x"], label="x", lw=1.6)
+axes[1].plot(time, motion_df["trans_y"], label="y", lw=1.6)
+axes[1].set_ylabel("Translation (mm)")
+axes[1].legend(frameon=False, ncol=2)
+
+axes[2].plot(time, motion_df["mean_fd"], label="Mean FD", lw=1.8)
+axes[2].plot(time, motion_df["max_fd"], label="Max FD", lw=1.2, alpha=0.8)
+axes[2].set_ylabel("Displacement (mm)")
+axes[2].legend(frameon=False, ncol=2)
+
+metric_color = "#d93a54"
+iteration_color = "#3ad9a4"
+ax_metric = axes[3]
+ax_metric.plot(time, motion_df["final_metric_value"], color=metric_color, lw=1.8)
+ax_metric.set_ylabel("Final metric", color=metric_color)
+ax_metric.tick_params(axis="y", colors=metric_color)
+ax_metric.spines["left"].set_color(metric_color)
+ax_metric.set_xlabel("Time (s)")
+ax_metric.set_title("Optimizer summary")
+
+ax_iterations = ax_metric.twinx()
+ax_iterations.plot(
+    time,
+    motion_df["n_iterations"],
+    color=iteration_color,
+    lw=1.2,
+    alpha=0.9,
+)
+ax_iterations.set_ylabel("Iterations", color=iteration_color)
+ax_iterations.tick_params(axis="y", colors=iteration_color)
+ax_iterations.spines["right"].set_color(iteration_color)
+
+# %% [markdown]
+# ## Compare a representative voxel before and after registration
+#
+# To make the effect easy to see, we pick the voxel with the largest temporal standard
+# deviation in the unregistered excerpt. In practice that usually lands on a large
+# vessel, where motion-induced intensity changes are most visible.
+
+# %% tags=["thumbnail"]
+std_map = data.squeeze("z", drop=True).std("time")
+voxel_y, voxel_x = np.unravel_index(np.nanargmax(std_map.values), std_map.shape)
+
+voxel_before = data.isel(z=0, y=voxel_y, x=voxel_x)
+voxel_after = registered.isel(z=0, y=voxel_y, x=voxel_x)
+
+fig, ax = plt.subplots(figsize=(9, 3.5), constrained_layout=True)
+fig.patch.set_facecolor(bg_color)
+ax.plot(voxel_before["time"], voxel_before, label="Before", lw=1.6, alpha=0.8)
+ax.plot(voxel_after["time"], voxel_after, label="After", lw=1.6)
+ax.set_xlabel("Time (s)")
+ax.set_ylabel("Power Doppler intensity")
+ax.set_title(f"Voxel at y={voxel_y}, x={voxel_x}")
+ax.legend(frameon=False)
+
+# %%
+data_db = data.fusi.scale.db()
+registered_db = registered.fusi.scale.db()
+
+# %% [markdown]
+# ## Build a before/after GIF
+#
+# A side-by-side movie is often the fastest qualitative check. We render the raw and
+# registered slices with a shared contrast scale so the residual jitter is easy to spot.
+
+
+# %%
+def _to_uint8_frame(values: np.ndarray, vmin: float, vmax: float) -> np.ndarray:
+    """Convert one 2D image to a clipped 8-bit grayscale frame.
+
+    Parameters
+    ----------
+    values : numpy.ndarray
+        Two-dimensional image data.
+    vmin : float
+        Lower display bound.
+    vmax : float
+        Upper display bound.
+
+    Returns
+    -------
+    numpy.ndarray
+        Unsigned 8-bit image with shape `(y, x)`.
+    """
+    if vmax <= vmin:
+        vmax = vmin + 1.0
+    clipped = np.clip((values - vmin) / (vmax - vmin), 0, 1)
+    return (255 * clipped).astype(np.uint8)
+
+
+# %%
+def _movie_html(before: xr.DataArray, after: xr.DataArray) -> HTML:
+    """Return an inline HTML `<img>` tag for a side-by-side animated GIF.
+
+    Parameters
+    ----------
+    before : xarray.DataArray
+        Unregistered movie with dims `(time, y, x)`.
+    after : xarray.DataArray
+        Registered movie with the same dims and coordinates as `before`.
+
+    Returns
+    -------
+    IPython.display.HTML
+        HTML object embedding the GIF as a data URI.
+    """
+    font = ImageDraw.Draw(Image.new("RGB", (1, 1))).getfont()
+    vmin = float(np.nanpercentile(before, 2))
+    vmax = float(np.nanpercentile(before, 99.8))
+    pad = 8
+    frames: list[Image.Image] = []
+
+    for i, t in enumerate(before["time"].values):
+        left = Image.fromarray(_to_uint8_frame(before.isel(time=i).values, vmin, vmax))
+        right = Image.fromarray(_to_uint8_frame(after.isel(time=i).values, vmin, vmax))
+        left = left.convert("RGB").resize((320, 260))
+        right = right.convert("RGB").resize((320, 260))
+
+        canvas = Image.new(
+            "RGB", (left.width + right.width + 3 * pad, left.height + 40), "black"
+        )
+        canvas.paste(left, (pad, 28))
+        canvas.paste(right, (left.width + 2 * pad, 28))
+
+        draw = ImageDraw.Draw(canvas)
+        draw.text((pad, 6), "Before", fill="white", font=font)
+        draw.text((left.width + 2 * pad, 6), "After", fill="white", font=font)
+        draw.text((canvas.width - 70, 6), f"{float(t):.1f}s", fill="white", font=font)
+        frames.append(canvas)
+
+    buffer = BytesIO()
+    frames[0].save(
+        buffer,
+        format="GIF",
+        save_all=True,
+        append_images=frames[1:],
+        duration=100,
+        loop=0,
+    )
+    gif_base64 = b64encode(buffer.getvalue()).decode("ascii")
+    return HTML(
+        f'<img src="data:image/gif;base64,{gif_base64}" alt="Before/after volumewise registration GIF" />'
+    )
+
+
+movie_before = data_db.squeeze("z", drop=True)
+movie_after = registered_db.squeeze("z", drop=True)
+_movie_html(movie_before, movie_after)
+
+# %% [markdown]
+# Even on this short excerpt, the registered movie is visibly more stable and the mean
+# image is slightly sharper. For a full preprocessing workflow, you would usually run
+# the same correction on the complete recording before downstream QC, decomposition, or
+# connectivity analysis.

--- a/docs/examples/02_registration/02_volumewise_motion_correction.py
+++ b/docs/examples/02_registration/02_volumewise_motion_correction.py
@@ -170,8 +170,8 @@ for ax, raster, title in [
         extent=[
             float(raster["time"].values[0]),
             float(raster["time"].values[-1]),
-            float(raster["y"].values[0]),
             float(raster["y"].values[-1]),
+            float(raster["y"].values[0]),
         ],
     )
     ax.set_title(title)

--- a/docs/examples/02_registration/02_volumewise_motion_correction.py
+++ b/docs/examples/02_registration/02_volumewise_motion_correction.py
@@ -1,25 +1,23 @@
 # %% [markdown]
 # # Motion correction of a single recording
 #
-# This example shows how to correct frame-to-frame brain motion in one fUSI recording
-# with [`register_volumewise`][confusius.registration.register_volumewise]. We reuse
-# the exact acquisition and rigid-registration settings from the
-# volumewise-registration GIF in the GUI guide: a short open-field excerpt from the
-# [Cybis Pereira 2026 dataset](https://doi.org/10.1016/j.celrep.2025.116791). We then
-# inspect three things that are useful in practice:
+# This example shows how to correct volume-to-volume brain motion in one fUSI recording
+# with [`register_volumewise`][confusius.registration.register_volumewise]. For this
+# example, we use a short subset of an open-feild 2D+t recording from the [Cybis Pereira
+# 2026
+# dataset](https://doi.org/10.1016/j.celrep.2025.116791). After volumewise registration,
+# we inspect three things that are useful in practice:
 #
 # - the motion diagnostics returned by
 #   [`create_motion_dataframe`][confusius.registration.create_motion_dataframe];
 # - a representative voxel trace before and after registration;
-# - a compact raster view showing how one image column stabilizes over time.
-#
-# As in the GUI GIF, we register a 120-frame excerpt rather than the full recording.
+# - a compact raster view showing how volumewise registration stabilized the recording.
 
 # %% [markdown]
 # ## Fetch and load a short motion-corrupted window
 #
-# This is the same open-field recording used by the GUI registration demo. The selected
-# acquisition is a single 2D slice, so the data shape is `(time, z=1, y, x)`.
+# The selected acquisition is a recording from a single 2D slice, so the data shape is
+# `(time, z=1, y, x)`.
 
 
 # %%
@@ -61,11 +59,14 @@ data = cf.load(pwd_path).isel(time=slice(start_frame, start_frame + n_frames)).c
 data
 
 # %% [markdown]
-# ## Register every frame to the middle frame
+# ## Register every frame to the first frame
 #
-# Registering to a central reference frame is a simple way to avoid anchoring the whole
-# excerpt to one edge of the motion trajectory. Here we match the GUI demo settings:
-# rigid transform, correlation metric, and a fixed `learning_rate=1.0`.
+# Volumewise registration can be applied using
+# [`register_volumewise`][confusius.registration.register_volumewise]. By default, each
+# volume (or frame in this case) is registered to the first acquired volume. You may
+# choose any other reference timepoint using the `reference_time`. Here, we're trying to
+# correct for rigid motion—that is, translation and rotations. A learning rate of 1.0
+# leads to good convergence across frames.
 
 # %%
 registered = cf.registration.register_volumewise(
@@ -73,39 +74,54 @@ registered = cf.registration.register_volumewise(
     transform="rigid",
     metric="correlation",
     learning_rate=1.0,
-    resample_interpolation="bspline",
-    show_progress=False,
 )
 
+# %% [markdown]
+# [`register_volumewise`][confusius.registration.register_volumewise] adds a
+# `motion_params` attribute to the motion-corrected DataArray. `motion_params` is a
+# DataFrame created using
+# [`create_motion_dataframe`][confusius.registration.create_motion_dataframe] and
+# containing the motion parameters and registration diagnostics: rotations (`rot_x`,
+# `rot_y`, `rot_z`), translations (`trans_x`, `trans_y`, `trans_z`), the framewise
+# displacement (FD)[^1] summaries (`mean_fd`, `max_fd`, `rms_fd`), and the optimizer
+# summaries (`final_metric_value`, `n_iterations`) added by
+# [`register_volumewise`][confusius.registration.register_volumewise]. Since we
+# registered a 2D+t recording, only the rotation along the z-axis and the translations
+# along the x- and y-axes are non-zero.
+
+# %%
 motion_df = registered.attrs["motion_params"]
 motion_df.head()
 
 # %% [markdown]
-# `motion_df` is the output of
-# [`create_motion_dataframe`][confusius.registration.create_motion_dataframe]. Even
-# though this recording has a singleton `z` axis, the table keeps the full 3D motion
-# summary: rotations (`rot_x`, `rot_y`, `rot_z`), translations (`trans_x`, `trans_y`,
-# `trans_z`), the framewise displacement summaries (`mean_fd`, `max_fd`, `rms_fd`),
-# and the optimizer summaries (`final_metric_value`, `n_iterations`) added by
-# [`register_volumewise`][confusius.registration.register_volumewise].
-
-# %% [markdown]
 # ## Plot the motion diagnostics
 #
-# The framewise displacement peak marks where the excerpt moves most strongly. The last
-# panel is a useful sanity check: frames that systematically hit the maximum iteration
-# count or converge to a much worse similarity metric deserve a closer look.
+# ConfUSIus provides the function
+# [`plot_motion_diagnostics`][confusius.registration.plot_motion_diagnostics] to plot
+# `motion_params` using four panels:
+#
+# - The first two panels show the rotations and translations found at each frame.
+# - The third panel shows the mean, maximum, and RMS of the framewise displacement (FD).
+#   The FD is a metric used to quantify brain motion between consecutive volumes by
+#   summing the absolute temporal derivatives of the realignment parameters
+#   (translations and rotations)[^1].
+# - The fourth panel shows the final registration metric and iteration count for each
+#   volume. Volumes showing outlier metric values or eaching the maximum number of
+#   iteration configured in `register_volumewise` are likely to not be registered
+#   correctly. In that case, you might want to tweak the registration parameters, or
+#   remove the corresponding volumes from further analysis.
 
 # %% tags=["thumbnail"]
 fig, axes = cf.plotting.plot_motion_diagnostics(motion_df)
 fig.patch.set_facecolor(bg_color)
 
 # %% [markdown]
-# ## Compare a representative voxel before and after registration
+# ## Compare a representative time series before and after registration
 #
-# To make the effect easy to see, we pick the voxel with the largest temporal standard
-# deviation in the unregistered excerpt. In practice that usually lands on a large
-# vessel, where motion-induced intensity changes are most visible.
+# To highlight the effect of the volumewise registration, we pick the voxel with the
+# largest temporal standard deviation in the unregistered recording. In practice that
+# usually lands on a large vessel, where motion-induced intensity changes are most
+# visible.
 
 # %%
 std_map = data.squeeze("z", drop=True).std("time")
@@ -126,10 +142,9 @@ _ = ax.legend(frameon=False)
 # %% [markdown]
 # ## Check the alignment over time
 #
-# A compact way to inspect the correction inside the notebook is to follow one image
-# column across time. Motion appears as slanted or wobbling vessel traces in this
-# `y × time` raster, while a good correction makes those traces more horizontal and
-# stable.
+# A compact way to inspect the correction inside the notebook is to follow one column
+# across time. Motion appears as slanted or wobbling vessel traces in this `y × time`
+# raster, while a good correction makes those traces more horizontal and stable.
 
 # %%
 raster_before = data.fusi.scale.db().isel(z=0, x=voxel_x)
@@ -166,8 +181,13 @@ _ = axes[0].set_ylabel("y (mm)")
 
 # %% [markdown]
 # For a full visual check of the corrected movie, open the result in napari with
-# [`plot_napari`][confusius.plotting.plot_napari] or inspect it in the ConfUSIus
-# plugin. We intentionally do not embed a full before/after GIF here because it would
-# make the rendered notebook unnecessarily heavy for the docs site. For a full
-# preprocessing workflow, you would usually run the same correction on the complete
-# recording before downstream QC, decomposition, or connectivity analysis.
+# [`plot_napari`][confusius.plotting.plot_napari] or inspect it in the ConfUSIus plugin.
+# We intentionally do not embed a full before/after GIF here because it would make the
+# rendered notebook unnecessarily heavy. For a full preprocessing workflow, you would
+# usually run the same correction on the complete recording before downstream QC,
+# decomposition, or connectivity analysis.
+#
+# [^1]:
+#     Power, J. D., Barnes, K. A., Snyder, A. Z., Schlaggar, B. L. & Petersen, S. E.
+#     Spurious but systematic correlations in functional connectivity MRI networks arise
+#     from subject motion. Neuroimage 59, 2142-2154

--- a/docs/includes/abbreviations.md
+++ b/docs/includes/abbreviations.md
@@ -27,4 +27,5 @@
 *[QC]: Quality Control
 *[tSNR]: Temporal Signal-to-Noise Ratio
 *[CV]: Coefficient of Variation
+*[FD]: Framewise Displacement
 

--- a/src/confusius/plotting/__init__.py
+++ b/src/confusius/plotting/__init__.py
@@ -7,6 +7,7 @@ __all__ = [
     "plot_composite",
     "plot_contours",
     "plot_matrix",
+    "plot_motion_diagnostics",
     "plot_napari",
     "plot_stat_map",
     "plot_volume",
@@ -22,6 +23,7 @@ from confusius.plotting.image import (
     plot_volume,
 )
 from confusius.plotting.matrix import plot_matrix
+from confusius.plotting.motion import plot_motion_diagnostics
 from confusius.plotting.napari import (
     draw_napari_labels,
     labels_from_layer,

--- a/src/confusius/plotting/motion.py
+++ b/src/confusius/plotting/motion.py
@@ -136,7 +136,7 @@ def plot_motion_diagnostics(
             )
             iter_ax.set_ylabel("Iterations", color=iteration_color)
             iter_ax.tick_params(axis="y", colors=iteration_color)
-            iter_ax.spines["right"].set_color(iteration_color)
+            iter_ax.spines["right" if has_metric else "left"].set_color(iteration_color)
 
     axes[-1].set_xlabel("Time (s)" if motion_df.index.name == "time" else "Frame")
     return fig, axes

--- a/src/confusius/plotting/motion.py
+++ b/src/confusius/plotting/motion.py
@@ -1,0 +1,142 @@
+"""Motion diagnostics plotting utilities."""
+
+from typing import TYPE_CHECKING
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+if TYPE_CHECKING:
+    import pandas as pd
+    from matplotlib.figure import Figure
+
+
+def plot_motion_diagnostics(
+    motion_df: "pd.DataFrame",
+    *,
+    figsize: tuple[float, float] | None = None,
+) -> tuple["Figure", np.ndarray]:
+    """Plot motion diagnostics from `create_motion_dataframe`.
+
+    Parameters
+    ----------
+    motion_df : pandas.DataFrame
+        Motion summary table, typically `result.attrs["motion_params"]` from
+        [`register_volumewise`][confusius.registration.register_volumewise]. The
+        function plots whichever standard columns are present.
+    figsize : tuple of float, optional
+        Figure size passed to Matplotlib. If not provided, a height is chosen from the
+        number of panels.
+
+    Returns
+    -------
+    fig : matplotlib.figure.Figure
+        Figure containing the motion plots.
+    axes : numpy.ndarray
+        Array of Matplotlib axes, one per panel.
+
+    Raises
+    ------
+    ValueError
+        If `motion_df` contains none of the supported motion-diagnostics columns.
+    """
+    time = np.asarray(motion_df.index, dtype=float)
+    panels: list[str] = []
+
+    rotation_cols = [
+        col for col in ["rotation", "rot_x", "rot_y", "rot_z"] if col in motion_df
+    ]
+    translation_cols = [
+        col for col in ["trans_x", "trans_y", "trans_z"] if col in motion_df
+    ]
+    displacement_cols = [
+        col for col in ["mean_fd", "max_fd", "rms_fd"] if col in motion_df
+    ]
+    has_metric = "final_metric_value" in motion_df
+    has_iterations = "n_iterations" in motion_df
+
+    if rotation_cols:
+        panels.append("rotation")
+    if translation_cols:
+        panels.append("translation")
+    if displacement_cols:
+        panels.append("displacement")
+    if has_metric or has_iterations:
+        panels.append("optimizer")
+
+    if not panels:
+        raise ValueError(
+            "motion_df does not contain any supported diagnostics columns."
+        )
+
+    if figsize is None:
+        figsize = (9, 2 + 1.8 * len(panels))
+    fig, axes = plt.subplots(
+        len(panels), 1, figsize=figsize, sharex=True, constrained_layout=True
+    )
+    axes = np.atleast_1d(axes)
+
+    panel_index = 0
+
+    if rotation_cols:
+        ax = axes[panel_index]
+        for col in rotation_cols:
+            label = col.replace("rot_", "") if col != "rotation" else None
+            ax.plot(time, np.rad2deg(motion_df[col]), lw=1.6, label=label)
+        ax.set_ylabel("Rotation (deg)")
+        ax.set_title("Motion estimates")
+        if any(col != "rotation" for col in rotation_cols):
+            ax.legend(frameon=False, ncol=len(rotation_cols))
+        panel_index += 1
+
+    if translation_cols:
+        ax = axes[panel_index]
+        for col in translation_cols:
+            ax.plot(time, motion_df[col], lw=1.6, label=col.removeprefix("trans_"))
+        ax.set_ylabel("Translation (mm)")
+        ax.legend(frameon=False, ncol=len(translation_cols))
+        panel_index += 1
+
+    if displacement_cols:
+        ax = axes[panel_index]
+        for col in displacement_cols:
+            label = {
+                "mean_fd": "Mean FD",
+                "max_fd": "Max FD",
+                "rms_fd": "RMS FD",
+            }[col]
+            lw = 1.8 if col == "mean_fd" else 1.2
+            ax.plot(time, motion_df[col], lw=lw, label=label)
+        ax.set_ylabel("Displacement (mm)")
+        ax.legend(frameon=False, ncol=len(displacement_cols))
+        panel_index += 1
+
+    if has_metric or has_iterations:
+        metric_color = "#d93a54"
+        iteration_color = "#3ad9a4"
+        ax = axes[panel_index]
+        ax.set_title("Optimizer summary")
+        if has_metric:
+            ax.plot(
+                time,
+                motion_df["final_metric_value"],
+                color=metric_color,
+                lw=1.8,
+            )
+            ax.set_ylabel("Final metric", color=metric_color)
+            ax.tick_params(axis="y", colors=metric_color)
+            ax.spines["left"].set_color(metric_color)
+        if has_iterations:
+            iter_ax = ax.twinx() if has_metric else ax
+            iter_ax.plot(
+                time,
+                motion_df["n_iterations"],
+                color=iteration_color,
+                lw=1.2,
+                alpha=0.9,
+            )
+            iter_ax.set_ylabel("Iterations", color=iteration_color)
+            iter_ax.tick_params(axis="y", colors=iteration_color)
+            iter_ax.spines["right"].set_color(iteration_color)
+
+    axes[-1].set_xlabel("Time (s)" if motion_df.index.name == "time" else "Frame")
+    return fig, axes

--- a/src/confusius/registration/__init__.py
+++ b/src/confusius/registration/__init__.py
@@ -4,6 +4,7 @@ from confusius.registration._progress import RegistrationProgressPlotter
 from confusius.registration.affines import (
     compose_affine,
     decompose_affine,
+    get_euler_xyz_from_rotation_matrix,
 )
 from confusius.registration.bspline import (
     invert_displacement_field,
@@ -30,6 +31,7 @@ __all__ = [
     "sample_displacement_field_like",
     "compose_affine",
     "decompose_affine",
+    "get_euler_xyz_from_rotation_matrix",
     "invert_displacement_field",
     "register_volume",
     "resample_volume",

--- a/src/confusius/registration/__init__.py
+++ b/src/confusius/registration/__init__.py
@@ -1,11 +1,7 @@
 """Registration module for fUSI data."""
 
 from confusius.registration._progress import RegistrationProgressPlotter
-from confusius.registration.affines import (
-    compose_affine,
-    decompose_affine,
-    get_euler_xyz_from_rotation_matrix,
-)
+from confusius.registration.affines import compose_affine, decompose_affine
 from confusius.registration.bspline import (
     invert_displacement_field,
     sample_displacement_field,
@@ -31,7 +27,6 @@ __all__ = [
     "sample_displacement_field_like",
     "compose_affine",
     "decompose_affine",
-    "get_euler_xyz_from_rotation_matrix",
     "invert_displacement_field",
     "register_volume",
     "resample_volume",

--- a/src/confusius/registration/affines.py
+++ b/src/confusius/registration/affines.py
@@ -125,6 +125,46 @@ def compose_affine(
     return A
 
 
+def get_euler_xyz_from_rotation_matrix(
+    R: npt.NDArray[np.floating],
+) -> tuple[float, float, float]:
+    """Get XYZ Euler angles from a 3D rotation matrix.
+
+    Parameters
+    ----------
+    R : (3, 3) numpy.ndarray
+        Rotation matrix.
+
+    Returns
+    -------
+    rot_x : float
+        Rotation angle around the x axis in radians.
+    rot_y : float
+        Rotation angle around the y axis in radians.
+    rot_z : float
+        Rotation angle around the z axis in radians.
+    """
+    if R.shape != (3, 3):
+        raise ValueError(f"Expected a (3, 3) rotation matrix, got {R.shape}.")
+
+    # XYZ convention: R = Rz @ Ry @ Rx
+    # R[2,0] = -sin(rot_y)
+    sy = -R[2, 0]
+    sy = max(-1.0, min(1.0, sy))
+    rot_y = math.asin(sy)
+
+    cos_y = math.cos(rot_y)
+    if abs(cos_y) > 1e-6:
+        rot_x = math.atan2(R[2, 1], R[2, 2])
+        rot_z = math.atan2(R[1, 0], R[0, 0])
+    else:
+        # Gimbal lock: set rot_x = 0 and compute rot_z.
+        rot_x = 0.0
+        rot_z = math.atan2(-R[0, 1], R[1, 1])
+
+    return rot_x, rot_y, rot_z
+
+
 def decompose_affine(
     A44: npt.NDArray[np.floating],
 ) -> tuple[

--- a/src/confusius/registration/affines.py
+++ b/src/confusius/registration/affines.py
@@ -143,6 +143,11 @@ def get_euler_xyz_from_rotation_matrix(
         Rotation angle around the y axis in radians.
     rot_z : float
         Rotation angle around the z axis in radians.
+
+    Raises
+    ------
+    ValueError
+        If `R` is not a `(3, 3)` array.
     """
     if R.shape != (3, 3):
         raise ValueError(f"Expected a (3, 3) rotation matrix, got {R.shape}.")

--- a/src/confusius/registration/affines.py
+++ b/src/confusius/registration/affines.py
@@ -125,51 +125,6 @@ def compose_affine(
     return A
 
 
-def get_euler_xyz_from_rotation_matrix(
-    R: npt.NDArray[np.floating],
-) -> tuple[float, float, float]:
-    """Get XYZ Euler angles from a 3D rotation matrix.
-
-    Parameters
-    ----------
-    R : (3, 3) numpy.ndarray
-        Rotation matrix.
-
-    Returns
-    -------
-    rot_x : float
-        Rotation angle around the x axis in radians.
-    rot_y : float
-        Rotation angle around the y axis in radians.
-    rot_z : float
-        Rotation angle around the z axis in radians.
-
-    Raises
-    ------
-    ValueError
-        If `R` is not a `(3, 3)` array.
-    """
-    if R.shape != (3, 3):
-        raise ValueError(f"Expected a (3, 3) rotation matrix, got {R.shape}.")
-
-    # XYZ convention: R = Rz @ Ry @ Rx
-    # R[2,0] = -sin(rot_y)
-    sy = -R[2, 0]
-    sy = max(-1.0, min(1.0, sy))
-    rot_y = math.asin(sy)
-
-    cos_y = math.cos(rot_y)
-    if abs(cos_y) > 1e-6:
-        rot_x = math.atan2(R[2, 1], R[2, 2])
-        rot_z = math.atan2(R[1, 0], R[0, 0])
-    else:
-        # Gimbal lock: set rot_x = 0 and compute rot_z.
-        rot_x = 0.0
-        rot_z = math.atan2(-R[0, 1], R[1, 1])
-
-    return rot_x, rot_y, rot_z
-
-
 def decompose_affine(
     A44: npt.NDArray[np.floating],
 ) -> tuple[

--- a/src/confusius/registration/motion.py
+++ b/src/confusius/registration/motion.py
@@ -294,18 +294,24 @@ def create_motion_dataframe(
         For 2D:
 
         - `rotation`: Rotation angle in radians.
-        - `trans_x`: Translation in x (mm).
-        - `trans_y`: Translation in y (mm).
+        - `trans_x`: Translation along the DataArray's `x` axis (mm).
+        - `trans_y`: Translation along the DataArray's `y` axis (mm).
 
         For 3D:
 
-        - `rot_x, rot_y, rot_z`: Rotation angles in radians.
-        - `trans_x, trans_y, trans_z`: Translations (mm).
+        - `rot_x, rot_y, rot_z`: Rotation angles around the DataArray's
+          `x`, `y`, and `z` axes, in radians.
+        - `trans_x, trans_y, trans_z`: Translations along the DataArray's
+          `x`, `y`, and `z` axes (mm).
 
         Both:
         - `mean_fd`: Mean framewise displacement (mm).
         - `max_fd`: Maximum framewise displacement (mm).
         - `rms_fd`: RMS framewise displacement (mm).
+
+        Motion columns are reported in named-axis order (`x`, `y`, `z`), even when
+        the input DataArray stores its spatial dimensions in a different order such as
+        `(z, y, x)`.
     """
     import pandas as pd
 
@@ -313,26 +319,30 @@ def create_motion_dataframe(
 
     fd_dict = compute_framewise_displacement(affines, reference, mask)
 
+    spatial_dims = tuple(str(dim) for dim in reference.dims)
+
     if params.shape[1] == 3:
+        axis_index = {dim: i for i, dim in enumerate(spatial_dims)}
         df = pd.DataFrame(
             {
                 "rotation": params[:, 0],
-                "trans_x": params[:, 1],
-                "trans_y": params[:, 2],
+                "trans_x": params[:, 1 + axis_index["x"]],
+                "trans_y": params[:, 1 + axis_index["y"]],
                 "mean_fd": fd_dict["mean_fd"],
                 "max_fd": fd_dict["max_fd"],
                 "rms_fd": fd_dict["rms_fd"],
             }
         )
     else:
+        axis_index = {dim: i for i, dim in enumerate(spatial_dims)}
         df = pd.DataFrame(
             {
-                "rot_x": params[:, 0],
-                "rot_y": params[:, 1],
-                "rot_z": params[:, 2],
-                "trans_x": params[:, 3],
-                "trans_y": params[:, 4],
-                "trans_z": params[:, 5],
+                "rot_x": params[:, axis_index["x"]],
+                "rot_y": params[:, axis_index["y"]],
+                "rot_z": params[:, axis_index["z"]],
+                "trans_x": params[:, 3 + axis_index["x"]],
+                "trans_y": params[:, 3 + axis_index["y"]],
+                "trans_z": params[:, 3 + axis_index["z"]],
                 "mean_fd": fd_dict["mean_fd"],
                 "max_fd": fd_dict["max_fd"],
                 "rms_fd": fd_dict["rms_fd"],

--- a/src/confusius/registration/motion.py
+++ b/src/confusius/registration/motion.py
@@ -185,8 +185,7 @@ def _get_motion_parameter_columns(
     Raises
     ------
     ValueError
-        If `params` does not have 3 or 6 columns, or if `reference` collapses to fewer
-        than two effective spatial axes.
+        If `params` does not have 3 or 6 columns.
     """
     spatial_dims = tuple(str(dim) for dim in reference.dims)
     axis_index = {dim: i for i, dim in enumerate(spatial_dims)}
@@ -202,21 +201,6 @@ def _get_motion_parameter_columns(
         raise ValueError(
             f"Expected motion parameters with 3 or 6 columns, got {params.shape[1]}."
         )
-
-    non_singleton_dims = [dim for dim in spatial_dims if reference.sizes[dim] > 1]
-    singleton_dims = [dim for dim in spatial_dims if reference.sizes[dim] == 1]
-
-    if singleton_dims:
-        if len(non_singleton_dims) < 2:
-            raise ValueError(
-                "Motion diagnostics require at least two non-singleton spatial axes."
-            )
-        collapsed_dim = singleton_dims[0]
-        columns: list[tuple[str, int]] = [("rotation", axis_index[collapsed_dim])]
-        for dim in ("x", "y", "z"):
-            if dim in non_singleton_dims:
-                columns.append((f"trans_{dim}", 3 + axis_index[dim]))
-        return columns
 
     columns = []
     for dim in ("x", "y", "z"):
@@ -334,20 +318,20 @@ def create_motion_dataframe(
     Returns
     -------
     pandas.DataFrame
-        DataFrame with columns:
+        DataFrame with columns determined by the affine dimensionality.
 
-        Effective 2D (a true 2D image, or a 3D image with any singleton spatial axis):
+        2D affines:
 
         - `rotation`: In-plane rotation angle in radians.
-        - `trans_<dim>`: Translation along each non-singleton in-plane spatial axis
-          (mm), for example `trans_x` and `trans_y` for `(z=1, y, x)` data.
+        - `trans_x, trans_y`: Translations along the DataArray's `x` and `y` axes
+          (mm).
 
-        True 3D:
+        3D affines:
 
         - `rot_x, rot_y, rot_z`: Rotation angles around the DataArray's
           `x`, `y`, and `z` axes, in radians.
         - `trans_x, trans_y, trans_z`: Translations along the DataArray's
-          `x`, `y`, and `z` axes (mm).
+          `x`, `y`, and `z` axes (mm), even when one spatial axis is singleton.
 
         Both:
         - `mean_fd`: Mean framewise displacement (mm).

--- a/src/confusius/registration/motion.py
+++ b/src/confusius/registration/motion.py
@@ -97,6 +97,14 @@ def extract_motion_parameters(
 
         - For 2D: `n_params = 3 (rotation, t0, t1)`.
         - For 3D: `n_params = 6 (r0, r1, r2, t0, t1, t2)`.
+
+    Raises
+    ------
+    ValueError
+        If `affines` is empty, contains a non-square array, an affine that is not
+        `(3, 3)` or `(4, 4)`, or mixes 2D and 3D affines.
+    TypeError
+        If any affine entry is not a `numpy.ndarray`.
     """
     import math
 
@@ -242,6 +250,15 @@ def compute_framewise_displacement(
         - `"max_fd"`: Maximum framewise displacement per frame.
         - `"rms_fd"`: RMS framewise displacement per frame.
 
+    Raises
+    ------
+    ValueError
+        If `reference` fails fUSI validation, if `affines` is empty, contains an
+        affine that is not `(3, 3)` or `(4, 4)`, or mixes 2D and 3D affines, or if
+        `reference`'s dimensionality does not match the affine dimensionality.
+    TypeError
+        If any affine entry is not a `numpy.ndarray`.
+
     References
     ----------
     [^1]:
@@ -355,6 +372,15 @@ def create_motion_dataframe(
         Motion columns are reported in named-axis order (`x`, `y`, `z`), even when
         the input DataArray stores its spatial dimensions in a different order such as
         `(z, y, x)`.
+
+    Raises
+    ------
+    ValueError
+        If `reference` fails fUSI validation, if `affines` is empty, contains an
+        affine that is not `(3, 3)` or `(4, 4)`, or mixes 2D and 3D affines, or if
+        `reference`'s dimensionality does not match the affine dimensionality.
+    TypeError
+        If any affine entry is not a `numpy.ndarray`.
     """
     import pandas as pd
 

--- a/src/confusius/registration/motion.py
+++ b/src/confusius/registration/motion.py
@@ -281,20 +281,22 @@ def compute_framewise_displacement(
     if mask is not None:
         points = points[mask.ravel()]
 
-    transformed = []
-    for affine in affines_validated:
-        pts_out = (affine[:ndim, :ndim] @ points.T).T + affine[:ndim, ndim]
-        transformed.append(pts_out)
-
     mean_fd = np.zeros(n_frames)
     max_fd = np.zeros(n_frames)
     rms_fd = np.zeros(n_frames)
 
+    # Framewise displacement is strictly pairwise, so transform one frame at a time and
+    # retain only the previous frame's points instead of every frame's transformed grid.
+    first = affines_validated[0]
+    prev_pts = (first[:ndim, :ndim] @ points.T).T + first[:ndim, ndim]
     for t in range(n_frames - 1):
-        displacements = np.linalg.norm(transformed[t + 1] - transformed[t], axis=1)
+        nxt = affines_validated[t + 1]
+        next_pts = (nxt[:ndim, :ndim] @ points.T).T + nxt[:ndim, ndim]
+        displacements = np.linalg.norm(next_pts - prev_pts, axis=1)
         mean_fd[t] = np.mean(displacements)
         max_fd[t] = np.max(displacements)
         rms_fd[t] = np.sqrt(np.mean(displacements**2))
+        prev_pts = next_pts
 
     mean_fd[-1] = 0.0
     max_fd[-1] = 0.0

--- a/src/confusius/registration/motion.py
+++ b/src/confusius/registration/motion.py
@@ -39,7 +39,7 @@ def _validate_affines(
     TypeError
         If any entry is not a `numpy.ndarray`.
     """
-    if not affines:
+    if len(affines) == 0:
         raise ValueError("affines must contain at least one affine matrix.")
 
     validated: list[NDArray[np.floating]] = []
@@ -191,11 +191,11 @@ def _get_motion_parameter_columns(
     axis_index = {dim: i for i, dim in enumerate(spatial_dims)}
 
     if params.shape[1] == 3:
-        return [
-            ("rotation", 0),
-            ("trans_x", 1 + axis_index["x"]),
-            ("trans_y", 1 + axis_index["y"]),
-        ]
+        columns: list[tuple[str, int]] = [("rotation", 0)]
+        for dim in ("x", "y", "z"):
+            if dim in axis_index:
+                columns.append((f"trans_{dim}", 1 + axis_index[dim]))
+        return columns
 
     if params.shape[1] != 6:
         raise ValueError(
@@ -256,7 +256,12 @@ def compute_framewise_displacement(
 
     affines_validated = _validate_affines(affines)
     n_frames = len(affines_validated)
-    ndim = reference.ndim
+    ndim = affines_validated[0].shape[0] - 1
+    if reference.ndim != ndim:
+        raise ValueError(
+            "reference dimensionality must match affine dimensionality, got "
+            f"reference.ndim={reference.ndim} and affine ndim={ndim}."
+        )
 
     coords_1d = [
         np.asarray(reference.coords[str(dim)].values, dtype=float)
@@ -323,8 +328,8 @@ def create_motion_dataframe(
         2D affines:
 
         - `rotation`: In-plane rotation angle in radians.
-        - `trans_x, trans_y`: Translations along the DataArray's `x` and `y` axes
-          (mm).
+        - `trans_<dim>`: Translations along the DataArray's two named spatial axes
+          (mm), reported in named-axis order.
 
         3D affines:
 

--- a/src/confusius/registration/motion.py
+++ b/src/confusius/registration/motion.py
@@ -6,38 +6,97 @@ from typing import TYPE_CHECKING
 import numpy as np
 from numpy.typing import NDArray
 
-from confusius.registration.affines import decompose_affine
+from confusius.registration.affines import (
+    decompose_affine,
+    get_euler_xyz_from_rotation_matrix,
+)
 
 if TYPE_CHECKING:
     import pandas as pd
     import xarray as xr
 
 
+def _validate_affines(
+    affines: Sequence[NDArray[np.floating]],
+) -> list[NDArray[np.floating]]:
+    """Return validated affine matrices for motion diagnostics.
+
+    Parameters
+    ----------
+    affines : list[numpy.ndarray]
+        Candidate affine matrices.
+
+    Returns
+    -------
+    list[numpy.ndarray]
+        Validated affine matrices.
+
+    Raises
+    ------
+    ValueError
+        If `affines` is empty, contains non-square arrays, unsupported affine shapes,
+        or mixes 2D and 3D affines.
+    TypeError
+        If any entry is not a `numpy.ndarray`.
+    """
+    if not affines:
+        raise ValueError("affines must contain at least one affine matrix.")
+
+    validated: list[NDArray[np.floating]] = []
+    ndim: int | None = None
+
+    for i, affine in enumerate(affines):
+        if not isinstance(affine, np.ndarray):
+            raise TypeError(
+                f"affines[{i}] must be a numpy.ndarray, got {type(affine).__name__}."
+            )
+        if affine.ndim != 2 or affine.shape[0] != affine.shape[1]:
+            raise ValueError(
+                f"affines[{i}] must be a square 2D array, got shape {affine.shape}."
+            )
+
+        affine_ndim = affine.shape[0] - 1
+        if affine_ndim not in (2, 3):
+            raise ValueError(
+                f"affines[{i}] must have shape (3, 3) or (4, 4), got {affine.shape}."
+            )
+
+        if ndim is None:
+            ndim = affine_ndim
+        elif affine_ndim != ndim:
+            raise ValueError(
+                "affines must all have the same dimensionality, got both "
+                f"{ndim}D and {affine_ndim}D affines."
+            )
+        validated.append(affine)
+
+    return validated
+
+
 def extract_motion_parameters(
-    affines: Sequence[NDArray[np.floating] | None],
+    affines: Sequence[NDArray[np.floating]],
 ) -> NDArray[np.floating]:
     """Extract motion parameters from affine matrices.
 
     Decomposes each `(N+1, N+1)` homogeneous affine into translation and
     rotation parameters.
 
-    For 2D transforms, extracts: `[rotation, translation_x, translation_y]`.
+    For 2D transforms, extracts: `[rotation, translation_0, translation_1]`.
     For 3D transforms, extracts:
-    `[rot_x, rot_y, rot_z, trans_x, trans_y, trans_z]`.
+    `[rotation_0, rotation_1, rotation_2, translation_0, translation_1, translation_2]`.
 
     Parameters
     ----------
-    affines : list[numpy.ndarray | None]
-        List of affine matrices from registration. `None` entries (e.g. from
-        B-spline transforms) are treated as identity transforms.
+    affines : list[numpy.ndarray]
+        List of affine matrices from registration.
 
     Returns
     -------
     (n_frames, n_params) numpy.ndarray
-        Motion parameters array.
+        Motion parameters array in raw transform-component order.
 
-        - For 2D: `n_params = 3 (rotation, tx, ty)`.
-        - For 3D: `n_params = 6 (rot_x, rot_y, rot_z, trans_x, trans_y, trans_z)`.
+        - For 2D: `n_params = 3 (rotation, t0, t1)`.
+        - For 3D: `n_params = 6 (r0, r1, r2, t0, t1, t2)`.
 
     Raises
     ------
@@ -46,19 +105,11 @@ def extract_motion_parameters(
     """
     import math
 
+    affines_validated = _validate_affines(affines)
     params_list = []
 
-    for affine in affines:
-        if affine is None:
-            # Non-linear (e.g. B-spline): treat as identity (zero motion). Dimension is
-            # unknown; append a placeholder and fix after loop.
-            params_list.append(None)
-            continue
-
+    for affine in affines_validated:
         ndim = affine.shape[0] - 1
-        if ndim not in (2, 3):
-            msg = f"Expected 2D or 3D affine, got shape {affine.shape}"
-            raise ValueError(msg)
 
         T, R, _Z, _S = (
             decompose_affine(affine) if ndim == 3 else _decompose_affine_2d(affine)
@@ -70,35 +121,16 @@ def extract_motion_parameters(
             params_list.append([rotation, float(T[0]), float(T[1])])
         else:
             # Decompose the 3D rotation matrix into Euler angles (XYZ convention).
-            rot_x, rot_y, rot_z = _rotation_matrix_to_euler_xyz(R)
+            rot_x, rot_y, rot_z = get_euler_xyz_from_rotation_matrix(R)
             params_list.append(
                 [rot_x, rot_y, rot_z, float(T[0]), float(T[1]), float(T[2])]
             )
 
-    # Resolve None placeholders: infer dimensionality from the first non-None entry.
-    ndim_inferred: int | None = None
-    for p in params_list:
-        if p is not None:
-            # 3 params → 2D, 6 params → 3D.
-            ndim_inferred = 2 if len(p) == 3 else 3
-            break
-
-    if ndim_inferred is None:
-        # All transforms are None; default to 3D identity.
-        ndim_inferred = 3
-
-    zero_2d = [0.0, 0.0, 0.0]
-    zero_3d = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
-    # ndim_inferred is spatial dimensionality (2 or 3), not n_params.
-    n_params = 3 if ndim_inferred == 2 else 6
-    resolved = [
-        p if p is not None else (zero_2d if n_params == 3 else zero_3d)
-        for p in params_list
-    ]
-
-    return np.array(resolved)
+    return np.array(params_list)
 
 
+# TODO: Temporary, to be removed once we enforce minimum dimensionality of 3D for all
+# fUSI DataArrays.
 def _decompose_affine_2d(
     A33: NDArray[np.floating],
 ) -> tuple[
@@ -140,43 +172,69 @@ def _decompose_affine_2d(
     return T, R, np.array([sx, sy]), np.array([sxy])
 
 
-def _rotation_matrix_to_euler_xyz(
-    R: NDArray[np.floating],
-) -> tuple[float, float, float]:
-    """Extract XYZ Euler angles from a (3, 3) rotation matrix.
+def _get_motion_parameter_columns(
+    reference: "xr.DataArray", params: NDArray[np.floating]
+) -> list[tuple[str, int]]:
+    """Return `(column_name, param_index)` pairs for `create_motion_dataframe`.
 
     Parameters
     ----------
-    R : (3, 3) numpy.ndarray
-        Rotation matrix.
+    reference : xarray.DataArray
+        Spatial reference DataArray whose dims and sizes define the named axes.
+    params : numpy.ndarray
+        Motion parameter array returned by `extract_motion_parameters`.
 
     Returns
     -------
-    rot_x, rot_y, rot_z : float
-        Rotation angles around X, Y, Z axes (radians).
+    list[tuple[str, int]]
+        Output motion columns paired with the source index in `params`.
+
+    Raises
+    ------
+    ValueError
+        If `params` does not have 3 or 6 columns, or if `reference` collapses to fewer
+        than two effective spatial axes.
     """
-    import math
+    spatial_dims = tuple(str(dim) for dim in reference.dims)
+    axis_index = {dim: i for i, dim in enumerate(spatial_dims)}
 
-    # XYZ convention: R = Rz @ Ry @ Rx
-    # R[2,0] = -sin(rot_y)
-    sy = -R[2, 0]
-    sy = max(-1.0, min(1.0, sy))
-    rot_y = math.asin(sy)
+    if params.shape[1] == 3:
+        return [
+            ("rotation", 0),
+            ("trans_x", 1 + axis_index["x"]),
+            ("trans_y", 1 + axis_index["y"]),
+        ]
 
-    cos_y = math.cos(rot_y)
-    if abs(cos_y) > 1e-6:
-        rot_x = math.atan2(R[2, 1], R[2, 2])
-        rot_z = math.atan2(R[1, 0], R[0, 0])
-    else:
-        # Gimbal lock: set rot_x = 0 and compute rot_z.
-        rot_x = 0.0
-        rot_z = math.atan2(-R[0, 1], R[1, 1])
+    if params.shape[1] != 6:
+        raise ValueError(
+            f"Expected motion parameters with 3 or 6 columns, got {params.shape[1]}."
+        )
 
-    return rot_x, rot_y, rot_z
+    non_singleton_dims = [dim for dim in spatial_dims if reference.sizes[dim] > 1]
+    singleton_dims = [dim for dim in spatial_dims if reference.sizes[dim] == 1]
+
+    if singleton_dims:
+        if len(non_singleton_dims) < 2:
+            raise ValueError(
+                "Motion diagnostics require at least two non-singleton spatial axes."
+            )
+        collapsed_dim = singleton_dims[0]
+        columns: list[tuple[str, int]] = [("rotation", axis_index[collapsed_dim])]
+        for dim in ("x", "y", "z"):
+            if dim in non_singleton_dims:
+                columns.append((f"trans_{dim}", 3 + axis_index[dim]))
+        return columns
+
+    columns = []
+    for dim in ("x", "y", "z"):
+        columns.append((f"rot_{dim}", axis_index[dim]))
+    for dim in ("x", "y", "z"):
+        columns.append((f"trans_{dim}", 3 + axis_index[dim]))
+    return columns
 
 
 def compute_framewise_displacement(
-    affines: Sequence[NDArray[np.floating] | None],
+    affines: Sequence[NDArray[np.floating]],
     reference: "xr.DataArray",
     mask: NDArray[np.bool_] | None = None,
 ) -> dict[str, NDArray[np.floating]]:
@@ -189,9 +247,8 @@ def compute_framewise_displacement(
 
     Parameters
     ----------
-    affines : list[numpy.ndarray | None]
-        List of affine matrices, one per frame. `None` entries are treated as identity
-        transforms.
+    affines : list[numpy.ndarray]
+        List of affine matrices, one per frame.
     reference : xarray.DataArray
         Spatial DataArray defining the physical grid (spacing and origin derived from
         its coordinates).
@@ -220,7 +277,8 @@ def compute_framewise_displacement(
         regular_spacing_dims="space",
     )
 
-    n_frames = len(affines)
+    affines_validated = _validate_affines(affines)
+    n_frames = len(affines_validated)
     ndim = reference.ndim
 
     coords_1d = [
@@ -235,12 +293,10 @@ def compute_framewise_displacement(
         mask_flat = mask.ravel()
         points = points[mask_flat]
 
-    eye = np.eye(ndim + 1)
     transformed = []
-    for affine in affines:
-        A = affine if affine is not None else eye
+    for affine in affines_validated:
         # Apply affine: p_out = A[:ndim, :ndim] @ p.T + A[:ndim, ndim]
-        pts_out = (A[:ndim, :ndim] @ points.T).T + A[:ndim, ndim]
+        pts_out = (affine[:ndim, :ndim] @ points.T).T + affine[:ndim, ndim]
         transformed.append(pts_out)
 
     mean_fd = np.zeros(n_frames)
@@ -266,7 +322,7 @@ def compute_framewise_displacement(
 
 
 def create_motion_dataframe(
-    affines: Sequence[NDArray[np.floating] | None],
+    affines: Sequence[NDArray[np.floating]],
     reference: "xr.DataArray",
     mask: NDArray[np.bool_] | None = None,
     time_coords: NDArray[np.floating] | None = None,
@@ -275,9 +331,8 @@ def create_motion_dataframe(
 
     Parameters
     ----------
-    affines : list[numpy.ndarray | None]
-        List of affine matrices from registration. `None` entries (e.g. from B-spline
-        transforms) are treated as identity.
+    affines : list[numpy.ndarray]
+        List of affine matrices from registration.
     reference : xarray.DataArray
         Spatial DataArray defining the physical grid for framewise displacement
         computation.
@@ -291,13 +346,13 @@ def create_motion_dataframe(
     pandas.DataFrame
         DataFrame with columns:
 
-        For 2D:
+        Effective 2D (a true 2D image, or a 3D image with any singleton spatial axis):
 
-        - `rotation`: Rotation angle in radians.
-        - `trans_x`: Translation along the DataArray's `x` axis (mm).
-        - `trans_y`: Translation along the DataArray's `y` axis (mm).
+        - `rotation`: In-plane rotation angle in radians.
+        - `trans_<dim>`: Translation along each non-singleton in-plane spatial axis
+          (mm), for example `trans_x` and `trans_y` for `(z=1, y, x)` data.
 
-        For 3D:
+        True 3D:
 
         - `rot_x, rot_y, rot_z`: Rotation angles around the DataArray's
           `x`, `y`, and `z` axes, in radians.
@@ -316,38 +371,20 @@ def create_motion_dataframe(
     import pandas as pd
 
     params = extract_motion_parameters(affines)
-
     fd_dict = compute_framewise_displacement(affines, reference, mask)
 
-    spatial_dims = tuple(str(dim) for dim in reference.dims)
-
-    if params.shape[1] == 3:
-        axis_index = {dim: i for i, dim in enumerate(spatial_dims)}
-        df = pd.DataFrame(
-            {
-                "rotation": params[:, 0],
-                "trans_x": params[:, 1 + axis_index["x"]],
-                "trans_y": params[:, 1 + axis_index["y"]],
-                "mean_fd": fd_dict["mean_fd"],
-                "max_fd": fd_dict["max_fd"],
-                "rms_fd": fd_dict["rms_fd"],
-            }
-        )
-    else:
-        axis_index = {dim: i for i, dim in enumerate(spatial_dims)}
-        df = pd.DataFrame(
-            {
-                "rot_x": params[:, axis_index["x"]],
-                "rot_y": params[:, axis_index["y"]],
-                "rot_z": params[:, axis_index["z"]],
-                "trans_x": params[:, 3 + axis_index["x"]],
-                "trans_y": params[:, 3 + axis_index["y"]],
-                "trans_z": params[:, 3 + axis_index["z"]],
-                "mean_fd": fd_dict["mean_fd"],
-                "max_fd": fd_dict["max_fd"],
-                "rms_fd": fd_dict["rms_fd"],
-            }
-        )
+    motion_data = {
+        name: params[:, index]
+        for name, index in _get_motion_parameter_columns(reference, params)
+    }
+    df = pd.DataFrame(
+        {
+            **motion_data,
+            "mean_fd": fd_dict["mean_fd"],
+            "max_fd": fd_dict["max_fd"],
+            "rms_fd": fd_dict["rms_fd"],
+        }
+    )
 
     if time_coords is not None:
         df.index = time_coords

--- a/src/confusius/registration/motion.py
+++ b/src/confusius/registration/motion.py
@@ -241,6 +241,13 @@ def compute_framewise_displacement(
         - `"mean_fd"`: Mean framewise displacement per frame.
         - `"max_fd"`: Maximum framewise displacement per frame.
         - `"rms_fd"`: RMS framewise displacement per frame.
+
+    References
+    ----------
+    [^1]:
+        Power, J. D., Barnes, K. A., Snyder, A. Z., Schlaggar, B. L. & Petersen, S. E.
+        Spurious but systematic correlations in functional connectivity MRI networks
+        arise from subject motion. Neuroimage 59, 2142-2154
     """
     from confusius.validation import validate_fusi_dataarray
 

--- a/src/confusius/registration/motion.py
+++ b/src/confusius/registration/motion.py
@@ -6,10 +6,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 from numpy.typing import NDArray
 
-from confusius.registration.affines import (
-    decompose_affine,
-    get_euler_xyz_from_rotation_matrix,
-)
+from confusius.registration.affines import decompose_affine
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -122,12 +119,58 @@ def extract_motion_parameters(
             rotation = math.atan2(R[1, 0], R[0, 0])
             params_list.append([rotation, float(T[0]), float(T[1])])
         else:
-            rot_x, rot_y, rot_z = get_euler_xyz_from_rotation_matrix(R)
+            rot_0, rot_1, rot_2 = _get_euler_xyz_from_rotation_matrix(R)
             params_list.append(
-                [rot_x, rot_y, rot_z, float(T[0]), float(T[1]), float(T[2])]
+                [rot_0, rot_1, rot_2, float(T[0]), float(T[1]), float(T[2])]
             )
 
     return np.array(params_list)
+
+
+def _get_euler_xyz_from_rotation_matrix(
+    R: NDArray[np.floating],
+) -> tuple[float, float, float]:
+    """Get XYZ Euler angles from a 3D rotation matrix.
+
+    Parameters
+    ----------
+    R : (3, 3) numpy.ndarray
+        Rotation matrix.
+
+    Returns
+    -------
+    rot_0 : float
+        First XYZ Euler angle in radians.
+    rot_1 : float
+        Second XYZ Euler angle in radians.
+    rot_2 : float
+        Third XYZ Euler angle in radians.
+
+    Raises
+    ------
+    ValueError
+        If `R` is not a `(3, 3)` array.
+    """
+    import math
+
+    if R.shape != (3, 3):
+        raise ValueError(f"Expected a (3, 3) rotation matrix, got {R.shape}.")
+
+    # XYZ convention: R = Rz @ Ry @ Rx.
+    sy = -R[2, 0]
+    sy = max(-1.0, min(1.0, sy))
+    rot_1 = math.asin(sy)
+
+    cos_y = math.cos(rot_1)
+    if abs(cos_y) > 1e-6:
+        rot_0 = math.atan2(R[2, 1], R[2, 2])
+        rot_2 = math.atan2(R[1, 0], R[0, 0])
+    else:
+        # Gimbal lock: set the first angle to zero and recover the third.
+        rot_0 = 0.0
+        rot_2 = math.atan2(-R[0, 1], R[1, 1])
+
+    return rot_0, rot_1, rot_2
 
 
 # TODO: Temporary, to be removed once we enforce minimum dimensionality of 3D for all

--- a/src/confusius/registration/volumewise.py
+++ b/src/confusius/registration/volumewise.py
@@ -189,7 +189,7 @@ def register_volumewise(
 
     with progress_context:
         results = cast(
-            "list[tuple[xr.DataArray, npt.NDArray[np.floating] | None, RegistrationDiagnostics]]",  # noqa: E501
+            "list[tuple[xr.DataArray, npt.NDArray[np.floating], RegistrationDiagnostics]]",  # noqa: E501
             Parallel(n_jobs=n_jobs)(
                 delayed(register_volume)(
                     volume,
@@ -219,7 +219,7 @@ def register_volumewise(
 
     arr = data_moved.values
     output = np.zeros_like(arr)
-    affines: list[npt.NDArray[np.floating] | None] = []
+    affines: list[npt.NDArray[np.floating]] = []
     final_metric_values: list[float] = []
     n_iterations_per_frame: list[int] = []
     diagnostics: list[RegistrationDiagnostics] = []

--- a/tests/unit/test_plotting/test_motion.py
+++ b/tests/unit/test_plotting/test_motion.py
@@ -1,0 +1,57 @@
+"""Unit tests for motion diagnostics plotting."""
+
+import matplotlib.pyplot as plt
+import pandas as pd
+
+from confusius.plotting import plot_motion_diagnostics
+
+
+class TestPlotMotionDiagnostics:
+    """Tests for `plot_motion_diagnostics`."""
+
+    def test_effective_2d_motion_dataframe(self):
+        """Effective 2D motion tables plot rotation, translation, and optimizer panels."""
+        motion_df = pd.DataFrame(
+            {
+                "rotation": [0.0, 0.1],
+                "trans_x": [0.0, 1.0],
+                "trans_y": [0.0, 2.0],
+                "mean_fd": [0.5, 0.0],
+                "max_fd": [1.0, 0.0],
+                "final_metric_value": [-1.0, -0.9],
+                "n_iterations": [10, 12],
+            },
+            index=pd.Index([0.0, 0.5], name="time"),
+        )
+
+        fig, axes = plot_motion_diagnostics(motion_df)
+
+        assert len(axes) == 4
+        assert axes[0].get_ylabel() == "Rotation (deg)"
+        assert axes[1].get_ylabel() == "Translation (mm)"
+        assert axes[2].get_ylabel() == "Displacement (mm)"
+        assert axes[-1].get_xlabel() == "Time (s)"
+        plt.close(fig)
+
+    def test_true_3d_motion_dataframe(self):
+        """True 3D motion tables plot all standard panels."""
+        motion_df = pd.DataFrame(
+            {
+                "rot_x": [0.0, 0.1],
+                "rot_y": [0.0, 0.2],
+                "rot_z": [0.0, 0.3],
+                "trans_x": [0.0, 1.0],
+                "trans_y": [0.0, 2.0],
+                "trans_z": [0.0, 3.0],
+                "mean_fd": [0.5, 0.0],
+                "max_fd": [1.0, 0.0],
+                "rms_fd": [0.7, 0.0],
+            },
+            index=pd.Index([0, 1], name="frame"),
+        )
+
+        fig, axes = plot_motion_diagnostics(motion_df)
+
+        assert len(axes) == 3
+        assert axes[-1].get_xlabel() == "Frame"
+        plt.close(fig)

--- a/tests/unit/test_plotting/test_motion.py
+++ b/tests/unit/test_plotting/test_motion.py
@@ -2,12 +2,34 @@
 
 import matplotlib.pyplot as plt
 import pandas as pd
+import pytest
 
 from confusius.plotting import plot_motion_diagnostics
 
 
 class TestPlotMotionDiagnostics:
     """Tests for `plot_motion_diagnostics`."""
+
+    def test_rejects_dataframe_without_supported_columns(self):
+        """A motion table needs at least one supported diagnostics column."""
+        motion_df = pd.DataFrame(index=pd.Index([0, 1], name="frame"))
+
+        with pytest.raises(ValueError, match="supported diagnostics columns"):
+            plot_motion_diagnostics(motion_df)
+
+    def test_optimizer_iterations_only_uses_single_axis(self):
+        """Optimizer-only tables still produce a single panel without twinned axes."""
+        motion_df = pd.DataFrame(
+            {"n_iterations": [10, 12]},
+            index=pd.Index([0, 1], name="frame"),
+        )
+
+        fig, axes = plot_motion_diagnostics(motion_df)
+
+        assert len(axes) == 1
+        assert axes[0].get_ylabel() == "Iterations"
+        assert len(fig.axes) == 1
+        plt.close(fig)
 
     def test_effective_2d_motion_dataframe(self):
         """Effective 2D motion tables plot rotation, translation, and optimizer panels."""

--- a/tests/unit/test_registration/test_affines.py
+++ b/tests/unit/test_registration/test_affines.py
@@ -9,6 +9,7 @@ from numpy.testing import assert_array_almost_equal, assert_array_equal
 from scipy.spatial.transform import Rotation
 
 from confusius.registration.affines import (
+    affine_to_sitk_linear_transform,
     compose_affine,
     decompose_affine,
     get_euler_xyz_from_rotation_matrix,
@@ -26,6 +27,26 @@ class TestCompose:
         Z = np.ones(3)
         with pytest.raises(ValueError, match="Expected shape"):
             compose_affine(T, R, Z)
+
+    def test_without_shear_uses_plain_rotation_and_zoom(self):
+        """Omitting shear keeps the affine equal to `R @ diag(Z)` plus translation."""
+        T = np.array([1.0, 2.0, 3.0])
+        R = Rotation.from_euler("xyz", [0.1, 0.2, 0.3]).as_matrix()
+        Z = np.array([2.0, 3.0, 4.0])
+
+        affine = compose_affine(T, R, Z)
+
+        assert_array_almost_equal(affine[:3, :3], R @ np.diag(Z))
+        assert_array_equal(affine[:3, 3], T)
+
+    def test_invalid_shear_length_raises(self):
+        """Shear vectors must have a triangular-number length."""
+        T = np.zeros(3)
+        R = np.eye(3)
+        Z = np.ones(3)
+
+        with pytest.raises(ValueError, match="strange number of shear elements"):
+            compose_affine(T, R, Z, np.array([0.1, 0.2]))
 
 
 class TestGetEulerXYZFromRotationMatrix:
@@ -45,9 +66,55 @@ class TestGetEulerXYZFromRotationMatrix:
         with pytest.raises(ValueError, match=r"\(3, 3\)"):
             get_euler_xyz_from_rotation_matrix(np.eye(4))
 
+    def test_handles_gimbal_lock(self):
+        """The gimbal-lock branch still returns stable XYZ angles."""
+        angles = (0.4, np.pi / 2, -0.2)
+        matrix = Rotation.from_euler("xyz", angles).as_matrix()
+
+        rot_x, rot_y, rot_z = get_euler_xyz_from_rotation_matrix(matrix)
+
+        assert rot_x == 0.0
+        assert_array_almost_equal((rot_y, rot_z), (np.pi / 2, -0.6))
+
 
 class TestSitkLinearTransformToAffine:
     """Tests for `sitk_linear_transform_to_affine`."""
+
+    def test_affine_to_sitk_linear_transform_round_trips(self):
+        """Affine matrices round-trip through SimpleITK affine transforms."""
+        affine = np.array(
+            [
+                [1.0, 0.1, 0.0, 2.0],
+                [0.0, 1.5, 0.2, 3.0],
+                [0.0, 0.0, 2.0, 4.0],
+                [0.0, 0.0, 0.0, 1.0],
+            ]
+        )
+
+        sitk_transform = affine_to_sitk_linear_transform(affine)
+
+        assert_array_almost_equal(sitk_linear_transform_to_affine(sitk_transform), affine)
+
+    def test_composite_transform_multiplies_child_affines_in_order(self):
+        """Composite transforms compose child affines in SimpleITK's application order."""
+        import SimpleITK as sitk
+
+        outer = sitk.TranslationTransform(3)
+        outer.SetOffset((1.0, 2.0, 3.0))
+        inner = sitk.Euler3DTransform()
+        inner.SetRotation(0.05, 0.0, 0.0)
+        inner.SetTranslation((0.5, 0.0, 0.0))
+
+        composite = sitk.CompositeTransform(3)
+        composite.AddTransform(outer)
+        composite.AddTransform(inner)
+
+        expected = (
+            sitk_linear_transform_to_affine(outer)
+            @ sitk_linear_transform_to_affine(inner)
+        )
+
+        assert_array_almost_equal(sitk_linear_transform_to_affine(composite), expected)
 
     def test_identity_transform_returns_identity_affine(self):
         """Identity-like transforms convert to identity matrices."""
@@ -109,3 +176,12 @@ class TestDecompose44:
             M[-1] = [0, 0, 0, 1]
             T, R, Z, S = decompose_affine(M)
             assert_array_almost_equal(compose_affine(T, R, Z, S), M)
+
+    def test_negative_determinant_flips_first_zoom_not_rotation(self):
+        """Reflections are represented with a negative zoom and a proper rotation."""
+        affine = np.diag([-2.0, 3.0, 4.0, 1.0])
+
+        _T, R, Z, _S = decompose_affine(affine)
+
+        assert np.linalg.det(R) > 0
+        assert Z[0] < 0

--- a/tests/unit/test_registration/test_affines.py
+++ b/tests/unit/test_registration/test_affines.py
@@ -7,7 +7,11 @@ import pytest
 from numpy.testing import assert_array_almost_equal, assert_array_equal
 from scipy.spatial.transform import Rotation
 
-from confusius.registration.affines import compose_affine, decompose_affine
+from confusius.registration.affines import (
+    compose_affine,
+    decompose_affine,
+    get_euler_xyz_from_rotation_matrix,
+)
 
 
 class TestCompose:
@@ -20,6 +24,24 @@ class TestCompose:
         Z = np.ones(3)
         with pytest.raises(ValueError, match="Expected shape"):
             compose_affine(T, R, Z)
+
+
+class TestGetEulerXYZFromRotationMatrix:
+    """Tests for `get_euler_xyz_from_rotation_matrix`."""
+
+    def test_matches_scipy_for_random_rotations(self):
+        """Extracted XYZ angles match SciPy away from singularities."""
+        rng = np.random.default_rng(42)
+        for _ in range(50):
+            angles = rng.uniform(-1.2, 1.2, size=3)
+            matrix = Rotation.from_euler("xyz", angles).as_matrix()
+            recovered = get_euler_xyz_from_rotation_matrix(matrix)
+            assert_array_almost_equal(recovered, angles)
+
+    def test_rejects_wrong_shape(self):
+        """Only 3x3 rotation matrices are accepted."""
+        with pytest.raises(ValueError, match=r"\(3, 3\)"):
+            get_euler_xyz_from_rotation_matrix(np.eye(4))
 
 
 class TestDecompose44:

--- a/tests/unit/test_registration/test_affines.py
+++ b/tests/unit/test_registration/test_affines.py
@@ -1,6 +1,7 @@
 """Unit tests for affine matrix decomposition utilities."""
 
 from itertools import permutations
+from typing import Any, cast
 
 import numpy as np
 import pytest
@@ -11,6 +12,7 @@ from confusius.registration.affines import (
     compose_affine,
     decompose_affine,
     get_euler_xyz_from_rotation_matrix,
+    sitk_linear_transform_to_affine,
 )
 
 
@@ -42,6 +44,37 @@ class TestGetEulerXYZFromRotationMatrix:
         """Only 3x3 rotation matrices are accepted."""
         with pytest.raises(ValueError, match=r"\(3, 3\)"):
             get_euler_xyz_from_rotation_matrix(np.eye(4))
+
+
+class TestSitkLinearTransformToAffine:
+    """Tests for `sitk_linear_transform_to_affine`."""
+
+    def test_identity_transform_returns_identity_affine(self):
+        """Identity-like transforms convert to identity matrices."""
+
+        class IdentityTransformStub:
+            def GetDimension(self):
+                return 3
+
+            def GetName(self):
+                return "IdentityTransform"
+
+        affine = sitk_linear_transform_to_affine(cast(Any, IdentityTransformStub()))
+
+        assert_array_equal(affine, np.eye(4))
+
+    def test_unsupported_transform_type_raises(self):
+        """Unexpected transform types raise a clear error."""
+
+        class UnsupportedTransformStub:
+            def GetDimension(self):
+                return 3
+
+            def GetName(self):
+                return "ScaleTransform"
+
+        with pytest.raises(ValueError, match="unsupported transform type"):
+            sitk_linear_transform_to_affine(cast(Any, UnsupportedTransformStub()))
 
 
 class TestDecompose44:

--- a/tests/unit/test_registration/test_affines.py
+++ b/tests/unit/test_registration/test_affines.py
@@ -12,7 +12,6 @@ from confusius.registration.affines import (
     affine_to_sitk_linear_transform,
     compose_affine,
     decompose_affine,
-    get_euler_xyz_from_rotation_matrix,
     sitk_linear_transform_to_affine,
 )
 
@@ -47,34 +46,6 @@ class TestCompose:
 
         with pytest.raises(ValueError, match="strange number of shear elements"):
             compose_affine(T, R, Z, np.array([0.1, 0.2]))
-
-
-class TestGetEulerXYZFromRotationMatrix:
-    """Tests for `get_euler_xyz_from_rotation_matrix`."""
-
-    def test_matches_scipy_for_random_rotations(self):
-        """Extracted XYZ angles match SciPy away from singularities."""
-        rng = np.random.default_rng(42)
-        for _ in range(50):
-            angles = rng.uniform(-1.2, 1.2, size=3)
-            matrix = Rotation.from_euler("xyz", angles).as_matrix()
-            recovered = get_euler_xyz_from_rotation_matrix(matrix)
-            assert_array_almost_equal(recovered, angles)
-
-    def test_rejects_wrong_shape(self):
-        """Only 3x3 rotation matrices are accepted."""
-        with pytest.raises(ValueError, match=r"\(3, 3\)"):
-            get_euler_xyz_from_rotation_matrix(np.eye(4))
-
-    def test_handles_gimbal_lock(self):
-        """The gimbal-lock branch still returns stable XYZ angles."""
-        angles = (0.4, np.pi / 2, -0.2)
-        matrix = Rotation.from_euler("xyz", angles).as_matrix()
-
-        rot_x, rot_y, rot_z = get_euler_xyz_from_rotation_matrix(matrix)
-
-        assert rot_x == 0.0
-        assert_array_almost_equal((rot_y, rot_z), (np.pi / 2, -0.6))
 
 
 class TestSitkLinearTransformToAffine:

--- a/tests/unit/test_registration/test_motion.py
+++ b/tests/unit/test_registration/test_motion.py
@@ -67,6 +67,13 @@ class TestValidateAffines:
         with pytest.raises(ValueError, match="at least one"):
             _validate_affines([])
 
+    def test_rejects_empty_affine_ndarray(self):
+        """An empty ndarray of affines is rejected cleanly."""
+        import pytest
+
+        with pytest.raises(ValueError, match="at least one"):
+            _validate_affines(cast(Any, np.empty((0, 3, 3))))
+
     def test_rejects_non_numpy_affine(self):
         """Affine entries must already be numpy arrays."""
         import pytest
@@ -197,6 +204,15 @@ class TestComputeFramewiseDisplacement:
 
         assert_allclose(fd["mean_fd"][0], 5.0, atol=1e-6)
 
+    def test_rejects_reference_affine_dimensionality_mismatch(
+        self, sample_2d_dataarray_spatial
+    ):
+        """Reference dimensionality must match affine dimensionality."""
+        import pytest
+
+        with pytest.raises(ValueError, match="dimensionality must match"):
+            compute_framewise_displacement([np.eye(4)], sample_2d_dataarray_spatial)
+
 
 class TestCreateMotionDataframe:
     """Tests for create_motion_dataframe function."""
@@ -294,6 +310,22 @@ class TestCreateMotionDataframe:
 
         assert_allclose(df.iloc[1]["trans_x"], 3.0, atol=1e-6)
         assert_allclose(df.iloc[1]["trans_y"], 2.0, atol=1e-6)
+
+    def test_2d_dataframe_uses_present_named_axes(self, sample_2d_dataarray_spatial):
+        """2D tables use the spatial axes actually present in the reference."""
+        ref = _with_spatial_dims(sample_2d_dataarray_spatial, ("z", "x"))
+        df = create_motion_dataframe([np.eye(3), _translation_affine_2d(2.0, 3.0)], ref)
+
+        assert list(df.columns) == [
+            "rotation",
+            "trans_x",
+            "trans_z",
+            "mean_fd",
+            "max_fd",
+            "rms_fd",
+        ]
+        assert_allclose(df.iloc[1]["trans_x"], 3.0, atol=1e-6)
+        assert_allclose(df.iloc[1]["trans_z"], 2.0, atol=1e-6)
 
     def test_3d_dataframe_reorders_translations_to_named_axes(
         self, sample_3d_dataarray_spatial

--- a/tests/unit/test_registration/test_motion.py
+++ b/tests/unit/test_registration/test_motion.py
@@ -217,56 +217,53 @@ class TestCreateMotionDataframe:
         assert list(df.columns) == expected_cols
         assert len(df) == 2
 
-    def test_singleton_z_dataframe_uses_effective_2d_columns(
+    def test_singleton_z_dataframe_keeps_all_3d_motion_columns(
         self, sample_3d_dataarray_spatial
     ):
-        """A singleton z axis collapses to effective 2D motion columns."""
+        """A singleton z axis still reports the full 3D motion summary."""
         ref = _with_singleton_dim(sample_3d_dataarray_spatial, "z")
         df = create_motion_dataframe(
             [np.eye(4), _translation_affine_3d(1.0, 2.0, 3.0)], ref
         )
 
         assert list(df.columns) == [
-            "rotation",
+            "rot_x",
+            "rot_y",
+            "rot_z",
             "trans_x",
-            "trans_y",
-            "mean_fd",
-            "max_fd",
-            "rms_fd",
-        ]
-        assert_allclose(df.iloc[1]["trans_x"], 3.0, atol=1e-6)
-        assert_allclose(df.iloc[1]["trans_y"], 2.0, atol=1e-6)
-
-    def test_singleton_x_dataframe_uses_effective_2d_columns(
-        self, sample_3d_dataarray_spatial
-    ):
-        """Any singleton spatial axis collapses to effective 2D motion columns."""
-        ref = _with_singleton_dim(sample_3d_dataarray_spatial, "x")
-        df = create_motion_dataframe(
-            [np.eye(4), _translation_affine_3d(1.0, 2.0, 3.0)], ref
-        )
-
-        assert list(df.columns) == [
-            "rotation",
             "trans_y",
             "trans_z",
             "mean_fd",
             "max_fd",
             "rms_fd",
         ]
+        assert_allclose(df.iloc[1]["trans_x"], 3.0, atol=1e-6)
         assert_allclose(df.iloc[1]["trans_y"], 2.0, atol=1e-6)
         assert_allclose(df.iloc[1]["trans_z"], 1.0, atol=1e-6)
 
-    def test_too_many_singleton_axes_raise_error(self, sample_3d_dataarray_spatial):
-        """Effective motion summaries need at least two non-singleton spatial axes."""
-        import pytest
-
-        ref = _with_singleton_dim(
-            _with_singleton_dim(sample_3d_dataarray_spatial, "z"), "y"
+    def test_singleton_x_dataframe_keeps_all_3d_motion_columns(
+        self, sample_3d_dataarray_spatial
+    ):
+        """Any singleton spatial axis still reports the full 3D motion summary."""
+        ref = _with_singleton_dim(sample_3d_dataarray_spatial, "x")
+        df = create_motion_dataframe(
+            [np.eye(4), _translation_affine_3d(1.0, 2.0, 3.0)], ref
         )
 
-        with pytest.raises(ValueError, match="at least two non-singleton"):
-            create_motion_dataframe([np.eye(4)], ref)
+        assert list(df.columns) == [
+            "rot_x",
+            "rot_y",
+            "rot_z",
+            "trans_x",
+            "trans_y",
+            "trans_z",
+            "mean_fd",
+            "max_fd",
+            "rms_fd",
+        ]
+        assert_allclose(df.iloc[1]["trans_x"], 3.0, atol=1e-6)
+        assert_allclose(df.iloc[1]["trans_y"], 2.0, atol=1e-6)
+        assert_allclose(df.iloc[1]["trans_z"], 1.0, atol=1e-6)
 
     def test_3d_dataframe_columns(self, sample_3d_dataarray_spatial):
         """3D affines produce DataFrame with correct columns."""

--- a/tests/unit/test_registration/test_motion.py
+++ b/tests/unit/test_registration/test_motion.py
@@ -1,9 +1,12 @@
 """Unit tests for motion parameter estimation functions."""
 
+from typing import Any, cast
+
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
 
 from confusius.registration.motion import (
+    _validate_affines,
     compute_framewise_displacement,
     create_motion_dataframe,
     extract_motion_parameters,
@@ -12,7 +15,9 @@ from confusius.registration.motion import (
 
 def _with_spatial_dims(reference, dims):
     """Return `reference` with reordered spatial dim names and matching coords."""
-    return reference.rename(dict(zip(reference.dims, dims, strict=True))).transpose(*dims)
+    return reference.rename(dict(zip(reference.dims, dims, strict=True))).transpose(
+        *dims
+    )
 
 
 def _translation_affine_2d(tx, ty):
@@ -43,6 +48,45 @@ def _rotation_affine_3d_first_axis(angle):
         ]
     )
     return A
+
+
+def _with_singleton_dim(reference, dim):
+    """Return `reference` with `dim` reduced to length 1 but preserved."""
+    reduced = reference.isel({dim: [0]})
+    reduced.coords[dim].attrs["voxdim"] = 1.0
+    return reduced
+
+
+class TestValidateAffines:
+    """Tests for affine validation used by motion diagnostics."""
+
+    def test_rejects_empty_affine_list(self):
+        """At least one affine matrix is required."""
+        import pytest
+
+        with pytest.raises(ValueError, match="at least one"):
+            _validate_affines([])
+
+    def test_rejects_non_numpy_affine(self):
+        """Affine entries must already be numpy arrays."""
+        import pytest
+
+        with pytest.raises(TypeError, match="numpy.ndarray"):
+            _validate_affines(cast(Any, [[[1, 0, 0], [0, 1, 0], [0, 0, 1]]]))
+
+    def test_rejects_wrong_affine_shape(self):
+        """Only homogeneous 2D and 3D affine shapes are accepted."""
+        import pytest
+
+        with pytest.raises(ValueError, match=r"shape \(3, 3\) or \(4, 4\)"):
+            _validate_affines([np.eye(5)])
+
+    def test_rejects_mixed_affine_dimensionality(self):
+        """All affine matrices must have the same dimensionality."""
+        import pytest
+
+        with pytest.raises(ValueError, match="same dimensionality"):
+            _validate_affines([np.eye(3), np.eye(4)])
 
 
 class TestExtractMotionParameters:
@@ -89,12 +133,6 @@ class TestExtractMotionParameters:
         assert_allclose(params[0], [0.0, 0.0, 0.0], atol=1e-6)
         assert_allclose(params[1, 1:], [2.0, 3.0], atol=1e-6)
 
-    def test_none_affine_treated_as_identity(self):
-        """None entry (e.g. B-spline) is treated as identity (zero motion)."""
-        params = extract_motion_parameters([None, np.eye(3)])
-        assert params.shape == (2, 3)
-        assert_allclose(params[0], [0.0, 0.0, 0.0], atol=1e-6)
-
 
 class TestComputeFramewiseDisplacement:
     """Tests for compute_framewise_displacement function."""
@@ -136,17 +174,11 @@ class TestComputeFramewiseDisplacement:
         t2 = _translation_affine_2d(3.0, 4.0)  # distance = 5.0
         mask = np.zeros(sample_2d_dataarray_spatial.shape, dtype=bool)
         mask[2:8, 2:8] = True
-        fd = compute_framewise_displacement([t1, t2], sample_2d_dataarray_spatial, mask=mask)
+        fd = compute_framewise_displacement(
+            [t1, t2], sample_2d_dataarray_spatial, mask=mask
+        )
 
         # Pure translation: same displacement regardless of mask.
-        assert_allclose(fd["mean_fd"][0], 5.0, atol=1e-6)
-
-    def test_none_affine_treated_as_identity(self, sample_2d_dataarray_spatial):
-        """None affine treated as identity: displacement equals the other transform."""
-        t1 = None  # identity
-        t2 = _translation_affine_2d(3.0, 4.0)  # distance = 5.0
-        fd = compute_framewise_displacement([t1, t2], sample_2d_dataarray_spatial)
-
         assert_allclose(fd["mean_fd"][0], 5.0, atol=1e-6)
 
 
@@ -168,6 +200,46 @@ class TestCreateMotionDataframe:
         ]
         assert list(df.columns) == expected_cols
         assert len(df) == 2
+
+    def test_singleton_z_dataframe_uses_effective_2d_columns(
+        self, sample_3d_dataarray_spatial
+    ):
+        """A singleton z axis collapses to effective 2D motion columns."""
+        ref = _with_singleton_dim(sample_3d_dataarray_spatial, "z")
+        df = create_motion_dataframe(
+            [np.eye(4), _translation_affine_3d(1.0, 2.0, 3.0)], ref
+        )
+
+        assert list(df.columns) == [
+            "rotation",
+            "trans_x",
+            "trans_y",
+            "mean_fd",
+            "max_fd",
+            "rms_fd",
+        ]
+        assert_allclose(df.iloc[1]["trans_x"], 3.0, atol=1e-6)
+        assert_allclose(df.iloc[1]["trans_y"], 2.0, atol=1e-6)
+
+    def test_singleton_x_dataframe_uses_effective_2d_columns(
+        self, sample_3d_dataarray_spatial
+    ):
+        """Any singleton spatial axis collapses to effective 2D motion columns."""
+        ref = _with_singleton_dim(sample_3d_dataarray_spatial, "x")
+        df = create_motion_dataframe(
+            [np.eye(4), _translation_affine_3d(1.0, 2.0, 3.0)], ref
+        )
+
+        assert list(df.columns) == [
+            "rotation",
+            "trans_y",
+            "trans_z",
+            "mean_fd",
+            "max_fd",
+            "rms_fd",
+        ]
+        assert_allclose(df.iloc[1]["trans_y"], 2.0, atol=1e-6)
+        assert_allclose(df.iloc[1]["trans_z"], 1.0, atol=1e-6)
 
     def test_3d_dataframe_columns(self, sample_3d_dataarray_spatial):
         """3D affines produce DataFrame with correct columns."""

--- a/tests/unit/test_registration/test_motion.py
+++ b/tests/unit/test_registration/test_motion.py
@@ -15,7 +15,9 @@ from confusius.registration.motion import (
 
 def _with_spatial_dims(reference, dims):
     """Return `reference` with reordered spatial dim names and matching coords."""
-    return reference.rename(dict(zip(reference.dims, dims, strict=True))).transpose(*dims)
+    return reference.rename(dict(zip(reference.dims, dims, strict=True))).transpose(
+        *dims
+    )
 
 
 def _translation_affine_2d(tx, ty):
@@ -72,6 +74,13 @@ class TestValidateAffines:
         with pytest.raises(TypeError, match="numpy.ndarray"):
             _validate_affines(cast(Any, [[[1, 0, 0], [0, 1, 0], [0, 0, 1]]]))
 
+    def test_rejects_non_square_affine_array(self):
+        """Affine matrices must be square 2D arrays."""
+        import pytest
+
+        with pytest.raises(ValueError, match="square 2D array"):
+            _validate_affines([np.zeros((3, 4))])
+
     def test_rejects_wrong_affine_shape(self):
         """Only homogeneous 2D and 3D affine shapes are accepted."""
         import pytest
@@ -105,6 +114,17 @@ class TestExtractMotionParameters:
         params = extract_motion_parameters([np.eye(3)])
         assert params.shape == (1, 3)
         assert_allclose(params[0], [0.0, 0.0, 0.0], atol=1e-6)
+
+    def test_2d_reflection_affine_keeps_valid_rotation_and_translation(self):
+        """2D reflection-like affines still return stable motion parameters."""
+        affine = np.eye(3)
+        affine[0, 0] = -1.0
+        affine[0, 2] = 1.0
+        affine[1, 2] = 2.0
+
+        params = extract_motion_parameters([affine])
+
+        assert_allclose(params[0], [0.0, 1.0, 2.0], atol=1e-6)
 
     def test_3d_translation_only(self):
         """3D pure translation extracts [0, 0, 0, tx, ty, tz]."""
@@ -237,6 +257,17 @@ class TestCreateMotionDataframe:
         assert_allclose(df.iloc[1]["trans_y"], 2.0, atol=1e-6)
         assert_allclose(df.iloc[1]["trans_z"], 1.0, atol=1e-6)
 
+    def test_too_many_singleton_axes_raise_error(self, sample_3d_dataarray_spatial):
+        """Effective motion summaries need at least two non-singleton spatial axes."""
+        import pytest
+
+        ref = _with_singleton_dim(
+            _with_singleton_dim(sample_3d_dataarray_spatial, "z"), "y"
+        )
+
+        with pytest.raises(ValueError, match="at least two non-singleton"):
+            create_motion_dataframe([np.eye(4)], ref)
+
     def test_3d_dataframe_columns(self, sample_3d_dataarray_spatial):
         """3D affines produce DataFrame with correct columns."""
         t1 = np.eye(4)
@@ -293,6 +324,28 @@ class TestCreateMotionDataframe:
         assert_allclose(df.iloc[1]["rot_x"], 0.0, atol=1e-6)
         assert_allclose(df.iloc[1]["rot_y"], 0.0, atol=1e-6)
         assert_allclose(df.iloc[1]["rot_z"], angle, atol=1e-6)
+
+    def test_rejects_unexpected_parameter_count(
+        self, monkeypatch, sample_2d_dataarray_spatial
+    ):
+        """Unexpected motion-parameter widths are rejected."""
+        import pytest
+
+        monkeypatch.setattr(
+            "confusius.registration.motion.extract_motion_parameters",
+            lambda affines: np.zeros((1, 4)),
+        )
+        monkeypatch.setattr(
+            "confusius.registration.motion.compute_framewise_displacement",
+            lambda affines, reference, mask=None: {
+                "mean_fd": np.zeros(1),
+                "max_fd": np.zeros(1),
+                "rms_fd": np.zeros(1),
+            },
+        )
+
+        with pytest.raises(ValueError, match="3 or 6 columns"):
+            create_motion_dataframe([np.eye(3)], sample_2d_dataarray_spatial)
 
     def test_time_coords_as_index(self, sample_2d_dataarray_spatial):
         """Time coordinates are used as DataFrame index."""

--- a/tests/unit/test_registration/test_motion.py
+++ b/tests/unit/test_registration/test_motion.py
@@ -10,28 +10,20 @@ from confusius.registration.motion import (
 )
 
 
-def _make_ref_da(size, spacing=1.0, ndim=2):
+def _make_ref_da(size, spacing=1.0, ndim=2, dims=None):
     """Create a spatial DataArray for FD reference."""
     import xarray as xr
 
     if ndim == 2:
-        return xr.DataArray(
-            np.zeros(size),
-            dims=("y", "x"),
-            coords={
-                "y": np.arange(size[0]) * spacing,
-                "x": np.arange(size[1]) * spacing,
-            },
-        )
-    return xr.DataArray(
-        np.zeros(size),
-        dims=("z", "y", "x"),
-        coords={
-            "z": np.arange(size[0]) * spacing,
-            "y": np.arange(size[1]) * spacing,
-            "x": np.arange(size[2]) * spacing,
-        },
-    )
+        if dims is None:
+            dims = ("y", "x")
+        coords = {dim: np.arange(size[i]) * spacing for i, dim in enumerate(dims)}
+        return xr.DataArray(np.zeros(size), dims=dims, coords=coords)
+
+    if dims is None:
+        dims = ("z", "y", "x")
+    coords = {dim: np.arange(size[i]) * spacing for i, dim in enumerate(dims)}
+    return xr.DataArray(np.zeros(size), dims=dims, coords=coords)
 
 
 def _translation_affine_2d(tx, ty):
@@ -45,9 +37,22 @@ def _translation_affine_2d(tx, ty):
 def _translation_affine_3d(tx, ty, tz):
     """Return a (4, 4) 3D translation affine."""
     A = np.eye(4)
-    A[0, 2] = tx
-    A[1, 2] = ty
-    A[2, 2] = tz
+    A[:3, 3] = [tx, ty, tz]
+    return A
+
+
+def _rotation_affine_3d_first_axis(angle):
+    """Return a (4, 4) 3D rotation affine around the first axis."""
+    A = np.eye(4)
+    c = np.cos(angle)
+    s = np.sin(angle)
+    A[:3, :3] = np.array(
+        [
+            [1.0, 0.0, 0.0],
+            [0.0, c, -s],
+            [0.0, s, c],
+        ]
+    )
     return A
 
 
@@ -202,6 +207,37 @@ class TestCreateMotionDataframe:
         ]
         assert list(df.columns) == expected_cols
 
+    def test_2d_dataframe_reorders_translations_to_named_axes(self):
+        """2D translations follow x/y names, not raw axis order."""
+        ref = _make_ref_da((10, 10), spacing=1.0, dims=("y", "x"))
+        df = create_motion_dataframe([np.eye(3), _translation_affine_2d(2.0, 3.0)], ref)
+
+        assert_allclose(df.iloc[1]["trans_x"], 3.0, atol=1e-6)
+        assert_allclose(df.iloc[1]["trans_y"], 2.0, atol=1e-6)
+
+    def test_3d_dataframe_reorders_translations_to_named_axes(self):
+        """3D translations follow x/y/z names, not raw axis order."""
+        ref = _make_ref_da((8, 8, 8), spacing=1.0, ndim=3, dims=("z", "y", "x"))
+        df = create_motion_dataframe(
+            [np.eye(4), _translation_affine_3d(1.0, 2.0, 3.0)], ref
+        )
+
+        assert_allclose(df.iloc[1]["trans_x"], 3.0, atol=1e-6)
+        assert_allclose(df.iloc[1]["trans_y"], 2.0, atol=1e-6)
+        assert_allclose(df.iloc[1]["trans_z"], 1.0, atol=1e-6)
+
+    def test_3d_dataframe_reorders_rotations_to_named_axes(self):
+        """3D rotations follow x/y/z names, not raw axis order."""
+        ref = _make_ref_da((8, 8, 8), spacing=1.0, ndim=3, dims=("z", "y", "x"))
+        angle = 0.1
+        df = create_motion_dataframe(
+            [np.eye(4), _rotation_affine_3d_first_axis(angle)], ref
+        )
+
+        assert_allclose(df.iloc[1]["rot_x"], 0.0, atol=1e-6)
+        assert_allclose(df.iloc[1]["rot_y"], 0.0, atol=1e-6)
+        assert_allclose(df.iloc[1]["rot_z"], angle, atol=1e-6)
+
     def test_time_coords_as_index(self):
         """Time coordinates are used as DataFrame index."""
         ref = _make_ref_da((10, 10), spacing=1.0)
@@ -220,7 +256,7 @@ class TestCreateMotionDataframe:
 
     def test_motion_values_correct(self):
         """Motion parameter values are correctly populated."""
-        ref = _make_ref_da((10, 10), spacing=1.0)
+        ref = _make_ref_da((10, 10), spacing=1.0, dims=("x", "y"))
         affines = [np.eye(3), _translation_affine_2d(2.0, 3.0)]
         df = create_motion_dataframe(affines, ref)
 

--- a/tests/unit/test_registration/test_motion.py
+++ b/tests/unit/test_registration/test_motion.py
@@ -4,6 +4,7 @@ from typing import Any, cast
 
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
+from scipy.spatial.transform import Rotation
 
 from confusius.registration.motion import (
     _validate_affines,
@@ -157,6 +158,25 @@ class TestExtractMotionParameters:
         assert params.shape == (2, 3)
         assert_allclose(params[0], [0.0, 0.0, 0.0], atol=1e-6)
         assert_allclose(params[1, 1:], [2.0, 3.0], atol=1e-6)
+
+    def test_3d_rotation_matches_xyz_component_order(self):
+        """3D rotations stay in raw XYZ component order."""
+        angles = np.array([0.2, -0.3, 0.4])
+        affine = np.eye(4)
+        affine[:3, :3] = Rotation.from_euler("xyz", angles).as_matrix()
+
+        params = extract_motion_parameters([affine])
+
+        assert_allclose(params[0, :3], angles, atol=1e-6)
+
+    def test_3d_gimbal_lock_keeps_stable_angles(self):
+        """The gimbal-lock branch still returns stable XYZ angles."""
+        affine = np.eye(4)
+        affine[:3, :3] = Rotation.from_euler("xyz", [0.4, np.pi / 2, -0.2]).as_matrix()
+
+        params = extract_motion_parameters([affine])
+
+        assert_allclose(params[0, :3], [0.0, np.pi / 2, -0.6], atol=1e-6)
 
 
 class TestComputeFramewiseDisplacement:

--- a/tests/unit/test_registration/test_motion.py
+++ b/tests/unit/test_registration/test_motion.py
@@ -178,6 +178,23 @@ class TestExtractMotionParameters:
 
         assert_allclose(params[0, :3], [0.0, np.pi / 2, -0.6], atol=1e-6)
 
+    def test_3d_rejects_non_3x3_rotation_from_decomposition(self, monkeypatch):
+        """Malformed decompositions are rejected when extracting 3D rotations."""
+        import pytest
+
+        monkeypatch.setattr(
+            "confusius.registration.motion.decompose_affine",
+            lambda affine: (
+                np.zeros(3),
+                np.eye(2),
+                np.ones(3),
+                np.zeros(3),
+            ),
+        )
+
+        with pytest.raises(ValueError, match=r"\(3, 3\)"):
+            extract_motion_parameters([np.eye(4)])
+
 
 class TestComputeFramewiseDisplacement:
     """Tests for compute_framewise_displacement function."""

--- a/tests/unit/test_registration/test_motion.py
+++ b/tests/unit/test_registration/test_motion.py
@@ -10,20 +10,9 @@ from confusius.registration.motion import (
 )
 
 
-def _make_ref_da(size, spacing=1.0, ndim=2, dims=None):
-    """Create a spatial DataArray for FD reference."""
-    import xarray as xr
-
-    if ndim == 2:
-        if dims is None:
-            dims = ("y", "x")
-        coords = {dim: np.arange(size[i]) * spacing for i, dim in enumerate(dims)}
-        return xr.DataArray(np.zeros(size), dims=dims, coords=coords)
-
-    if dims is None:
-        dims = ("z", "y", "x")
-    coords = {dim: np.arange(size[i]) * spacing for i, dim in enumerate(dims)}
-    return xr.DataArray(np.zeros(size), dims=dims, coords=coords)
+def _with_spatial_dims(reference, dims):
+    """Return `reference` with reordered spatial dim names and matching coords."""
+    return reference.rename(dict(zip(reference.dims, dims, strict=True))).transpose(*dims)
 
 
 def _translation_affine_2d(tx, ty):
@@ -110,22 +99,20 @@ class TestExtractMotionParameters:
 class TestComputeFramewiseDisplacement:
     """Tests for compute_framewise_displacement function."""
 
-    def test_identical_transforms_zero_fd(self):
+    def test_identical_transforms_zero_fd(self, sample_2d_dataarray_spatial):
         """Identical affines produce zero framewise displacement."""
-        ref = _make_ref_da((10, 10), spacing=1.0)
         affines = [np.eye(3), np.eye(3)]
-        fd = compute_framewise_displacement(affines, ref)
+        fd = compute_framewise_displacement(affines, sample_2d_dataarray_spatial)
 
         assert_allclose(fd["mean_fd"], [0.0, 0.0])
         assert_allclose(fd["max_fd"], [0.0, 0.0])
         assert_allclose(fd["rms_fd"], [0.0, 0.0])
 
-    def test_known_translation_displacement_2d(self):
+    def test_known_translation_displacement_2d(self, sample_2d_dataarray_spatial):
         """Known 2D translation produces correct FD (Euclidean distance)."""
-        ref = _make_ref_da((10, 10), spacing=1.0)
         t1 = np.eye(3)
         t2 = _translation_affine_2d(3.0, 4.0)  # distance = 5.0
-        fd = compute_framewise_displacement([t1, t2], ref)
+        fd = compute_framewise_displacement([t1, t2], sample_2d_dataarray_spatial)
 
         # Pure translation: all voxels displace equally.
         assert_allclose(fd["mean_fd"][0], 5.0, atol=1e-6)
@@ -133,35 +120,32 @@ class TestComputeFramewiseDisplacement:
         assert_allclose(fd["rms_fd"][0], 5.0, atol=1e-6)
         assert fd["mean_fd"][-1] == 0.0
 
-    def test_known_translation_displacement_3d(self):
+    def test_known_translation_displacement_3d(self, sample_3d_dataarray_spatial):
         """Known 3D translation produces correct FD."""
-        ref = _make_ref_da((8, 8, 8), spacing=1.0, ndim=3)
         t1 = np.eye(4)
         t2 = np.eye(4)
         t2[:3, 3] = [1.0, 2.0, 2.0]  # distance = 3.0
-        fd = compute_framewise_displacement([t1, t2], ref)
+        fd = compute_framewise_displacement([t1, t2], sample_3d_dataarray_spatial)
 
         assert_allclose(fd["mean_fd"][0], 3.0, atol=1e-6)
         assert_allclose(fd["max_fd"][0], 3.0, atol=1e-6)
 
-    def test_with_mask(self):
+    def test_with_mask(self, sample_2d_dataarray_spatial):
         """Mask restricts FD computation to masked voxels."""
-        ref = _make_ref_da((10, 10), spacing=1.0)
         t1 = np.eye(3)
         t2 = _translation_affine_2d(3.0, 4.0)  # distance = 5.0
-        mask = np.zeros((10, 10), dtype=bool)
+        mask = np.zeros(sample_2d_dataarray_spatial.shape, dtype=bool)
         mask[2:8, 2:8] = True
-        fd = compute_framewise_displacement([t1, t2], ref, mask=mask)
+        fd = compute_framewise_displacement([t1, t2], sample_2d_dataarray_spatial, mask=mask)
 
         # Pure translation: same displacement regardless of mask.
         assert_allclose(fd["mean_fd"][0], 5.0, atol=1e-6)
 
-    def test_none_affine_treated_as_identity(self):
+    def test_none_affine_treated_as_identity(self, sample_2d_dataarray_spatial):
         """None affine treated as identity: displacement equals the other transform."""
-        ref = _make_ref_da((10, 10), spacing=1.0)
         t1 = None  # identity
         t2 = _translation_affine_2d(3.0, 4.0)  # distance = 5.0
-        fd = compute_framewise_displacement([t1, t2], ref)
+        fd = compute_framewise_displacement([t1, t2], sample_2d_dataarray_spatial)
 
         assert_allclose(fd["mean_fd"][0], 5.0, atol=1e-6)
 
@@ -169,11 +153,10 @@ class TestComputeFramewiseDisplacement:
 class TestCreateMotionDataframe:
     """Tests for create_motion_dataframe function."""
 
-    def test_2d_dataframe_columns(self):
+    def test_2d_dataframe_columns(self, sample_2d_dataarray_spatial):
         """2D affines produce DataFrame with correct columns."""
-        ref = _make_ref_da((10, 10), spacing=1.0)
         affines = [np.eye(3), _translation_affine_2d(2.0, 3.0)]
-        df = create_motion_dataframe(affines, ref)
+        df = create_motion_dataframe(affines, sample_2d_dataarray_spatial)
 
         expected_cols = [
             "rotation",
@@ -186,13 +169,12 @@ class TestCreateMotionDataframe:
         assert list(df.columns) == expected_cols
         assert len(df) == 2
 
-    def test_3d_dataframe_columns(self):
+    def test_3d_dataframe_columns(self, sample_3d_dataarray_spatial):
         """3D affines produce DataFrame with correct columns."""
-        ref = _make_ref_da((8, 8, 8), spacing=1.0, ndim=3)
         t1 = np.eye(4)
         t2 = np.eye(4)
         t2[:3, 3] = [1.0, 2.0, 3.0]
-        df = create_motion_dataframe([t1, t2], ref)
+        df = create_motion_dataframe([t1, t2], sample_3d_dataarray_spatial)
 
         expected_cols = [
             "rot_x",
@@ -207,17 +189,21 @@ class TestCreateMotionDataframe:
         ]
         assert list(df.columns) == expected_cols
 
-    def test_2d_dataframe_reorders_translations_to_named_axes(self):
+    def test_2d_dataframe_reorders_translations_to_named_axes(
+        self, sample_2d_dataarray_spatial
+    ):
         """2D translations follow x/y names, not raw axis order."""
-        ref = _make_ref_da((10, 10), spacing=1.0, dims=("y", "x"))
+        ref = _with_spatial_dims(sample_2d_dataarray_spatial, ("y", "x"))
         df = create_motion_dataframe([np.eye(3), _translation_affine_2d(2.0, 3.0)], ref)
 
         assert_allclose(df.iloc[1]["trans_x"], 3.0, atol=1e-6)
         assert_allclose(df.iloc[1]["trans_y"], 2.0, atol=1e-6)
 
-    def test_3d_dataframe_reorders_translations_to_named_axes(self):
+    def test_3d_dataframe_reorders_translations_to_named_axes(
+        self, sample_3d_dataarray_spatial
+    ):
         """3D translations follow x/y/z names, not raw axis order."""
-        ref = _make_ref_da((8, 8, 8), spacing=1.0, ndim=3, dims=("z", "y", "x"))
+        ref = _with_spatial_dims(sample_3d_dataarray_spatial, ("z", "y", "x"))
         df = create_motion_dataframe(
             [np.eye(4), _translation_affine_3d(1.0, 2.0, 3.0)], ref
         )
@@ -226,9 +212,11 @@ class TestCreateMotionDataframe:
         assert_allclose(df.iloc[1]["trans_y"], 2.0, atol=1e-6)
         assert_allclose(df.iloc[1]["trans_z"], 1.0, atol=1e-6)
 
-    def test_3d_dataframe_reorders_rotations_to_named_axes(self):
+    def test_3d_dataframe_reorders_rotations_to_named_axes(
+        self, sample_3d_dataarray_spatial
+    ):
         """3D rotations follow x/y/z names, not raw axis order."""
-        ref = _make_ref_da((8, 8, 8), spacing=1.0, ndim=3, dims=("z", "y", "x"))
+        ref = _with_spatial_dims(sample_3d_dataarray_spatial, ("z", "y", "x"))
         angle = 0.1
         df = create_motion_dataframe(
             [np.eye(4), _rotation_affine_3d_first_axis(angle)], ref
@@ -238,25 +226,25 @@ class TestCreateMotionDataframe:
         assert_allclose(df.iloc[1]["rot_y"], 0.0, atol=1e-6)
         assert_allclose(df.iloc[1]["rot_z"], angle, atol=1e-6)
 
-    def test_time_coords_as_index(self):
+    def test_time_coords_as_index(self, sample_2d_dataarray_spatial):
         """Time coordinates are used as DataFrame index."""
-        ref = _make_ref_da((10, 10), spacing=1.0)
         affines = [np.eye(3), np.eye(3)]
         time_coords = np.array([0.0, 0.5])
-        df = create_motion_dataframe(affines, ref, time_coords=time_coords)
+        df = create_motion_dataframe(
+            affines, sample_2d_dataarray_spatial, time_coords=time_coords
+        )
 
         assert df.index.name == "time"
         assert_array_equal(df.index, time_coords)
 
-    def test_no_time_coords_uses_frame_index(self):
+    def test_no_time_coords_uses_frame_index(self, sample_2d_dataarray_spatial):
         """Without time coords, index is named 'frame'."""
-        ref = _make_ref_da((10, 10), spacing=1.0)
-        df = create_motion_dataframe([np.eye(3)], ref)
+        df = create_motion_dataframe([np.eye(3)], sample_2d_dataarray_spatial)
         assert df.index.name == "frame"
 
-    def test_motion_values_correct(self):
+    def test_motion_values_correct(self, sample_2d_dataarray_spatial):
         """Motion parameter values are correctly populated."""
-        ref = _make_ref_da((10, 10), spacing=1.0, dims=("x", "y"))
+        ref = _with_spatial_dims(sample_2d_dataarray_spatial, ("x", "y"))
         affines = [np.eye(3), _translation_affine_2d(2.0, 3.0)]
         df = create_motion_dataframe(affines, ref)
 

--- a/tools/prefetch_doc_datasets.py
+++ b/tools/prefetch_doc_datasets.py
@@ -108,6 +108,14 @@ def _prefetch_cybis_pereira() -> None:
         acqs="slice32",
     )
 
+    # docs/examples/registration/volumewise_motion_correction.py
+    fetch_cybis_pereira_2026(
+        datasets="rawdata",
+        subjects="rat75",
+        sessions="20220523",
+        acqs="slice32",
+    )
+
 
 def main() -> None:
     _prefetch_nunez_elizalde()

--- a/tools/prefetch_doc_datasets.py
+++ b/tools/prefetch_doc_datasets.py
@@ -113,6 +113,7 @@ def _prefetch_cybis_pereira() -> None:
         datasets="rawdata",
         subjects="rat75",
         sessions="20220523",
+        datatypes="fusi",
         acqs="slice32",
     )
 

--- a/zensical.toml
+++ b/zensical.toml
@@ -72,6 +72,7 @@ nav = [
         ]},
         { "Registration" = [
             { "Registration of two sessions from the same subject" = "examples/_built/registration/register_volume_same_subject.md" },
+            { "Volumewise motion correction" = "examples/_built/registration/volumewise_motion_correction.md" },
         ]},
         { "Decomposition" = [
             { "PCA on a single fUSI recording" = "examples/_built/decomposition/pca_single_recording.md" },

--- a/zensical.toml
+++ b/zensical.toml
@@ -72,7 +72,7 @@ nav = [
         ]},
         { "Registration" = [
             { "Registration of two sessions from the same subject" = "examples/_built/registration/register_volume_same_subject.md" },
-            { "Volumewise motion correction" = "examples/_built/registration/volumewise_motion_correction.md" },
+            { "Motion correction of a single recording" = "examples/_built/registration/volumewise_motion_correction.md" },
         ]},
         { "Decomposition" = [
             { "PCA on a single fUSI recording" = "examples/_built/decomposition/pca_single_recording.md" },


### PR DESCRIPTION
Adds a gallery example for volumewise motion correction using the same dataset and registration settings as the GUI registration demo.

Also folds in the motion-diagnostics cleanup that the example needed:
- add `confusius.plotting.plot_motion_diagnostics()` for plotting motion summaries
- make `create_motion_dataframe()` label motion columns by named axes
- keep the full affine-dimensional motion summary in the output table (`rotation` + translations for 2D affines, full rotation/translation axes for 3D affines even when one spatial axis is singleton)
- require real affine arrays in motion-diagnostics helpers instead of `None` placeholders
- move Euler-angle extraction to `confusius.registration.affines` and cover the new behavior with unit tests

Closes #282
Closes #98