### PR TITLE
fix(io): handle bad volume timing sidecars

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,10 @@ Current development version for the next ConfUSIus release.
 
 ### :bug: Fixes
 
+- NIfTI loading no longer crashes when a sidecar `VolumeTiming` length disagrees with
+  the actual data. ConfUSIus now ignores the malformed sidecar timing, falls back to
+  `pixdim[4]` when available, and otherwise warns before using frame indices.
+  ([#PR](https://github.com/confusius-tools/confusius/pull/PR)).
 - Motion parameter tables from
   [`create_motion_dataframe`][confusius.registration.create_motion_dataframe] now label
   rotations and translations by the coordinate names `x`/`y`/`z` instead of by raw

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,7 +15,7 @@ Current development version for the next ConfUSIus release.
 - NIfTI loading no longer crashes when a sidecar `VolumeTiming` length disagrees with
   the actual data. ConfUSIus now ignores the malformed sidecar timing, falls back to
   `pixdim[4]` when available, and otherwise warns before using frame indices.
-  ([#PR](https://github.com/confusius-tools/confusius/pull/PR)).
+  ([#304](https://github.com/confusius-tools/confusius/pull/304)).
 - Motion parameter tables from
   [`create_motion_dataframe`][confusius.registration.create_motion_dataframe] now label
   rotations and translations by the coordinate names `x`/`y`/`z` instead of by raw

--- a/src/confusius/io/nifti.py
+++ b/src/confusius/io/nifti.py
@@ -429,7 +429,7 @@ def _create_spatial_coords_from_nifti(
 
 def _validate_volume_timing_length(
     volume_timing: npt.NDArray[np.floating], *, n_time: int
-) -> npt.NDArray[np.floating] | None:
+) -> tuple[npt.NDArray[np.floating] | None, bool]:
     """Validate sidecar `VolumeTiming` against the NIfTI time-axis length.
 
     Parameters
@@ -441,26 +441,28 @@ def _validate_volume_timing_length(
 
     Returns
     -------
-    numpy.ndarray or None
+    volume_timing : numpy.ndarray or None
         `volume_timing` unchanged when its shape and length are valid, or `None` when
         the sidecar values cannot be used safely.
+    length_mismatch : bool
+        Whether the sidecar had a valid 1D shape but the wrong length.
     """
     if volume_timing.ndim != 1 or volume_timing.size == 0:
         warnings.warn(
             "`VolumeTiming` metadata is not a non-empty 1D array. Ignoring it.",
             stacklevel=find_stack_level(),
         )
-        return None
+        return None, False
 
     if volume_timing.size == n_time:
-        return volume_timing
+        return volume_timing, False
 
     warnings.warn(
         f"`VolumeTiming` length ({volume_timing.size}) does not match the data time "
         f"dimension ({n_time}). Ignoring it.",
         stacklevel=find_stack_level(),
     )
-    return None
+    return None, True
 
 
 def _create_temporal_coords_from_nifti(
@@ -530,12 +532,10 @@ def _create_temporal_coords_from_nifti(
     volume_timing_length_mismatch = False
     if "volume_timing" in attrs:
         raw_volume_timing = np.asarray(attrs.pop("volume_timing"), dtype=np.float64)
-        volume_timing_length_mismatch = (
-            raw_volume_timing.ndim == 1
-            and raw_volume_timing.size > 0
-            and raw_volume_timing.size != n_time
+        volume_timing, volume_timing_length_mismatch = _validate_volume_timing_length(
+            raw_volume_timing,
+            n_time=n_time,
         )
-        volume_timing = _validate_volume_timing_length(raw_volume_timing, n_time=n_time)
         if volume_timing is not None:
             time_values = volume_timing
             if time_unit is not None:
@@ -602,16 +602,16 @@ def _create_temporal_coords_from_nifti(
     elif time_values is None and sampling_period_nifti is not None:
         if volume_timing_length_mismatch:
             warnings.warn(
-                f"Ignoring mismatched `VolumeTiming` and using NIfTI header "
-                f"`pixdim[4]` ({sampling_period_nifti}) for timing.",
+                f"Ignoring mismatched `VolumeTiming`; using NIfTI header `pixdim[4]` "
+                f"({sampling_period_nifti}) for timing.",
                 stacklevel=find_stack_level(),
             )
         time_values = sampling_period_nifti * np.arange(n_time)
     elif time_values is None:
         if volume_timing_length_mismatch:
             warnings.warn(
-                "Ignoring mismatched `VolumeTiming`, and NIfTI header `pixdim[4]` is "
-                "not positive. Falling back to frame indices.",
+                "Ignoring mismatched `VolumeTiming`; NIfTI header `pixdim[4]` is not "
+                "positive. Falling back to frame indices.",
                 stacklevel=find_stack_level(),
             )
         time_values = np.arange(n_time, dtype=np.float64)

--- a/src/confusius/io/nifti.py
+++ b/src/confusius/io/nifti.py
@@ -427,6 +427,42 @@ def _create_spatial_coords_from_nifti(
     return coords, extra_attrs
 
 
+def _coerce_volume_timing_length(
+    volume_timing: npt.NDArray[np.floating], *, n_time: int
+) -> npt.NDArray[np.floating] | None:
+    """Coerce sidecar `VolumeTiming` to the NIfTI time-axis length.
+
+    Parameters
+    ----------
+    volume_timing : numpy.ndarray
+        1D `VolumeTiming` values from the sidecar.
+    n_time : int
+        Length of the NIfTI time dimension.
+
+    Returns
+    -------
+    numpy.ndarray or None
+        `volume_timing` unchanged when lengths already match, or `None` when the
+        sidecar values cannot be used safely.
+    """
+    if volume_timing.ndim != 1 or volume_timing.size == 0:
+        warnings.warn(
+            "`volume_timing` metadata is not a non-empty 1D array. Ignoring it.",
+            stacklevel=find_stack_level(),
+        )
+        return None
+
+    if volume_timing.size == n_time:
+        return volume_timing
+
+    warnings.warn(
+        f"`volume_timing` length ({volume_timing.size}) does not match the data "
+        f"time dimension ({n_time}). Falling back to NIfTI header timing.",
+        stacklevel=find_stack_level(),
+    )
+    return None
+
+
 def _create_temporal_coords_from_nifti(
     img: "nib.nifti1.Nifti1Image | nib.nifti2.Nifti2Image",
     extractor: "_NiftiHeaderExtractor",
@@ -490,16 +526,27 @@ def _create_temporal_coords_from_nifti(
             )
         time_attrs["volume_acquisition_duration"] = volume_duration
 
+    time_values: npt.NDArray[np.floating] | None = None
+    volume_timing_length_mismatch = False
     if "volume_timing" in attrs:
-        time_values = np.asarray(attrs.pop("volume_timing"))
-        if time_unit is not None:
-            time_values = convert_time_units(
-                time_values,
-                from_unit="s",
-                to_unit=time_unit,
-                raise_on_unknown=True,
-            )
-    elif "repetition_time" in attrs:
+        raw_volume_timing = np.asarray(attrs.pop("volume_timing"), dtype=np.float64)
+        volume_timing_length_mismatch = (
+            raw_volume_timing.ndim == 1
+            and raw_volume_timing.size > 0
+            and raw_volume_timing.size != n_time
+        )
+        volume_timing = _coerce_volume_timing_length(raw_volume_timing, n_time=n_time)
+        if volume_timing is not None:
+            time_values = volume_timing
+            if time_unit is not None:
+                time_values = convert_time_units(
+                    time_values,
+                    from_unit="s",
+                    to_unit=time_unit,
+                    raise_on_unknown=True,
+                )
+
+    if time_values is None and "repetition_time" in attrs:
         sampling_period_sidecar = float(attrs.pop("repetition_time"))
         delay = float(attrs.pop("delay_after_trigger", 0.0))
         delay_time = float(attrs.pop("delay_time", 0.0))
@@ -552,9 +599,15 @@ def _create_temporal_coords_from_nifti(
                     stacklevel=find_stack_level(),
                 )
         time_values = delay + sampling_period_sidecar * np.arange(n_time)
-    elif sampling_period_nifti is not None:
+    elif time_values is None and sampling_period_nifti is not None:
         time_values = sampling_period_nifti * np.arange(n_time)
-    else:
+    elif time_values is None:
+        if volume_timing_length_mismatch:
+            warnings.warn(
+                "`volume_timing` could not be used, and NIfTI header `pixdim[4]` is "
+                "not positive. Falling back to frame indices.",
+                stacklevel=find_stack_level(),
+            )
         time_values = np.arange(n_time, dtype=np.float64)
 
     coords: dict[str, xr.DataArray] = {

--- a/src/confusius/io/nifti.py
+++ b/src/confusius/io/nifti.py
@@ -427,10 +427,10 @@ def _create_spatial_coords_from_nifti(
     return coords, extra_attrs
 
 
-def _coerce_volume_timing_length(
+def _validate_volume_timing_length(
     volume_timing: npt.NDArray[np.floating], *, n_time: int
 ) -> npt.NDArray[np.floating] | None:
-    """Coerce sidecar `VolumeTiming` to the NIfTI time-axis length.
+    """Validate sidecar `VolumeTiming` against the NIfTI time-axis length.
 
     Parameters
     ----------
@@ -442,12 +442,12 @@ def _coerce_volume_timing_length(
     Returns
     -------
     numpy.ndarray or None
-        `volume_timing` unchanged when lengths already match, or `None` when the
-        sidecar values cannot be used safely.
+        `volume_timing` unchanged when its shape and length are valid, or `None` when
+        the sidecar values cannot be used safely.
     """
     if volume_timing.ndim != 1 or volume_timing.size == 0:
         warnings.warn(
-            "`volume_timing` metadata is not a non-empty 1D array. Ignoring it.",
+            "`VolumeTiming` metadata is not a non-empty 1D array. Ignoring it.",
             stacklevel=find_stack_level(),
         )
         return None
@@ -456,8 +456,9 @@ def _coerce_volume_timing_length(
         return volume_timing
 
     warnings.warn(
-        f"`volume_timing` length ({volume_timing.size}) does not match the data "
-        f"time dimension ({n_time}). Falling back to NIfTI header timing.",
+        f"`VolumeTiming` length ({volume_timing.size}) does not match the data time "
+        f"dimension ({n_time}). Ignoring it and falling back to RepetitionTime, "
+        "NIfTI header timing, or frame indices.",
         stacklevel=find_stack_level(),
     )
     return None
@@ -535,7 +536,7 @@ def _create_temporal_coords_from_nifti(
             and raw_volume_timing.size > 0
             and raw_volume_timing.size != n_time
         )
-        volume_timing = _coerce_volume_timing_length(raw_volume_timing, n_time=n_time)
+        volume_timing = _validate_volume_timing_length(raw_volume_timing, n_time=n_time)
         if volume_timing is not None:
             time_values = volume_timing
             if time_unit is not None:
@@ -604,7 +605,7 @@ def _create_temporal_coords_from_nifti(
     elif time_values is None:
         if volume_timing_length_mismatch:
             warnings.warn(
-                "`volume_timing` could not be used, and NIfTI header `pixdim[4]` is "
+                "`VolumeTiming` could not be used, and NIfTI header `pixdim[4]` is "
                 "not positive. Falling back to frame indices.",
                 stacklevel=find_stack_level(),
             )

--- a/src/confusius/io/nifti.py
+++ b/src/confusius/io/nifti.py
@@ -457,8 +457,7 @@ def _validate_volume_timing_length(
 
     warnings.warn(
         f"`VolumeTiming` length ({volume_timing.size}) does not match the data time "
-        f"dimension ({n_time}). Ignoring it and falling back to RepetitionTime, "
-        "NIfTI header timing, or frame indices.",
+        f"dimension ({n_time}). Ignoring it.",
         stacklevel=find_stack_level(),
     )
     return None
@@ -601,11 +600,17 @@ def _create_temporal_coords_from_nifti(
                 )
         time_values = delay + sampling_period_sidecar * np.arange(n_time)
     elif time_values is None and sampling_period_nifti is not None:
+        if volume_timing_length_mismatch:
+            warnings.warn(
+                f"Ignoring mismatched `VolumeTiming` and using NIfTI header "
+                f"`pixdim[4]` ({sampling_period_nifti}) for timing.",
+                stacklevel=find_stack_level(),
+            )
         time_values = sampling_period_nifti * np.arange(n_time)
     elif time_values is None:
         if volume_timing_length_mismatch:
             warnings.warn(
-                "`VolumeTiming` could not be used, and NIfTI header `pixdim[4]` is "
+                "Ignoring mismatched `VolumeTiming`, and NIfTI header `pixdim[4]` is "
                 "not positive. Falling back to frame indices.",
                 stacklevel=find_stack_level(),
             )

--- a/tests/unit/test_io/test_nifti.py
+++ b/tests/unit/test_io/test_nifti.py
@@ -682,12 +682,8 @@ class TestLoadNifti:
             warnings.simplefilter("always")
             loaded = load_nifti(path)
 
-        assert any(
-            "`VolumeTiming` length" in str(w.message)
-            and "falling back to RepetitionTime, NIfTI header timing, or frame indices"
-            in str(w.message)
-            for w in caught
-        )
+        assert any("`VolumeTiming` length" in str(w.message) for w in caught)
+        assert any("using NIfTI header `pixdim[4]`" in str(w.message) for w in caught)
         np.testing.assert_allclose(loaded.coords["time"].values, [0, 2, 4, 6, 8])
 
     def test_load_nifti_volume_timing_plus_one_entry_falls_back_to_header(
@@ -706,8 +702,12 @@ class TestLoadNifti:
                 f,
             )
 
-        with pytest.warns(UserWarning, match="falling back to RepetitionTime"):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
             loaded = load_nifti(path)
+
+        assert any("`VolumeTiming` length" in str(w.message) for w in caught)
+        assert any("using NIfTI header `pixdim[4]`" in str(w.message) for w in caught)
 
         np.testing.assert_allclose(loaded.coords["time"].values, [0, 2, 4, 6, 8])
 

--- a/tests/unit/test_io/test_nifti.py
+++ b/tests/unit/test_io/test_nifti.py
@@ -665,6 +665,75 @@ class TestLoadNifti:
             [0.0, 1500.0, 2800.0, 4600.0, 6000.0],
         )
 
+    def test_load_nifti_volume_timing_length_mismatch_falls_back_to_header(
+        self, tmp_path: Path
+    ) -> None:
+        """Unrepairable `VolumeTiming` length mismatches are ignored after warning."""
+        data = np.random.default_rng(0).random((2, 3, 4, 5)).astype(np.float32)
+        path = tmp_path / "volume_timing_bad_length.nii.gz"
+        img = nib.Nifti1Image(data, np.eye(4))
+        img.header.set_zooms((1.0, 1.0, 1.0, 2.0))
+        img.to_filename(path)
+
+        with open(tmp_path / "volume_timing_bad_length.json", "w") as f:
+            json.dump({"VolumeTiming": [0.0, 1.0, 2.0]}, f)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            loaded = load_nifti(path)
+
+        assert any(
+            "does not match the data time dimension" in str(w.message) for w in caught
+        )
+        assert any(
+            "Falling back to NIfTI header timing" in str(w.message) for w in caught
+        )
+        np.testing.assert_allclose(loaded.coords["time"].values, [0, 2, 4, 6, 8])
+
+    def test_load_nifti_volume_timing_plus_one_entry_falls_back_to_header(
+        self, tmp_path: Path
+    ) -> None:
+        """An off-by-one `VolumeTiming` sidecar is ignored like any other mismatch."""
+        data = np.random.default_rng(0).random((2, 3, 4, 5)).astype(np.float32)
+        path = tmp_path / "volume_timing_plus_one.nii.gz"
+        img = nib.Nifti1Image(data, np.eye(4))
+        img.header.set_zooms((1.0, 1.0, 1.0, 2.0))
+        img.to_filename(path)
+
+        with open(tmp_path / "volume_timing_plus_one.json", "w") as f:
+            json.dump(
+                {"FrameAcquisitionDuration": 0.25, "VolumeTiming": [0, 1, 2, 3, 4, 5]},
+                f,
+            )
+
+        with pytest.warns(UserWarning, match="Falling back to NIfTI header timing"):
+            loaded = load_nifti(path)
+
+        np.testing.assert_allclose(loaded.coords["time"].values, [0, 2, 4, 6, 8])
+
+    def test_load_nifti_volume_timing_length_mismatch_without_header_tr_uses_indices(
+        self, tmp_path: Path
+    ) -> None:
+        """Mismatched `VolumeTiming` falls back to frame indices when `pixdim[4]` is invalid."""
+        data = np.random.default_rng(0).random((2, 3, 4, 5)).astype(np.float32)
+        path = tmp_path / "volume_timing_bad_length_no_header_tr.nii.gz"
+        img = nib.Nifti1Image(data, np.eye(4))
+        img.header.set_zooms((1.0, 1.0, 1.0, 0.0))
+        img.to_filename(path)
+
+        with open(tmp_path / "volume_timing_bad_length_no_header_tr.json", "w") as f:
+            json.dump({"VolumeTiming": [0.0, 1.0, 2.0]}, f)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            loaded = load_nifti(path)
+
+        assert any(
+            "does not match the data time dimension" in str(w.message) for w in caught
+        )
+        assert any("Falling back to frame indices" in str(w.message) for w in caught)
+        np.testing.assert_allclose(loaded.coords["time"].values, [0, 1, 2, 3, 4])
+
     def test_load_nifti_validation_runtime_error_warns(self, tmp_path: Path) -> None:
         """Unexpected sidecar validation failures degrade to a warning when loading."""
         data = np.random.default_rng(0).random((4, 3, 2)).astype(np.float32)

--- a/tests/unit/test_io/test_nifti.py
+++ b/tests/unit/test_io/test_nifti.py
@@ -683,10 +683,10 @@ class TestLoadNifti:
             loaded = load_nifti(path)
 
         assert any(
-            "does not match the data time dimension" in str(w.message) for w in caught
-        )
-        assert any(
-            "Falling back to NIfTI header timing" in str(w.message) for w in caught
+            "`VolumeTiming` length" in str(w.message)
+            and "falling back to RepetitionTime, NIfTI header timing, or frame indices"
+            in str(w.message)
+            for w in caught
         )
         np.testing.assert_allclose(loaded.coords["time"].values, [0, 2, 4, 6, 8])
 
@@ -706,7 +706,7 @@ class TestLoadNifti:
                 f,
             )
 
-        with pytest.warns(UserWarning, match="Falling back to NIfTI header timing"):
+        with pytest.warns(UserWarning, match="falling back to RepetitionTime"):
             loaded = load_nifti(path)
 
         np.testing.assert_allclose(loaded.coords["time"].values, [0, 2, 4, 6, 8])
@@ -728,9 +728,7 @@ class TestLoadNifti:
             warnings.simplefilter("always")
             loaded = load_nifti(path)
 
-        assert any(
-            "does not match the data time dimension" in str(w.message) for w in caught
-        )
+        assert any("`VolumeTiming` length" in str(w.message) for w in caught)
         assert any("Falling back to frame indices" in str(w.message) for w in caught)
         np.testing.assert_allclose(loaded.coords["time"].values, [0, 1, 2, 3, 4])
 
@@ -751,6 +749,7 @@ class TestLoadNifti:
             warnings.simplefilter("always")
             loaded = load_nifti(path)
 
+        assert any("VolumeTiming" in str(w.message) for w in caught)
         assert any("not a non-empty 1D array" in str(w.message) for w in caught)
         np.testing.assert_allclose(loaded.coords["time"].values, [0, 2, 4, 6, 8])
 

--- a/tests/unit/test_io/test_nifti.py
+++ b/tests/unit/test_io/test_nifti.py
@@ -734,6 +734,26 @@ class TestLoadNifti:
         assert any("Falling back to frame indices" in str(w.message) for w in caught)
         np.testing.assert_allclose(loaded.coords["time"].values, [0, 1, 2, 3, 4])
 
+    def test_load_nifti_invalid_volume_timing_uses_header_timing(
+        self, tmp_path: Path
+    ) -> None:
+        """Invalid 4D `VolumeTiming` metadata is ignored after warning."""
+        data = np.random.default_rng(0).random((2, 3, 4, 5)).astype(np.float32)
+        path = tmp_path / "invalid_volume_timing_4d.nii.gz"
+        img = nib.Nifti1Image(data, np.eye(4))
+        img.header.set_zooms((1.0, 1.0, 1.0, 2.0))
+        img.to_filename(path)
+
+        with open(tmp_path / "invalid_volume_timing_4d.json", "w") as f:
+            json.dump({"VolumeTiming": [[0.0, 1.0]]}, f)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            loaded = load_nifti(path)
+
+        assert any("not a non-empty 1D array" in str(w.message) for w in caught)
+        np.testing.assert_allclose(loaded.coords["time"].values, [0, 2, 4, 6, 8])
+
     def test_load_nifti_validation_runtime_error_warns(self, tmp_path: Path) -> None:
         """Unexpected sidecar validation failures degrade to a warning when loading."""
         data = np.random.default_rng(0).random((4, 3, 2)).astype(np.float32)


### PR DESCRIPTION
## Summary
- ignore malformed `VolumeTiming` when its length disagrees with the data
- fall back to `pixdim[4]`, then to frame indices with a dedicated warning
- add regression tests for header and frame-index fallbacks

Closes #303