### PR TITLE
docs(gallery): style pandas DataFrame reprs like Jupyter notebooks

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,6 +19,12 @@ Current development version for the next ConfUSIus release.
   single-index selection, so `plot_contours(atlas.annotation.sel(z=6))` works like
   `sel(z=[6])` ([#296](https://github.com/confusius-tools/confusius/pull/296)).
 
+### :wrench: Maintenance
+
+- pandas DataFrame outputs in the example gallery now render with clean, theme-aware
+  notebook styling instead of a fully-bordered table
+  ([#306](https://github.com/confusius-tools/confusius/issues/306)).
+
 ## 0.5.2
 
 Released 2026-07-10.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -23,7 +23,7 @@ Current development version for the next ConfUSIus release.
 
 - pandas DataFrame outputs in the example gallery now render with clean, theme-aware
   notebook styling instead of a fully-bordered table
-  ([#306](https://github.com/confusius-tools/confusius/issues/306)).
+  ([#307](https://github.com/confusius-tools/confusius/pull/307)).
 
 ## 0.5.2
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -471,3 +471,86 @@
   white-space: pre-wrap;
   overflow-wrap: anywhere;
 }
+
+/* pandas' `DataFrame._repr_html_()` emits `<table border="1" class="dataframe">`
+   with only a tiny scoped <style>; without notebook CSS the `border="1"` renders
+   as an ugly fully-bordered table. Restyle `.dataframe` blocks to match Jupyter's
+   clean notebook look, theme-aware. The docs theme only styles unclassed tables
+   (`.md-typeset table:not([class])`), so the classed pandas table is left to us —
+   including horizontal scroll, hence `overflow-x:auto` on the wrapper. */
+.gallery-rich-output {
+  overflow-x: auto;
+}
+
+.gallery-rich-output table.dataframe {
+  border: none;
+  border-collapse: collapse;
+  margin: 0.5rem auto;
+  font-size: 0.72rem;
+}
+
+.gallery-rich-output table.dataframe th,
+.gallery-rich-output table.dataframe td {
+  border: none;
+  padding: 0.3em 0.75em;
+  text-align: right;
+  vertical-align: middle;
+}
+
+.gallery-rich-output table.dataframe thead {
+  border-bottom: 2px solid var(--md-default-fg-color--light);
+}
+
+.gallery-rich-output table.dataframe thead th {
+  font-weight: 700;
+}
+
+.gallery-rich-output table.dataframe tbody th {
+  font-weight: 700;
+}
+
+/* Alternating row colors mirroring the xarray coordinate repr, theme-aware. These
+   hex values match the `--xr-background-color-row-*` variables injected alongside
+   the xarray HTML repr in tools/gallery/render.py. The first (odd) row uses the
+   stronger shade, matching xarray's `nth-child(odd)` override. */
+[data-md-color-scheme="default"]
+  .gallery-rich-output
+  table.dataframe
+  tbody
+  tr:nth-child(odd) {
+  background: #edf0f5;
+}
+
+[data-md-color-scheme="default"]
+  .gallery-rich-output
+  table.dataframe
+  tbody
+  tr:nth-child(even) {
+  background: #f8f9fb;
+}
+
+[data-md-color-scheme="slate"]
+  .gallery-rich-output
+  table.dataframe
+  tbody
+  tr:nth-child(odd) {
+  background: #1d2533;
+}
+
+[data-md-color-scheme="slate"]
+  .gallery-rich-output
+  table.dataframe
+  tbody
+  tr:nth-child(even) {
+  background: #161d29;
+}
+
+/* Hover highlight, kept above the striping rules (which include a color scheme
+   attribute) so the hovered row wins regardless of its odd/even shade. */
+[data-md-color-scheme]
+  .gallery-rich-output
+  table.dataframe
+  tbody
+  tr:hover {
+  background: var(--md-default-fg-color--lightest);
+}


### PR DESCRIPTION
Fixes #306.

## Summary

pandas DataFrame outputs in the example gallery rendered as an ugly fully-bordered grid. The renderer already prefers `text/html`, so it *was* emitting pandas' `__repr_html__` — but pandas ships `<table border="1" class="dataframe">` with only a tiny scoped `<style>`, and the docs theme styles unclassed tables only (`.md-typeset table:not([class])`). With no CSS for the classed `.dataframe` table, the browser fell back to the `border="1"` grid.

This adds theme-aware CSS for `.gallery-rich-output .dataframe` so the table renders in the clean Jupyter notebook look — centered, with alternating row stripes reusing the xarray coordinate repr shades and a mouse-hover row highlight — in both light and dark schemes. CSS-only; no Python change.

<img width="909" height="395" alt="image" src="https://github.com/user-attachments/assets/9637b056-1800-4f65-880b-5a2365b950b4" />

