### PR TITLE
fix(datasets): update Landemard OSF project

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,6 +24,10 @@ Current development version for the next ConfUSIus release.
   [`write_events`][confusius.bids.save_events] →
   [`save_events`][confusius.bids.save_events]
   ([#294](https://github.com/confusius-tools/confusius/pull/294)).
+- [`fetch_landemard_2026`][confusius.datasets.fetch_landemard_2026] now resolves the
+  dataset from OSF project `7cf9g` instead of `dkseb`. Existing local caches may need a
+  one-time `refresh=True` to replace the cached OSF file index before downloading or
+  checking for upstream updates ([#311](https://github.com/confusius-tools/confusius/pull/311)).
 
 ### :sparkles: Enhancements
 

--- a/docs/user-guide/datasets.md
+++ b/docs/user-guide/datasets.md
@@ -189,7 +189,7 @@ confusius datasets --list
     Functional ultrasound imaging recordings from awake, head-fixed,
     freely-running mice, from Landemard et al. (2026)[^landemard2026],
     re-exported to fUSI-BIDS format and hosted on
-    [OSF (dkseb)](https://osf.io/dkseb/overview).
+    [OSF (7cf9g)](https://osf.io/7cf9g/overview).
     Total size: **~42 GB**.
 
     Use [`fetch_landemard_2026`][confusius.datasets.fetch_landemard_2026] to

--- a/src/confusius/datasets/_landemard_2026.py
+++ b/src/confusius/datasets/_landemard_2026.py
@@ -14,7 +14,7 @@ from ._osf import (
 )
 from ._utils import get_datasets_dir, print_citation_message
 
-_OSF_PROJECT_ID = "dkseb"
+_OSF_PROJECT_ID = "7cf9g"
 _BIDS_ROOT = "landemard-2026-bids"
 _TOTAL_SIZE_BYTES = 42_036_009_786
 _CITATION = (
@@ -202,7 +202,7 @@ def fetch_landemard_2026(
 
     [^2]:
         fUSI-BIDS dataset on OSF:
-        [https://osf.io/dkseb/](https://osf.io/dkseb/overview)
+        [https://osf.io/7cf9g/](https://osf.io/7cf9g/overview)
 
     [^3]:
         Dataset license (CC BY-NC 4.0):


### PR DESCRIPTION
## Summary
- point the Landemard dataset fetcher at OSF project 7cf9g
- update the user guide link
- note the one-time refresh requirement in the changelog