### PR TITLE
refactor(iq): simplify axial velocity estimation

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -29,9 +29,9 @@ Current development version for the next ConfUSIus release.
   one-time `refresh=True` to replace the cached OSF file index before downloading or
   checking for upstream updates ([#311](https://github.com/confusius-tools/confusius/pull/311)).
 - Axial velocity processing now always uses the standard Kasai estimator (`arg(mean(R1))`);
-  the `estimation_method` argument and `axial_velocity_estimation_method` metadata were
-  removed, and `spatial_kernel` now defaults to `3` and accepts explicit `(z, y, x)`
-  sizes ([#313](https://github.com/confusius-tools/confusius/pull/313)).
+  the `estimation_method` and `absolute_velocity` arguments were removed, the
+  corresponding metadata fields were dropped, and `spatial_kernel` now defaults to `3`
+  and accepts explicit `(z, y, x)` sizes ([#313](https://github.com/confusius-tools/confusius/pull/313)).
 
 ### :sparkles: Enhancements
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -68,6 +68,12 @@ Current development version for the next ConfUSIus release.
   single-index selection, so `plot_contours(atlas.annotation.sel(z=6))` works like
   `sel(z=[6])` ([#296](https://github.com/confusius-tools/confusius/pull/296)).
 
+### :books: Documentation
+
+- Fixed velocity sign interpretation in [Beamformed IQ user
+  guide](user-guide/beamformed-iq.md)
+  ([#313](https://github.com/confusius-tools/confusius/pull/313)).
+
 ### :wrench: Maintenance
 
 - [Example Gallery]: pandas DataFrame outputs in the example gallery now render with

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -49,7 +49,8 @@ Current development version for the next ConfUSIus release.
 ### :bug: Fixes
 
 - Axial velocity estimation now scales the Kasai phase increment by the requested
-  autocorrelation `lag`, so multi-volume lags no longer overestimate velocity.
+  autocorrelation `lag`, so multi-volume lags no longer overestimate velocity
+  ([#313](https://github.com/confusius-tools/confusius/pull/313)).
 - NIfTI loading no longer crashes when a sidecar `VolumeTiming` length disagrees with
   the actual data. ConfUSIus now ignores the malformed sidecar timing, falls back to
   `pixdim[4]` when available, and otherwise warns before using frame indices.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -28,6 +28,9 @@ Current development version for the next ConfUSIus release.
   dataset from OSF project `7cf9g` instead of `dkseb`. Existing local caches may need a
   one-time `refresh=True` to replace the cached OSF file index before downloading or
   checking for upstream updates ([#311](https://github.com/confusius-tools/confusius/pull/311)).
+- Axial velocity processing now always uses the standard Kasai estimator (`arg(mean(R1))`);
+  the `estimation_method` argument and `axial_velocity_estimation_method` metadata were
+  removed.
 
 ### :sparkles: Enhancements
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -48,6 +48,8 @@ Current development version for the next ConfUSIus release.
 
 ### :bug: Fixes
 
+- Axial velocity estimation now scales the Kasai phase increment by the requested
+  autocorrelation `lag`, so multi-volume lags no longer overestimate velocity.
 - NIfTI loading no longer crashes when a sidecar `VolumeTiming` length disagrees with
   the actual data. ConfUSIus now ignores the malformed sidecar timing, falls back to
   `pixdim[4]` when available, and otherwise warns before using frame indices.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -30,7 +30,7 @@ Current development version for the next ConfUSIus release.
   checking for upstream updates ([#311](https://github.com/confusius-tools/confusius/pull/311)).
 - Axial velocity processing now always uses the standard Kasai estimator (`arg(mean(R1))`);
   the `estimation_method` argument and `axial_velocity_estimation_method` metadata were
-  removed.
+  removed ([#313](https://github.com/confusius-tools/confusius/pull/313)).
 
 ### :sparkles: Enhancements
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -30,7 +30,8 @@ Current development version for the next ConfUSIus release.
   checking for upstream updates ([#311](https://github.com/confusius-tools/confusius/pull/311)).
 - Axial velocity processing now always uses the standard Kasai estimator (`arg(mean(R1))`);
   the `estimation_method` argument and `axial_velocity_estimation_method` metadata were
-  removed ([#313](https://github.com/confusius-tools/confusius/pull/313)).
+  removed, and `spatial_kernel` now defaults to `3` and accepts explicit `(z, y, x)`
+  sizes ([#313](https://github.com/confusius-tools/confusius/pull/313)).
 
 ### :sparkles: Enhancements
 

--- a/docs/user-guide/beamformed-iq.md
+++ b/docs/user-guide/beamformed-iq.md
@@ -621,8 +621,7 @@ function or the corresponding Xarray accessor method.
         velocity_window_width=50,
         filter_method="svd_indices",
         low_cutoff=50,
-        lag=1,                          # Autocorrelation lag (volumes).
-        estimation_method="average_angle",  # Velocity estimation method.
+        lag=1,  # Autocorrelation lag (volumes).
     )
     ```
 
@@ -645,8 +644,7 @@ function or the corresponding Xarray accessor method.
         velocity_window_width=50,
         filter_method="svd_indices",
         low_cutoff=50,
-        lag=1,                          # Autocorrelation lag (volumes).
-        estimation_method="average_angle",  # Velocity estimation method.
+        lag=1,  # Autocorrelation lag (volumes).
     )
     ```
 

--- a/docs/user-guide/beamformed-iq.md
+++ b/docs/user-guide/beamformed-iq.md
@@ -674,16 +674,14 @@ Attributes:
 
 #### Interpreting Velocity
 
-Velocity values are returned in **meters per second** with sign indicating direction:
-
-- **Positive values**: Flow toward the transducer.
-- **Negative values**: Flow away from the transducer.
-- **Magnitude**: Speed of flow.
+Velocity values are returned in **meters per second** and correspond to the speed of
+scatterers along the ultrasound beam. That is, positive velocities indicate motion away
+from the transducer, while negative values indicate motion toward the transducer.
 
 !!! warning "Velocity aliasing"
     Very high velocities may exceed the Nyquist limit and cause aliasing (wrapping). If
-    you observe sudden sign reversals in high-flow regions, reduce the `lag` parameter or
-    increase the pulse repetition frequency during acquisition.
+    you observe sudden sign reversals in high-motion regions, reduce the `lag` parameter
+    or increase the pulse repetition frequency during acquisition.
 
 ### B-mode
 

--- a/docs/user-guide/beamformed-iq.md
+++ b/docs/user-guide/beamformed-iq.md
@@ -675,8 +675,12 @@ Attributes:
 #### Interpreting Velocity
 
 Velocity values are returned in **meters per second** and correspond to the speed of
-scatterers along the ultrasound beam. That is, positive velocities indicate motion away
-from the transducer, while negative values indicate motion toward the transducer.
+scatterers along the ultrasound beam. However, the **sign convention is scanner-
+dependent**: it depends on choices such as the analytic-signal convention, the IQ
+demodulation, and other parameters. Before interpreting the sign, verify it on your
+scanner with a known flow direction (e.g., large arteries flowing from the circle of
+Willis toward the probe) or a phantom, or another acquisition where the motion direction
+is unambiguous.
 
 !!! warning "Velocity aliasing"
     Very high velocities may exceed the Nyquist limit and cause aliasing (wrapping). If

--- a/src/confusius/bids/mapping.py
+++ b/src/confusius/bids/mapping.py
@@ -99,7 +99,6 @@ CONFUSIUS_INTERNAL_FIELDS: Final[frozenset[str]] = frozenset(
         "axial_velocity_lag",
         "axial_velocity_absolute",
         "axial_velocity_spatial_kernel",
-        "axial_velocity_estimation_method",
         "dim4_name",
         "dim4_coordinates",
         "dim4_attrs",

--- a/src/confusius/bids/mapping.py
+++ b/src/confusius/bids/mapping.py
@@ -97,7 +97,6 @@ CONFUSIUS_INTERNAL_FIELDS: Final[frozenset[str]] = frozenset(
         "axial_velocity_integration_duration",
         "axial_velocity_integration_stride",
         "axial_velocity_lag",
-        "axial_velocity_absolute",
         "axial_velocity_spatial_kernel",
         "dim4_name",
         "dim4_coordinates",

--- a/src/confusius/iq/process.py
+++ b/src/confusius/iq/process.py
@@ -802,7 +802,6 @@ def compute_axial_velocity_volume(
     spatial_kernel: int = 1,
     transmit_frequency: float = 15.625e6,
     beamforming_sound_velocity: float = 1540,
-    estimation_method: Literal["average_angle", "angle_average"] = "average_angle",
 ) -> npt.NDArray:
     """Compute axial velocity volumes from beamformed IQ data.
 
@@ -858,13 +857,6 @@ def compute_axial_velocity_volume(
         Ultrasound transmit frequency in hertz.
     beamforming_sound_velocity : float, default: 1540
         Speed of sound assumed during beamforming, in meters per second.
-    estimation_method : {"average_angle", "angle_average"}, default: "average_angle"
-        Method for computing the velocity estimate.
-
-        - `"average_angle"`: Compute the angle of the autocorrelation, then average
-          (i.e., average of angles).
-        - `"angle_average"`: Average the autocorrelation, then compute the angle
-          (i.e., angle of average).
 
     Returns
     -------
@@ -887,7 +879,6 @@ def compute_axial_velocity_volume(
         fs: float,
         transmit_frequency: float,
         beamforming_sound_velocity: float,
-        estimation_method: Literal["average_angle", "angle_average"],
         **_,
     ) -> npt.NDArray:
         """Compute the Kasai estimator from an array of IQ data.
@@ -910,8 +901,6 @@ def compute_axial_velocity_volume(
             Ultrasound transmit frequency in hertz.
         beamforming_sound_velocity : float
             Speed of sound in the imaged medium, in meters per second.
-        estimation_method : {"average_angle", "angle_average"}
-            Method for computing the velocity estimate.
         **_
             Additional unused keyword arguments (absorbed and ignored).
 
@@ -924,20 +913,9 @@ def compute_axial_velocity_volume(
         block_rolled_conjugate[:lag, ...] = 0
         autocorrelation = cast("npt.NDArray", block * block_rolled_conjugate)[lag:]
 
-        if estimation_method == "average_angle":
-            autocorrelation_phase = np.angle(autocorrelation)
-            if absolute_velocity:
-                autocorrelation_phase = np.abs(autocorrelation_phase)
-            average_autocorrelation_phase = autocorrelation_phase.mean(0)
-        elif estimation_method == "angle_average":
-            average_autocorrelation_phase = np.angle(autocorrelation.mean(0))
-            if absolute_velocity:
-                average_autocorrelation_phase = np.abs(average_autocorrelation_phase)
-        else:
-            raise ValueError(
-                f"Unknown estimation method: {estimation_method}. "
-                "Must be 'average_angle' or 'angle_average'."
-            )
+        average_autocorrelation_phase = np.angle(autocorrelation.mean(0))
+        if absolute_velocity:
+            average_autocorrelation_phase = np.abs(average_autocorrelation_phase)
 
         if spatial_kernel > 1:
             import scipy.signal as sp_signal
@@ -972,7 +950,6 @@ def compute_axial_velocity_volume(
         lag=lag,
         absolute_velocity=absolute_velocity,
         beamforming_sound_velocity=beamforming_sound_velocity,
-        estimation_method=estimation_method,
     )
 
 
@@ -1498,7 +1475,6 @@ def process_iq_to_axial_velocity(
     lag: int = 1,
     absolute_velocity: bool = False,
     spatial_kernel: int = 1,
-    estimation_method: Literal["average_angle", "angle_average"] = "average_angle",
 ) -> xr.DataArray:
     """Process blocks of beamformed IQ into axial velocity volumes using sliding windows.
 
@@ -1562,13 +1538,6 @@ def process_iq_to_axial_velocity(
     spatial_kernel : int, default: 1
         Size of the median filter kernel applied spatially to denoise. Must be
         positive and odd. If `1`, no spatial filtering is applied.
-    estimation_method : {"average_angle", "angle_average"}, default: "average_angle"
-        Method for computing the velocity estimate.
-
-        - `"average_angle"`: Compute the angle of the autocorrelation, then average
-          (i.e., average of angles).
-        - `"angle_average"`: Average the autocorrelation, then compute the angle
-          (i.e., angle of average).
 
     Returns
     -------
@@ -1665,7 +1634,6 @@ def process_iq_to_axial_velocity(
         spatial_kernel=spatial_kernel,
         transmit_frequency=transmit_frequency,
         beamforming_sound_velocity=beamforming_sound_velocity,
-        estimation_method=estimation_method,
     )
 
     output_times_values, velocity_window_durations = compute_processed_volume_timings(
@@ -1725,7 +1693,6 @@ def process_iq_to_axial_velocity(
         "axial_velocity_spatial_kernel": spatial_kernel,
         "transmit_frequency": transmit_frequency,
         "beamforming_sound_velocity": beamforming_sound_velocity,
-        "axial_velocity_estimation_method": estimation_method,
         "axial_velocity_integration_duration": velocity_window_duration,
         "axial_velocity_integration_stride": velocity_window_stride_duration,
     }

--- a/src/confusius/iq/process.py
+++ b/src/confusius/iq/process.py
@@ -917,7 +917,7 @@ def compute_axial_velocity_volume(
     Notes
     -----
     The Kasai estimator computes velocity from the phase shift of the autocorrelation
-    function between consecutive IQ volumes.
+    function between IQ volumes separated by `lag` volumes.
     """
 
     def process_block_func(
@@ -955,11 +955,8 @@ def compute_axial_velocity_volume(
         (z, y, x) numpy.ndarray
             Axial velocity volume in meters per second.
         """
-        block_rolled_conjugate = np.roll(block, lag, axis=0).conj()
-        block_rolled_conjugate[:lag, ...] = 0
-        autocorrelation = cast("npt.NDArray", block * block_rolled_conjugate)[lag:]
-
-        average_autocorrelation_phase = np.angle(autocorrelation.mean(0))
+        autocorrelation = cast("npt.NDArray", block[lag:] * np.conj(block[:-lag]))
+        average_autocorrelation_phase = np.angle(autocorrelation.mean(axis=0))
 
         kernel_size = _normalize_spatial_kernel(spatial_kernel, block.shape[1:])
         if any(size > 1 for size in kernel_size):
@@ -973,7 +970,7 @@ def compute_axial_velocity_volume(
             average_autocorrelation_phase
             * fs
             * beamforming_sound_velocity
-            / (4 * np.pi * transmit_frequency)
+            / (4 * np.pi * transmit_frequency * lag)
         )
 
     return process_iq_block_with_clutter_filter(

--- a/src/confusius/iq/process.py
+++ b/src/confusius/iq/process.py
@@ -66,6 +66,52 @@ def _format_clutter_filter_spec(
     return f"{label} [{low}, {high}{closing}"
 
 
+def _normalize_spatial_kernel(
+    spatial_kernel: int | tuple[int, int, int] | list[int],
+    spatial_shape: tuple[int, int, int] | None = None,
+) -> tuple[int, int, int]:
+    """Return a validated `(z, y, x)` median-filter kernel.
+
+    Parameters
+    ----------
+    spatial_kernel : int or tuple[int, int, int] or list[int]
+        Median-filter kernel size as a scalar or explicit `(z, y, x)` sizes.
+    spatial_shape : tuple[int, int, int], optional
+        Spatial data shape used to clip each kernel axis to the available size.
+
+    Returns
+    -------
+    tuple[int, int, int]
+        Validated odd kernel sizes for `(z, y, x)`.
+
+    Raises
+    ------
+    ValueError
+        If `spatial_kernel` is not a positive int or a length-3 sequence of positive
+        ints.
+    """
+    if isinstance(spatial_kernel, int):
+        kernel = (spatial_kernel, spatial_kernel, spatial_kernel)
+    elif len(spatial_kernel) == 3 and all(
+        isinstance(size, int) for size in spatial_kernel
+    ):
+        kernel = tuple(spatial_kernel)
+    else:
+        raise ValueError(
+            "`spatial_kernel` must be a positive int or a length-3 sequence of positive ints."
+        )
+
+    if any(size < 1 for size in kernel):
+        raise ValueError("`spatial_kernel` values must be positive.")
+
+    if spatial_shape is not None:
+        kernel = tuple(
+            min(size, dim) for size, dim in zip(kernel, spatial_shape, strict=True)
+        )
+
+    return tuple(size + 1 if size % 2 == 0 else size for size in kernel)
+
+
 def _get_volume_acquisition_duration(iq: xr.DataArray) -> float:
     """Return the input IQ volume acquisition duration in coordinate units.
 
@@ -799,7 +845,7 @@ def compute_axial_velocity_volume(
     velocity_window_stride: int | None = None,
     lag: int = 1,
     absolute_velocity: bool = False,
-    spatial_kernel: int = 1,
+    spatial_kernel: int | tuple[int, int, int] | list[int] = 3,
     transmit_frequency: float = 15.625e6,
     beamforming_sound_velocity: float = 1540,
 ) -> npt.NDArray:
@@ -850,9 +896,12 @@ def compute_axial_velocity_volume(
     absolute_velocity : bool, default: False
         If `True`, compute absolute velocity values. If `False`, preserve sign
         information.
-    spatial_kernel : int, default: 1
-        Size of the median filter kernel applied spatially to denoise. Must be
-        positive and odd. If `1`, no spatial filtering is applied.
+    spatial_kernel : int or tuple[int, int, int] or list[int], default: 3
+        Size of the median filter kernel applied spatially to denoise. A scalar uses
+        the same kernel size on all spatial axes; a length-3 sequence specifies
+        `(z, y, x)` sizes directly. Values must be positive. Any even sizes are
+        rounded up to the next odd size. If all sizes are `1`, no spatial filtering is
+        applied.
     transmit_frequency : float, default: 15.625e6
         Ultrasound transmit frequency in hertz.
     beamforming_sound_velocity : float, default: 1540
@@ -873,7 +922,7 @@ def compute_axial_velocity_volume(
 
     def process_block_func(
         block: npt.NDArray,
-        spatial_kernel: int,
+        spatial_kernel: int | tuple[int, int, int] | list[int],
         lag: int,
         absolute_velocity: bool,
         fs: float,
@@ -887,9 +936,10 @@ def compute_axial_velocity_volume(
         ----------
         block : (time, z, y, x) numpy.ndarray
             Complex IQ data.
-        spatial_kernel : int
-            Size of the median filter kernel applied spatially to denoise. Must be
-            positive and odd.
+        spatial_kernel : int or tuple[int, int, int] or list[int]
+            Size of the median filter kernel applied spatially to denoise. A scalar
+            uses the same size on all spatial axes; a length-3 sequence specifies
+            `(z, y, x)` sizes directly.
         lag : int
             Temporal lag in volumes for autocorrelation computation.
         absolute_velocity : bool
@@ -917,12 +967,10 @@ def compute_axial_velocity_volume(
         if absolute_velocity:
             average_autocorrelation_phase = np.abs(average_autocorrelation_phase)
 
-        if spatial_kernel > 1:
+        kernel_size = _normalize_spatial_kernel(spatial_kernel, block.shape[1:])
+        if any(size > 1 for size in kernel_size):
             import scipy.signal as sp_signal
 
-            kernel_size = [min(spatial_kernel, s) for s in block.shape[1:]]
-            # Median filter requires odd kernel sizes.
-            kernel_size = [s + 1 if s % 2 == 0 else s for s in kernel_size]
             average_autocorrelation_phase = sp_signal.medfilt(
                 average_autocorrelation_phase, kernel_size
             )
@@ -1474,7 +1522,7 @@ def process_iq_to_axial_velocity(
     velocity_window_stride: int | None = None,
     lag: int = 1,
     absolute_velocity: bool = False,
-    spatial_kernel: int = 1,
+    spatial_kernel: int | tuple[int, int, int] | list[int] = 3,
 ) -> xr.DataArray:
     """Process blocks of beamformed IQ into axial velocity volumes using sliding windows.
 
@@ -1535,9 +1583,12 @@ def process_iq_to_axial_velocity(
     absolute_velocity : bool, default: False
         If `True`, compute absolute velocity values. If `False`, preserve sign
         information.
-    spatial_kernel : int, default: 1
-        Size of the median filter kernel applied spatially to denoise. Must be
-        positive and odd. If `1`, no spatial filtering is applied.
+    spatial_kernel : int or tuple[int, int, int] or list[int], default: 3
+        Size of the median filter kernel applied spatially to denoise. A scalar uses
+        the same kernel size on all spatial axes; a length-3 sequence specifies
+        `(z, y, x)` sizes directly. Values must be positive. Any even sizes are
+        rounded up to the next odd size. If all sizes are `1`, no spatial filtering is
+        applied.
 
     Returns
     -------

--- a/src/confusius/iq/process.py
+++ b/src/confusius/iq/process.py
@@ -109,7 +109,11 @@ def _normalize_spatial_kernel(
             min(size, dim) for size, dim in zip(kernel, spatial_shape, strict=True)
         )
 
-    return tuple(size + 1 if size % 2 == 0 else size for size in kernel)
+    return (
+        kernel[0] + 1 if kernel[0] % 2 == 0 else kernel[0],
+        kernel[1] + 1 if kernel[1] % 2 == 0 else kernel[1],
+        kernel[2] + 1 if kernel[2] % 2 == 0 else kernel[2],
+    )
 
 
 def _get_volume_acquisition_duration(iq: xr.DataArray) -> float:
@@ -844,7 +848,6 @@ def compute_axial_velocity_volume(
     velocity_window_width: int | None = None,
     velocity_window_stride: int | None = None,
     lag: int = 1,
-    absolute_velocity: bool = False,
     spatial_kernel: int | tuple[int, int, int] | list[int] = 3,
     transmit_frequency: float = 15.625e6,
     beamforming_sound_velocity: float = 1540,
@@ -893,9 +896,6 @@ def compute_axial_velocity_volume(
         `velocity_window_width`.
     lag : int, default: 1
         Temporal lag in volumes for autocorrelation computation. Must be positive.
-    absolute_velocity : bool, default: False
-        If `True`, compute absolute velocity values. If `False`, preserve sign
-        information.
     spatial_kernel : int or tuple[int, int, int] or list[int], default: 3
         Size of the median filter kernel applied spatially to denoise. A scalar uses
         the same kernel size on all spatial axes; a length-3 sequence specifies
@@ -924,7 +924,6 @@ def compute_axial_velocity_volume(
         block: npt.NDArray,
         spatial_kernel: int | tuple[int, int, int] | list[int],
         lag: int,
-        absolute_velocity: bool,
         fs: float,
         transmit_frequency: float,
         beamforming_sound_velocity: float,
@@ -942,9 +941,6 @@ def compute_axial_velocity_volume(
             `(z, y, x)` sizes directly.
         lag : int
             Temporal lag in volumes for autocorrelation computation.
-        absolute_velocity : bool
-            If `True`, compute absolute velocity values. If `False`, preserve sign
-            information.
         fs : float
             Volume sampling frequency in hertz.
         transmit_frequency : float
@@ -964,8 +960,6 @@ def compute_axial_velocity_volume(
         autocorrelation = cast("npt.NDArray", block * block_rolled_conjugate)[lag:]
 
         average_autocorrelation_phase = np.angle(autocorrelation.mean(0))
-        if absolute_velocity:
-            average_autocorrelation_phase = np.abs(average_autocorrelation_phase)
 
         kernel_size = _normalize_spatial_kernel(spatial_kernel, block.shape[1:])
         if any(size > 1 for size in kernel_size):
@@ -996,7 +990,6 @@ def compute_axial_velocity_volume(
         transmit_frequency=transmit_frequency,
         spatial_kernel=spatial_kernel,
         lag=lag,
-        absolute_velocity=absolute_velocity,
         beamforming_sound_velocity=beamforming_sound_velocity,
     )
 
@@ -1521,7 +1514,6 @@ def process_iq_to_axial_velocity(
     velocity_window_width: int | None = None,
     velocity_window_stride: int | None = None,
     lag: int = 1,
-    absolute_velocity: bool = False,
     spatial_kernel: int | tuple[int, int, int] | list[int] = 3,
 ) -> xr.DataArray:
     """Process blocks of beamformed IQ into axial velocity volumes using sliding windows.
@@ -1580,9 +1572,6 @@ def process_iq_to_axial_velocity(
         If not provided, equals `velocity_window_width`.
     lag : int, default: 1
         Temporal lag in volumes for autocorrelation computation. Must be positive.
-    absolute_velocity : bool, default: False
-        If `True`, compute absolute velocity values. If `False`, preserve sign
-        information.
     spatial_kernel : int or tuple[int, int, int] or list[int], default: 3
         Size of the median filter kernel applied spatially to denoise. A scalar uses
         the same kernel size on all spatial axes; a length-3 sequence specifies
@@ -1681,7 +1670,6 @@ def process_iq_to_axial_velocity(
         velocity_window_width=velocity_window_width,
         velocity_window_stride=velocity_window_stride,
         lag=lag,
-        absolute_velocity=absolute_velocity,
         spatial_kernel=spatial_kernel,
         transmit_frequency=transmit_frequency,
         beamforming_sound_velocity=beamforming_sound_velocity,
@@ -1729,18 +1717,16 @@ def process_iq_to_axial_velocity(
         },
     )
 
-    velocity_cmap = "viridis" if absolute_velocity else "coolwarm"
     output_attrs = {
         "units": "m/s",
         "long_name": "Axial velocity",
-        "cmap": velocity_cmap,
+        "cmap": "coolwarm",
         "clutter_filters": _format_clutter_filter_spec(
             filter_method, low_cutoff, high_cutoff
         ),
         "clutter_filter_window_duration": clutter_window_duration,
         "clutter_filter_window_stride": clutter_window_stride_duration,
         "axial_velocity_lag": lag,
-        "axial_velocity_absolute": absolute_velocity,
         "axial_velocity_spatial_kernel": spatial_kernel,
         "transmit_frequency": transmit_frequency,
         "beamforming_sound_velocity": beamforming_sound_velocity,

--- a/src/confusius/xarray/iq.py
+++ b/src/confusius/xarray/iq.py
@@ -139,7 +139,6 @@ class FUSIIQAccessor:
         velocity_window_width: int | None = None,
         velocity_window_stride: int | None = None,
         lag: int = 1,
-        absolute_velocity: bool = False,
         spatial_kernel: int | tuple[int, int, int] | list[int] = 3,
     ) -> xr.DataArray:
         """Process beamformed IQ into axial velocity volumes.
@@ -188,9 +187,6 @@ class FUSIIQAccessor:
             If not provided, equals `velocity_window_width`.
         lag : int, default: 1
             Temporal lag in volumes for autocorrelation computation. Must be positive.
-        absolute_velocity : bool, default: False
-            If `True`, compute absolute velocity values. If `False`, preserve sign
-            information.
         spatial_kernel : int or tuple[int, int, int] or list[int], default: 3
             Size of the median filter kernel applied spatially to denoise. A scalar
             uses the same kernel size on all spatial axes; a length-3 sequence
@@ -228,7 +224,6 @@ class FUSIIQAccessor:
             velocity_window_width=velocity_window_width,
             velocity_window_stride=velocity_window_stride,
             lag=lag,
-            absolute_velocity=absolute_velocity,
             spatial_kernel=spatial_kernel,
         )
 

--- a/src/confusius/xarray/iq.py
+++ b/src/confusius/xarray/iq.py
@@ -140,7 +140,7 @@ class FUSIIQAccessor:
         velocity_window_stride: int | None = None,
         lag: int = 1,
         absolute_velocity: bool = False,
-        spatial_kernel: int = 1,
+        spatial_kernel: int | tuple[int, int, int] | list[int] = 3,
     ) -> xr.DataArray:
         """Process beamformed IQ into axial velocity volumes.
 
@@ -191,9 +191,12 @@ class FUSIIQAccessor:
         absolute_velocity : bool, default: False
             If `True`, compute absolute velocity values. If `False`, preserve sign
             information.
-        spatial_kernel : int, default: 1
-            Size of the median filter kernel applied spatially to denoise. Must be
-            positive and odd. If `1`, no spatial filtering is applied.
+        spatial_kernel : int or tuple[int, int, int] or list[int], default: 3
+            Size of the median filter kernel applied spatially to denoise. A scalar
+            uses the same kernel size on all spatial axes; a length-3 sequence
+            specifies `(z, y, x)` sizes directly. Values must be positive. Any even
+            sizes are rounded up to the next odd size. If all sizes are `1`, no
+            spatial filtering is applied.
 
         Returns
         -------

--- a/src/confusius/xarray/iq.py
+++ b/src/confusius/xarray/iq.py
@@ -141,7 +141,6 @@ class FUSIIQAccessor:
         lag: int = 1,
         absolute_velocity: bool = False,
         spatial_kernel: int = 1,
-        estimation_method: Literal["average_angle", "angle_average"] = "average_angle",
     ) -> xr.DataArray:
         """Process beamformed IQ into axial velocity volumes.
 
@@ -195,13 +194,6 @@ class FUSIIQAccessor:
         spatial_kernel : int, default: 1
             Size of the median filter kernel applied spatially to denoise. Must be
             positive and odd. If `1`, no spatial filtering is applied.
-        estimation_method : {"average_angle", "angle_average"}, default: "average_angle"
-            Method for computing the velocity estimate.
-
-            - `"average_angle"`: Compute the angle of the autocorrelation, then
-              average (i.e., average of angles).
-            - `"angle_average"`: Average the autocorrelation, then compute the angle
-              (i.e., angle of average).
 
         Returns
         -------
@@ -235,7 +227,6 @@ class FUSIIQAccessor:
             lag=lag,
             absolute_velocity=absolute_velocity,
             spatial_kernel=spatial_kernel,
-            estimation_method=estimation_method,
         )
 
     def process_to_bmode(

--- a/tests/unit/test_io/test_nifti.py
+++ b/tests/unit/test_io/test_nifti.py
@@ -1624,7 +1624,6 @@ class TestSaveNifti:
                 "axial_velocity_lag": 2,
                 "axial_velocity_absolute": True,
                 "axial_velocity_spatial_kernel": 3,
-                "axial_velocity_estimation_method": "angle_average",
             }
         )
 
@@ -1646,7 +1645,6 @@ class TestSaveNifti:
         assert sidecar["ConfUSIusAxialVelocityLag"] == 2
         assert sidecar["ConfUSIusAxialVelocityAbsolute"] is True
         assert sidecar["ConfUSIusAxialVelocitySpatialKernel"] == 3
-        assert sidecar["ConfUSIusAxialVelocityEstimationMethod"] == "angle_average"
         assert sidecar["ConfUSIusLongName"] == "Power Doppler intensity"
         assert sidecar["ConfUSIusCmap"] == "gray"
         assert "long_name" not in sidecar

--- a/tests/unit/test_io/test_nifti.py
+++ b/tests/unit/test_io/test_nifti.py
@@ -1622,7 +1622,6 @@ class TestSaveNifti:
                 "axial_velocity_integration_stride": 0.25,
                 "bmode_integration_stride": 0.3,
                 "axial_velocity_lag": 2,
-                "axial_velocity_absolute": True,
                 "axial_velocity_spatial_kernel": 3,
             }
         )
@@ -1643,7 +1642,6 @@ class TestSaveNifti:
         assert sidecar["ConfUSIusAxialVelocityIntegrationStride"] == pytest.approx(0.25)
         assert sidecar["ConfUSIusBmodeIntegrationStride"] == pytest.approx(0.3)
         assert sidecar["ConfUSIusAxialVelocityLag"] == 2
-        assert sidecar["ConfUSIusAxialVelocityAbsolute"] is True
         assert sidecar["ConfUSIusAxialVelocitySpatialKernel"] == 3
         assert sidecar["ConfUSIusLongName"] == "Power Doppler intensity"
         assert sidecar["ConfUSIusCmap"] == "gray"

--- a/tests/unit/test_iq/test_process.py
+++ b/tests/unit/test_iq/test_process.py
@@ -340,23 +340,20 @@ class TestComputePowerDopplerVolume:
 class TestComputeAxialVelocityVolume:
     """Tests for compute_axial_velocity_volume function."""
 
-    def test_matches_reference_kasai_estimator(self, sample_iq_block_4d):
+    @pytest.mark.parametrize("lag", [1, 2])
+    def test_matches_reference_kasai_estimator(self, sample_iq_block_4d, lag):
         """Result matches the standard Kasai estimator."""
         fs = 100.0
         transmit_frequency = 15.625e6
         beamforming_sound_velocity = 1540.0
-        lag = 1
 
-        block_rolled_conjugate = np.roll(sample_iq_block_4d, lag, axis=0).conj()
-        block_rolled_conjugate[:lag, ...] = 0
-        autocorrelation = sample_iq_block_4d * block_rolled_conjugate
-        autocorrelation = autocorrelation[lag:]
-        average_phase = np.angle(autocorrelation.mean(0))
+        autocorrelation = sample_iq_block_4d[lag:] * np.conj(sample_iq_block_4d[:-lag])
+        average_phase = np.angle(autocorrelation.mean(axis=0))
         expected = (
             average_phase
             * fs
             * beamforming_sound_velocity
-            / (4 * np.pi * transmit_frequency)
+            / (4 * np.pi * transmit_frequency * lag)
         )
 
         result = compute_axial_velocity_volume(

--- a/tests/unit/test_iq/test_process.py
+++ b/tests/unit/test_iq/test_process.py
@@ -365,9 +365,49 @@ class TestComputeAxialVelocityVolume:
             transmit_frequency=transmit_frequency,
             beamforming_sound_velocity=beamforming_sound_velocity,
             lag=lag,
+            spatial_kernel=1,
         )
 
         assert_allclose(result[0], expected, rtol=1e-5)
+
+    def test_spatial_kernel_accepts_per_axis_sizes(
+        self, monkeypatch, sample_iq_block_4d
+    ):
+        """Per-axis spatial kernels are passed to the median filter."""
+        import scipy.signal as sp_signal
+
+        kernel_sizes: list[tuple[int, ...]] = []
+        real_medfilt = sp_signal.medfilt
+
+        def wrapped_medfilt(volume, kernel_size):
+            kernel_sizes.append(tuple(kernel_size))
+            return real_medfilt(volume, kernel_size)
+
+        monkeypatch.setattr(sp_signal, "medfilt", wrapped_medfilt)
+
+        compute_axial_velocity_volume(
+            sample_iq_block_4d,
+            fs=100.0,
+            spatial_kernel=(1, 3, 5),
+        )
+
+        assert kernel_sizes == [(1, 3, 5)]
+
+    def test_spatial_kernel_rejects_invalid_sequences(self, sample_iq_block_4d):
+        """Spatial kernels must be positive length-3 integer sizes."""
+        with pytest.raises(ValueError, match="length-3 sequence"):
+            compute_axial_velocity_volume(
+                sample_iq_block_4d,
+                fs=100.0,
+                spatial_kernel=(3, 3),  # type: ignore[arg-type]
+            )
+
+        with pytest.raises(ValueError, match="must be positive"):
+            compute_axial_velocity_volume(
+                sample_iq_block_4d,
+                fs=100.0,
+                spatial_kernel=(1, 0, 3),
+            )
 
 
 class TestProcessIqBlocks:
@@ -1017,7 +1057,6 @@ class TestProcessIqToAxialVelocity:
             sample_iq_dataarray,
             lag=2,
             absolute_velocity=True,
-            spatial_kernel=3,
         )
 
         assert result.attrs["axial_velocity_lag"] == 2
@@ -1028,6 +1067,15 @@ class TestProcessIqToAxialVelocity:
         assert "absolute_velocity" not in result.attrs
         assert "spatial_kernel" not in result.attrs
         assert "estimation_method" not in result.attrs
+
+    def test_axial_velocity_accepts_per_axis_spatial_kernel(self, sample_iq_dataarray):
+        """Axial velocity metadata preserves explicit per-axis kernel sizes."""
+        result = process_iq_to_axial_velocity(
+            sample_iq_dataarray,
+            spatial_kernel=(1, 3, 5),
+        )
+
+        assert result.attrs["axial_velocity_spatial_kernel"] == (1, 3, 5)
 
 
 class TestDataArrayClutterMask:

--- a/tests/unit/test_iq/test_process.py
+++ b/tests/unit/test_iq/test_process.py
@@ -1,6 +1,6 @@
 """Unit tests for IQ processing functions."""
 
-from typing import Literal, NotRequired, TypedDict
+from typing import Any, Literal, NotRequired, TypedDict, cast
 
 import dask.array as da
 import numpy as np
@@ -399,7 +399,7 @@ class TestComputeAxialVelocityVolume:
             compute_axial_velocity_volume(
                 sample_iq_block_4d,
                 fs=100.0,
-                spatial_kernel=(3, 3),  # type: ignore[arg-type]
+                spatial_kernel=cast("Any", (3, 3)),
             )
 
         with pytest.raises(ValueError, match="must be positive"):
@@ -920,7 +920,6 @@ class TestProcessIqToAxialVelocity:
             velocity_window_width=3,
             velocity_window_stride=1,
             lag=2,
-            absolute_velocity=True,
         )
 
         assert result.name == "axial_velocity"
@@ -935,7 +934,6 @@ class TestProcessIqToAxialVelocity:
         assert result.attrs["axial_velocity_integration_stride"] == pytest.approx(0.1)
         assert result.coords["time"].attrs["volume_acquisition_reference"] == "start"
         assert result.attrs["axial_velocity_lag"] == 2
-        assert result.attrs["axial_velocity_absolute"] is True
 
     def test_uses_attrs_for_parameters(self, sample_iq_dataarray):
         """Uses DataArray attributes for transmit frequency and sound velocity."""
@@ -1029,7 +1027,6 @@ class TestProcessIqToAxialVelocity:
                 velocity_window_width=10,
                 velocity_window_stride=5,
                 lag=2,
-                absolute_velocity=True,
                 spatial_kernel=3,
             )
 
@@ -1045,7 +1042,6 @@ class TestProcessIqToAxialVelocity:
             velocity_window_width=10,
             velocity_window_stride=5,
             lag=2,
-            absolute_velocity=True,
             spatial_kernel=3,
         )
 
@@ -1053,14 +1049,9 @@ class TestProcessIqToAxialVelocity:
         self, sample_iq_dataarray
     ):
         """Axial-velocity-specific attrs use explicit `axial_velocity_` prefixes."""
-        result = process_iq_to_axial_velocity(
-            sample_iq_dataarray,
-            lag=2,
-            absolute_velocity=True,
-        )
+        result = process_iq_to_axial_velocity(sample_iq_dataarray, lag=2)
 
         assert result.attrs["axial_velocity_lag"] == 2
-        assert result.attrs["axial_velocity_absolute"] is True
         assert result.attrs["axial_velocity_spatial_kernel"] == 3
         assert "axial_velocity_estimation_method" not in result.attrs
         assert "lag" not in result.attrs

--- a/tests/unit/test_iq/test_process.py
+++ b/tests/unit/test_iq/test_process.py
@@ -341,45 +341,12 @@ class TestComputeAxialVelocityVolume:
     """Tests for compute_axial_velocity_volume function."""
 
     def test_matches_reference_kasai_estimator(self, sample_iq_block_4d):
-        """Result matches reference Kasai estimator implementation."""
+        """Result matches the standard Kasai estimator."""
         fs = 100.0
         transmit_frequency = 15.625e6
         beamforming_sound_velocity = 1540.0
         lag = 1
 
-        # Reference Kasai estimator (average_angle method).
-        block_rolled_conjugate = np.roll(sample_iq_block_4d, lag, axis=0).conj()
-        block_rolled_conjugate[:lag, ...] = 0
-        autocorrelation = sample_iq_block_4d * block_rolled_conjugate
-        autocorrelation = autocorrelation[lag:]
-        autocorrelation_phase = np.angle(autocorrelation)
-        average_phase = autocorrelation_phase.mean(0)
-        expected = (
-            average_phase
-            * fs
-            * beamforming_sound_velocity
-            / (4 * np.pi * transmit_frequency)
-        )
-
-        result = compute_axial_velocity_volume(
-            sample_iq_block_4d,
-            fs=fs,
-            transmit_frequency=transmit_frequency,
-            beamforming_sound_velocity=beamforming_sound_velocity,
-            lag=lag,
-            estimation_method="average_angle",
-        )
-
-        assert_allclose(result[0], expected, rtol=1e-5)
-
-    def test_angle_average_method(self, sample_iq_block_4d):
-        """Angle_average method computes angle of average autocorrelation."""
-        fs = 100.0
-        transmit_frequency = 15.625e6
-        beamforming_sound_velocity = 1540.0
-        lag = 1
-
-        # Reference: angle of average autocorrelation.
         block_rolled_conjugate = np.roll(sample_iq_block_4d, lag, axis=0).conj()
         block_rolled_conjugate[:lag, ...] = 0
         autocorrelation = sample_iq_block_4d * block_rolled_conjugate
@@ -398,19 +365,9 @@ class TestComputeAxialVelocityVolume:
             transmit_frequency=transmit_frequency,
             beamforming_sound_velocity=beamforming_sound_velocity,
             lag=lag,
-            estimation_method="angle_average",
         )
 
         assert_allclose(result[0], expected, rtol=1e-5)
-
-    def test_invalid_estimation_method_raises(self, sample_iq_block_4d):
-        """Invalid estimation_method raises ValueError."""
-        with pytest.raises(ValueError, match="Unknown estimation method"):
-            compute_axial_velocity_volume(
-                sample_iq_block_4d,
-                fs=100.0,
-                estimation_method="invalid",  # type: ignore
-            )
 
 
 class TestProcessIqBlocks:
@@ -1034,7 +991,6 @@ class TestProcessIqToAxialVelocity:
                 lag=2,
                 absolute_velocity=True,
                 spatial_kernel=3,
-                estimation_method="angle_average",
             )
 
         mock_fn.assert_called_once_with(
@@ -1051,7 +1007,6 @@ class TestProcessIqToAxialVelocity:
             lag=2,
             absolute_velocity=True,
             spatial_kernel=3,
-            estimation_method="angle_average",
         )
 
     def test_axial_velocity_output_uses_prefixed_metadata_names(
@@ -1063,13 +1018,12 @@ class TestProcessIqToAxialVelocity:
             lag=2,
             absolute_velocity=True,
             spatial_kernel=3,
-            estimation_method="angle_average",
         )
 
         assert result.attrs["axial_velocity_lag"] == 2
         assert result.attrs["axial_velocity_absolute"] is True
         assert result.attrs["axial_velocity_spatial_kernel"] == 3
-        assert result.attrs["axial_velocity_estimation_method"] == "angle_average"
+        assert "axial_velocity_estimation_method" not in result.attrs
         assert "lag" not in result.attrs
         assert "absolute_velocity" not in result.attrs
         assert "spatial_kernel" not in result.attrs

--- a/tests/unit/test_xarray/test_wrapper_calls.py
+++ b/tests/unit/test_xarray/test_wrapper_calls.py
@@ -170,7 +170,6 @@ def test_iq_wrappers_forward_calls(monkeypatch, sample_3dt_volume_complex):
             lag=2,
             absolute_velocity=True,
             spatial_kernel=3,
-            estimation_method="angle_average",
         )
         is expected
     )
@@ -189,7 +188,6 @@ def test_iq_wrappers_forward_calls(monkeypatch, sample_3dt_volume_complex):
             "lag": 2,
             "absolute_velocity": True,
             "spatial_kernel": 3,
-            "estimation_method": "angle_average",
         },
     )
 

--- a/tests/unit/test_xarray/test_wrapper_calls.py
+++ b/tests/unit/test_xarray/test_wrapper_calls.py
@@ -168,7 +168,6 @@ def test_iq_wrappers_forward_calls(monkeypatch, sample_3dt_volume_complex):
             velocity_window_width=8,
             velocity_window_stride=4,
             lag=2,
-            absolute_velocity=True,
             spatial_kernel=(1, 3, 5),
         )
         is expected
@@ -186,7 +185,6 @@ def test_iq_wrappers_forward_calls(monkeypatch, sample_3dt_volume_complex):
             "velocity_window_width": 8,
             "velocity_window_stride": 4,
             "lag": 2,
-            "absolute_velocity": True,
             "spatial_kernel": (1, 3, 5),
         },
     )

--- a/tests/unit/test_xarray/test_wrapper_calls.py
+++ b/tests/unit/test_xarray/test_wrapper_calls.py
@@ -169,7 +169,7 @@ def test_iq_wrappers_forward_calls(monkeypatch, sample_3dt_volume_complex):
             velocity_window_stride=4,
             lag=2,
             absolute_velocity=True,
-            spatial_kernel=3,
+            spatial_kernel=(1, 3, 5),
         )
         is expected
     )
@@ -187,7 +187,7 @@ def test_iq_wrappers_forward_calls(monkeypatch, sample_3dt_volume_complex):
             "velocity_window_stride": 4,
             "lag": 2,
             "absolute_velocity": True,
-            "spatial_kernel": 3,
+            "spatial_kernel": (1, 3, 5),
         },
     )
 


### PR DESCRIPTION
Always uses the standard Kasai estimator, removes `estimation_method`, and lets axial velocity `spatial_kernel` default to `3` or be passed per axis as `(z, y, x)`.

Closes #314.