### PR TITLE
feat(io): add experimental Iconeus SCAN v2 loader

### DIFF
--- a/.harper-dictionary.txt
+++ b/.harper-dictionary.txt
@@ -67,5 +67,6 @@ stereotactic
 subspaces
 tSNR
 ty
+unvalidated
 velocimetry
 volumewise

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -33,9 +33,10 @@ Current development version for the next ConfUSIus release.
 
 - [`load_scan`][confusius.io.load_scan] now opens binary Iconeus SCAN v2 files in
   addition to HDF5 SCAN v1 files, detecting the format automatically. SCAN v2 support is
-  experimental: data, timing, voxel spacing, and the depth origin are recovered (lateral
-  and elevation axes are centred on zero), but there is no `physical_to_lab` affine yet
-  and multi-pose layouts are inferred
+  experimental: data, timing, voxel spacing, the depth origin, and provenance
+  (subject/session/project/scan/experimenter, serial number, acquisition datetime) are
+  recovered (lateral and elevation axes are centred on zero), but there is no
+  `physical_to_lab` affine yet and multi-pose layouts are inferred
   ([#316](https://github.com/confusius-tools/confusius/issues/316)).
 - **[Napari plugin]** Added an interactive registration panel for volume alignment in
   napari, including linear and non-linear transforms, progress preview, manual and

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -39,7 +39,8 @@ Current development version for the next ConfUSIus release.
   pitch, focal depth, imaging depth, PRF, plane-wave angles, SVD low cutoff, power-Doppler
   integration window) are recovered (lateral and elevation axes are centred on zero). A
   `physical_to_lab` affine is derived from a header block read as a 6DOF probe pose
-  (experimental, assumed convention). Multi-pose layouts are inferred
+  (experimental, assumed convention), and a BPS sidecar composes a `physical_to_brain`
+  affine as for v1. Multi-pose layouts are inferred
   ([#317](https://github.com/confusius-tools/confusius/pull/317)).
 - **[Napari plugin]** Added an interactive registration panel for volume alignment in
   napari, including linear and non-linear transforms, progress preview, manual and

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -31,6 +31,12 @@ Current development version for the next ConfUSIus release.
 
 ### :sparkles: Enhancements
 
+- [`load_scan`][confusius.io.load_scan] now opens binary Iconeus SCAN v2 files in
+  addition to HDF5 SCAN v1 files, detecting the format automatically. SCAN v2 support is
+  experimental: data, timing, voxel spacing, and the depth origin are recovered (lateral
+  and elevation axes are centred on zero), but there is no `physical_to_lab` affine yet
+  and multi-pose layouts are inferred
+  ([#316](https://github.com/confusius-tools/confusius/issues/316)).
 - **[Napari plugin]** Added an interactive registration panel for volume alignment in
   napari, including linear and non-linear transforms, progress preview, manual and
   automatic initialization, saving/loading transforms, and forward/inverse transform

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -33,10 +33,12 @@ Current development version for the next ConfUSIus release.
 
 - [`load_scan`][confusius.io.load_scan] now opens binary Iconeus SCAN v2 files in
   addition to HDF5 SCAN v1 files, detecting the format automatically. SCAN v2 support is
-  experimental: data, timing, voxel spacing, the depth origin, and provenance
-  (subject/session/project/scan/experimenter, serial number, acquisition datetime) are
-  recovered (lateral and elevation axes are centred on zero), but there is no
-  `physical_to_lab` affine yet and multi-pose layouts are inferred
+  experimental: data, timing, voxel spacing, the depth origin, provenance
+  (subject/session/project/scan/experimenter, serial number, acquisition datetime), and
+  BIDS-corresponding acquisition settings (probe model, centre/transmit frequencies,
+  pitch, focal depth, imaging depth, PRF, plane-wave angles, SVD low cutoff, power-Doppler
+  integration window) are recovered (lateral and elevation axes are centred on zero), but
+  there is no `physical_to_lab` affine yet and multi-pose layouts are inferred
   ([#317](https://github.com/confusius-tools/confusius/pull/317)).
 - **[Napari plugin]** Added an interactive registration panel for volume alignment in
   napari, including linear and non-linear transforms, progress preview, manual and

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -35,9 +35,9 @@ Current development version for the next ConfUSIus release.
   addition to HDF5 SCAN v1 files, detecting the format automatically. SCAN v2 support is
   experimental: data, timing, voxel spacing, the depth origin, provenance
   (subject/session/project/scan/experimenter, serial number, acquisition datetime), and
-  BIDS-corresponding acquisition settings (probe model, centre/transmit frequencies,
+  BIDS-corresponding acquisition settings (probe model, center/transmit frequencies,
   pitch, focal depth, imaging depth, PRF, plane-wave angles, SVD low cutoff, power-Doppler
-  integration window) are recovered (lateral and elevation axes are centred on zero). A
+  integration window) are recovered (lateral and elevation axes are centered on zero). A
   `physical_to_lab` affine is derived from a header block read as a 6DOF probe pose
   (experimental, assumed convention), and a BPS sidecar composes a `physical_to_brain`
   affine as for v1. Multi-pose layouts are inferred

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -37,8 +37,9 @@ Current development version for the next ConfUSIus release.
   (subject/session/project/scan/experimenter, serial number, acquisition datetime), and
   BIDS-corresponding acquisition settings (probe model, centre/transmit frequencies,
   pitch, focal depth, imaging depth, PRF, plane-wave angles, SVD low cutoff, power-Doppler
-  integration window) are recovered (lateral and elevation axes are centred on zero), but
-  there is no `physical_to_lab` affine yet and multi-pose layouts are inferred
+  integration window) are recovered (lateral and elevation axes are centred on zero). A
+  `physical_to_lab` affine is derived from a header block read as a 6DOF probe pose
+  (experimental, assumed convention). Multi-pose layouts are inferred
   ([#317](https://github.com/confusius-tools/confusius/pull/317)).
 - **[Napari plugin]** Added an interactive registration panel for volume alignment in
   napari, including linear and non-linear transforms, progress preview, manual and

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -37,7 +37,7 @@ Current development version for the next ConfUSIus release.
   (subject/session/project/scan/experimenter, serial number, acquisition datetime) are
   recovered (lateral and elevation axes are centred on zero), but there is no
   `physical_to_lab` affine yet and multi-pose layouts are inferred
-  ([#316](https://github.com/confusius-tools/confusius/issues/316)).
+  ([#317](https://github.com/confusius-tools/confusius/pull/317)).
 - **[Napari plugin]** Added an interactive registration panel for volume alignment in
   napari, including linear and non-linear transforms, progress preview, manual and
   automatic initialization, saving/loading transforms, and forward/inverse transform

--- a/docs/user-guide/io.md
+++ b/docs/user-guide/io.md
@@ -284,9 +284,10 @@ compute operations on it.
 
 ### Loading Iconeus SCAN Files
 
-Use [`load_scan`][confusius.io.load_scan] to load Iconeus `.scan` files (HDF5 files
-produced by IcoScan) as lazy Xarray DataArrays. Three acquisition modes are supported,
-each yielding a DataArray with different dimensions:
+Use [`load_scan`][confusius.io.load_scan] to load Iconeus `.scan` files as lazy Xarray
+DataArrays. Two on-disk formats are detected automatically: the HDF5-based **v1** format
+(produced by IcoScan) and the newer binary **v2** format (see below). For v1, three
+acquisition modes are supported, each yielding a DataArray with different dimensions:
 
 | Mode | Dimensions | Description |
 |------|------------|-------------|
@@ -342,7 +343,7 @@ SCAN files stay open while the Dask graph is un-computed, so keep the DataArray 
 scope or call [`.compute()`][xarray.DataArray.compute] before discarding it.
 
 !!! warning "SCAN files and parallel processing"
-    SCAN files are HDF5 files, and h5py datasets **cannot be pickled**. This means
+    v1 SCAN files are HDF5 files, and h5py datasets **cannot be pickled**. This means
     lazy SCAN DataArrays cannot be passed to functions that use parallel workers
     (e.g., [`register_volumewise`][confusius.registration.register_volumewise] with
     `n_jobs != 1`). Call `.compute()` to load the data into memory before running any
@@ -360,6 +361,22 @@ scope or call [`.compute()`][xarray.DataArray.compute] before discarding it.
 
 Provenance metadata from the file is stored in `da.attrs`: `scan_mode`, `subject`,
 `session`, `scan`, `project`, `date`, `neuroscan_version`, and `machine_sn`.
+
+#### SCAN v2 (binary format)
+
+`load_scan` also opens the newer binary SCAN v2 format, detected automatically (no extra
+arguments needed).
+
+!!! warning "Experimental"
+    v2 field offsets were reverse-engineered from a few example files. The data, timing,
+    voxel spacing, depth origin, provenance (`iconeus_*` attrs plus the raw
+    `iconeus_header_strings`), acquisition datetime, and BIDS-corresponding acquisition
+    settings (`probe_model`, `probe_center_frequency`, `transmit_frequency`,
+    `pulse_repetition_frequency`, `plane_wave_angles`, `svd_low_cutoff`, …) are recovered
+    into `da.attrs`. Lateral/elevation coordinates are centered on zero. A
+    `physical_to_lab` affine is derived from a header block read as a 6DOF probe pose;
+    this and multi-pose layouts are unvalidated and may change. `bps_path` works as for
+    v1 when that affine could be built.
 
 #### Loading a BPS File
 

--- a/docs/user-guide/io.md
+++ b/docs/user-guide/io.md
@@ -284,10 +284,15 @@ compute operations on it.
 
 ### Loading Iconeus SCAN Files
 
+
 Use [`load_scan`][confusius.io.load_scan] to load Iconeus `.scan` files as lazy Xarray
-DataArrays. Two on-disk formats are detected automatically: the HDF5-based **v1** format
-(produced by IcoScan) and the newer binary **v2** format (see below). For v1, three
-acquisition modes are supported, each yielding a DataArray with different dimensions:
+DataArrays. Two on-disk formats are detected automatically: the HDF5-based SCAN v1
+format and the newer binary SCAN v2 format.
+
+#### SCAN v1 (HDF5 format)
+
+For SCAN v1, three acquisition modes are supported, each yielding a DataArray with
+different dimensions:
 
 | Mode | Dimensions | Description |
 |------|------------|-------------|
@@ -339,15 +344,15 @@ All spatial coordinates are in millimeters; the `time` coordinate is in seconds.
     per-pose acquisition timestamps.
 
 The DataArray is loaded **lazily**: data remains on disk until explicitly computed.
-SCAN files stay open while the Dask graph is un-computed, so keep the DataArray in
+SCAN files stay open while the Dask graph remains non-computed, so keep the DataArray in
 scope or call [`.compute()`][xarray.DataArray.compute] before discarding it.
 
 !!! warning "SCAN files and parallel processing"
-    v1 SCAN files are HDF5 files, and h5py datasets **cannot be pickled**. This means
-    lazy SCAN DataArrays cannot be passed to functions that use parallel workers
-    (e.g., [`register_volumewise`][confusius.registration.register_volumewise] with
-    `n_jobs != 1`). Call `.compute()` to load the data into memory before running any
-    parallel operation:
+    SCAN v1 files are HDF5 files, and h5py datasets **cannot be pickled**. This means
+    lazy SCAN DataArrays cannot be passed to functions that use parallel workers (e.g.,
+    [`register_volumewise`][confusius.registration.register_volumewise] with `n_jobs !=
+    1`). Call `.compute()` to load the data into memory before running any parallel
+    operation:
 
     ```python
     import confusius as cf
@@ -368,15 +373,13 @@ Provenance metadata from the file is stored in `da.attrs`: `scan_mode`, `subject
 arguments needed).
 
 !!! warning "Experimental"
-    v2 field offsets were reverse-engineered from a few example files. The data, timing,
-    voxel spacing, depth origin, provenance (`iconeus_*` attrs plus the raw
-    `iconeus_header_strings`), acquisition datetime, and BIDS-corresponding acquisition
-    settings (`probe_model`, `probe_center_frequency`, `transmit_frequency`,
-    `pulse_repetition_frequency`, `plane_wave_angles`, `svd_low_cutoff`, …) are recovered
-    into `da.attrs`. Lateral/elevation coordinates are centered on zero. A
-    `physical_to_lab` affine is derived from a header block read as a 6DOF probe pose;
-    this and multi-pose layouts are unvalidated and may change. `bps_path` works as for
-    v1 when that affine could be built.
+    SCAN v2 metadata were reverse-engineered from a few example files. The data, timing,
+    voxel spacing, depth origin, `physical_to_lab` affine, provenance (`iconeus_*`
+    attrs), acquisition datetime, and BIDS-corresponding acquisition settings
+    (`probe_model`, `probe_center_frequency`, `transmit_frequency`,
+    `pulse_repetition_frequency`, `plane_wave_angles`, `svd_low_cutoff`, …) are
+    recovered into `da.attrs`. Lateral/elevation coordinates are centered on zero. This
+    and multi-pose layouts are unvalidated and may change.
 
 #### Loading a BPS File
 

--- a/src/confusius/io/scan.py
+++ b/src/confusius/io/scan.py
@@ -48,10 +48,84 @@ _SCAN_V2_OFFSETS: dict[str, int] = {
 """Byte offsets of fixed-position fields in the SCAN v2 header.
 
 All fields listed here live before the first variable-length string in the header, so
-their absolute offsets are stable across files. Integer fields are little-endian
-`uint64`; `dt` and the voxel sizes are little-endian `float64`; `time_coords` is the
-start of an array of `n_time` little-endian `float64` values.
+their absolute offsets are stable across files. The dimension and size fields are
+little-endian `uint64`; `svd_clutter_cutoff` and `power_doppler_integration_window` are
+`uint32`; `dt` and the voxel sizes are `float64`; `time_coords` is the start of an array
+of `n_time` little-endian `float64` values.
 """
+
+
+def _u16(buffer: bytes, offset: int) -> int:
+    """Read a little-endian `uint16` from `buffer` at `offset`.
+
+    Parameters
+    ----------
+    buffer : bytes
+        Byte buffer to read from.
+    offset : int
+        Byte offset of the value.
+
+    Returns
+    -------
+    int
+        The decoded value.
+    """
+    return int.from_bytes(buffer[offset : offset + 2], "little")
+
+
+def _u32(buffer: bytes, offset: int) -> int:
+    """Read a little-endian `uint32` from `buffer` at `offset`.
+
+    Parameters
+    ----------
+    buffer : bytes
+        Byte buffer to read from.
+    offset : int
+        Byte offset of the value.
+
+    Returns
+    -------
+    int
+        The decoded value.
+    """
+    return int.from_bytes(buffer[offset : offset + 4], "little")
+
+
+def _u64(buffer: bytes, offset: int) -> int:
+    """Read a little-endian `uint64` from `buffer` at `offset`.
+
+    Parameters
+    ----------
+    buffer : bytes
+        Byte buffer to read from.
+    offset : int
+        Byte offset of the value.
+
+    Returns
+    -------
+    int
+        The decoded value.
+    """
+    return int.from_bytes(buffer[offset : offset + 8], "little")
+
+
+def _f64(buffer: bytes, offset: int) -> float:
+    """Read a little-endian `float64` from `buffer` at `offset`.
+
+    Parameters
+    ----------
+    buffer : bytes
+        Byte buffer to read from.
+    offset : int
+        Byte offset of the value.
+
+    Returns
+    -------
+    float
+        The decoded value.
+    """
+    return float(struct.unpack_from("<d", buffer, offset)[0])
+
 
 PHYSICAL_TO_PROBE_PERMUTATION: npt.NDArray[np.float64] = np.array(
     [[0, 0, 1, 0], [1, 0, 0, 0], [0, -1, 0, 0], [0, 0, 0, 1]], dtype=float
@@ -278,6 +352,30 @@ def load_bps(bps_path: str | Path) -> npt.NDArray[np.float64]:
     return brain_to_confusius_lab
 
 
+def _add_physical_to_brain(affines: dict[str, Any], bps_path: str | Path) -> None:
+    """Compose a `physical_to_brain` affine from a BPS sidecar and store it in `affines`.
+
+    Requires `affines["physical_to_lab"]` to be present. The composition matches both the
+    v1 and v2 loaders: `physical_to_brain = inv(load_bps(bps_path)) @ physical_to_lab`.
+
+    Parameters
+    ----------
+    affines : dict
+        The DataArray's `affines` attribute; mutated in place to add `physical_to_brain`.
+    bps_path : str or pathlib.Path
+        Path to the BPS file (`.bps`).
+
+    Returns
+    -------
+    None
+        `affines` is updated in place.
+    """
+    brain_to_lab = load_bps(bps_path)
+    affines["physical_to_brain"] = (
+        np.linalg.inv(brain_to_lab) @ affines["physical_to_lab"]
+    )
+
+
 def load_scan(
     path: str | Path,
     bps_path: str | Path | None = None,
@@ -411,10 +509,7 @@ def load_scan(
                     "for this SCAN v2 file (the 6DOF probe-pose block was missing or "
                     "implausible), so the BPS transform cannot be composed."
                 )
-            brain_to_lab = load_bps(bps_path)
-            affines["physical_to_brain"] = (
-                np.linalg.inv(brain_to_lab) @ affines["physical_to_lab"]
-            )
+            _add_physical_to_brain(affines, bps_path)
         return data_array
 
     raise ValueError(
@@ -506,9 +601,7 @@ def _load_scan_v1(
 
         data_array.name = attrs["iconeus_scan"] or path.stem
         if bps_path is not None:
-            brain_to_lab = load_bps(bps_path)
-            physical_to_brain = np.linalg.inv(brain_to_lab) @ physical_to_lab
-            data_array.attrs["affines"]["physical_to_brain"] = physical_to_brain
+            _add_physical_to_brain(data_array.attrs["affines"], bps_path)
     except Exception:
         h5.close()
         raise
@@ -746,9 +839,8 @@ def _read_scan_v2_header(header: bytes) -> dict[str, Any]:
     -------
     dict
         Parsed fields: `size_x`, `size_y`, `size_z`, `n_time`, `npose`,
-        `nblock_repeat`, `payload_bytes`, `total_header_bytes`, `svd_clutter_cutoff`,
-        `power_doppler_integration_window` (int); `dt`, `x_voxel_m`, `y_voxel_m`,
-        `z_voxel_m` (float); and `time_coords` (`(n_time,) numpy.ndarray`).
+        `nblock_repeat`, `payload_bytes`, `total_header_bytes` (int); `dt`, `x_voxel_m`,
+        `y_voxel_m`, `z_voxel_m` (float); and `time_coords` (`(n_time,) numpy.ndarray`).
 
     Raises
     ------
@@ -758,16 +850,7 @@ def _read_scan_v2_header(header: bytes) -> dict[str, Any]:
     """
     o = _SCAN_V2_OFFSETS
 
-    def u32(offset: int) -> int:
-        return int.from_bytes(header[offset : offset + 4], "little")
-
-    def u64(offset: int) -> int:
-        return int.from_bytes(header[offset : offset + 8], "little")
-
-    def f64(offset: int) -> float:
-        return float(struct.unpack_from("<d", header, offset)[0])
-
-    n_time = u64(o["n_time"])
+    n_time = _u64(header, o["n_time"])
     time_end = o["time_coords"] + 8 * n_time
     if n_time < 1 or time_end > len(header):
         raise ValueError(
@@ -776,20 +859,18 @@ def _read_scan_v2_header(header: bytes) -> dict[str, Any]:
         )
 
     fields: dict[str, Any] = {
-        "size_x": u64(o["size_x"]),
-        "size_y": u64(o["size_y"]),
-        "size_z": u64(o["size_z"]),
+        "size_x": _u64(header, o["size_x"]),
+        "size_y": _u64(header, o["size_y"]),
+        "size_z": _u64(header, o["size_z"]),
         "n_time": n_time,
-        "npose": u64(o["npose"]),
-        "nblock_repeat": u64(o["nblock_repeat"]),
-        "payload_bytes": u64(o["payload_bytes"]),
-        "total_header_bytes": u64(o["total_header_bytes"]),
-        "dt": f64(o["dt"]),
-        "svd_clutter_cutoff": u32(o["svd_clutter_cutoff"]),
-        "power_doppler_integration_window": u32(o["power_doppler_integration_window"]),
-        "x_voxel_m": f64(o["x_voxel_m"]),
-        "y_voxel_m": f64(o["y_voxel_m"]),
-        "z_voxel_m": f64(o["z_voxel_m"]),
+        "npose": _u64(header, o["npose"]),
+        "nblock_repeat": _u64(header, o["nblock_repeat"]),
+        "payload_bytes": _u64(header, o["payload_bytes"]),
+        "total_header_bytes": _u64(header, o["total_header_bytes"]),
+        "dt": _f64(header, o["dt"]),
+        "x_voxel_m": _f64(header, o["x_voxel_m"]),
+        "y_voxel_m": _f64(header, o["y_voxel_m"]),
+        "z_voxel_m": _f64(header, o["z_voxel_m"]),
         "time_coords": np.frombuffer(
             header, dtype="<f8", count=n_time, offset=o["time_coords"]
         ).copy(),
@@ -835,7 +916,7 @@ def _scan_v2_strings(header: bytes) -> list[tuple[str, bool, int]]:
     i = 0
     n = len(header)
     while i + 4 <= n:
-        length = int.from_bytes(header[i : i + 4], "little")
+        length = _u32(header, i)
         if 1 <= length <= 256 and i + 4 + length <= n:
             body = header[i + 4 : i + 4 + length]
             if all(32 <= c < 127 for c in body):
@@ -885,7 +966,7 @@ def _scan_v2_datetime(header: bytes, records: list[tuple[str, bool, int]]) -> st
     plain_ends = [end for text, is_hex, end in records if not is_hex]
     start = plain_ends[4] if len(plain_ends) >= 5 else 0
     for offset in range(start, len(header) - 7):
-        value = int.from_bytes(header[offset : offset + 8], "little")
+        value = _u64(header, offset)
         if 1_420_000_000 <= value <= 2_050_000_000:
             return datetime.fromtimestamp(value, UTC).isoformat()
     return ""
@@ -990,10 +1071,9 @@ def _load_scan_v2(
         If the header is truncated, reports implausible dimensions, or if the reported
         payload size does not match the product of the dimensions.
     """
+    offset = _SCAN_V2_OFFSETS["total_header_bytes"]
     with path.open("rb") as f:
-        total_header_bytes = int.from_bytes(
-            f.read(_SCAN_V2_OFFSETS["total_header_bytes"] + 8)[-8:], "little"
-        )
+        total_header_bytes = _u64(f.read(offset + 8), offset)
         f.seek(0)
         header = f.read(total_header_bytes)
 
@@ -1092,8 +1172,8 @@ def _scan_v2_depth_start(header: bytes, size_z: int, dz_mm: float) -> float:
     expected_span = (size_z - 1) * dz_mm
     tolerance = max(0.1, dz_mm)
     for offset in range(0, len(header) - 16):
-        start = struct.unpack_from("<d", header, offset)[0]
-        end = struct.unpack_from("<d", header, offset + 8)[0]
+        start = _f64(header, offset)
+        end = _f64(header, offset + 8)
         if 0.0 < start < end < 100.0 and abs((end - start) - expected_span) < tolerance:
             return float(start)
     return 0.0
@@ -1213,19 +1293,12 @@ def _scan_v2_acquisition(
     """
     o = _SCAN_V2_OFFSETS
 
-    def u16(offset: int) -> int:
-        return int.from_bytes(header[offset : offset + 2], "little")
-
-    def u32(offset: int) -> int:
-        return int.from_bytes(header[offset : offset + 4], "little")
-
-    def f64(offset: int) -> float:
-        return float(struct.unpack_from("<d", header, offset)[0])
-
     # Filter fields at fixed absolute offsets, always available.
     result: dict[str, Any] = {
-        "svd_low_cutoff": u32(o["svd_clutter_cutoff"]),
-        "power_doppler_integration_window": u32(o["power_doppler_integration_window"]),
+        "svd_low_cutoff": _u32(header, o["svd_clutter_cutoff"]),
+        "power_doppler_integration_window": _u32(
+            header, o["power_doppler_integration_window"]
+        ),
     }
 
     # Structured block: after time_coords (n_time f64) and frame indices (n_time u32)
@@ -1236,7 +1309,7 @@ def _scan_v2_acquisition(
     if name_off + 2 > len(header):
         return result
 
-    name_len = u16(name_off)
+    name_len = _u16(header, name_off)
     name_end = name_off + 2 + name_len
     if not (1 <= name_len <= 64) or name_end + 52 > len(header):
         return result
@@ -1246,19 +1319,19 @@ def _scan_v2_acquisition(
 
     # Anchor check: the depth range starts right after the probe name and must agree
     # with the independently located depth origin.
-    depth_start = f64(name_end)
+    depth_start = _f64(header, name_end)
     if not depth_start_mm or abs(depth_start - depth_start_mm) > 0.5:
         return result
 
     result["probe_model"] = name_bytes.decode("ascii")
-    result["probe_center_frequency"] = f64(freq_off)
-    result["probe_pitch"] = f64(freq_off + 8)
-    result["probe_focal_depth"] = f64(freq_off + 24)
-    result["imaging_depth"] = (depth_start, f64(name_end + 8))
-    result["transmit_frequency"] = f64(name_end + 16)
-    result["pulse_repetition_frequency"] = f64(name_end + 24)
+    result["probe_center_frequency"] = _f64(header, freq_off)
+    result["probe_pitch"] = _f64(header, freq_off + 8)
+    result["probe_focal_depth"] = _f64(header, freq_off + 24)
+    result["imaging_depth"] = (depth_start, _f64(header, name_end + 8))
+    result["transmit_frequency"] = _f64(header, name_end + 16)
+    result["pulse_repetition_frequency"] = _f64(header, name_end + 24)
 
-    n_angles = u32(name_end + 48)
+    n_angles = _u32(header, name_end + 48)
     if 1 <= n_angles <= 512 and name_end + 52 + 8 * n_angles <= len(header):
         angles = np.frombuffer(
             header, dtype="<f8", count=n_angles, offset=name_end + 52

--- a/src/confusius/io/scan.py
+++ b/src/confusius/io/scan.py
@@ -829,7 +829,7 @@ def _scan_v2_strings(header: bytes) -> list[tuple[str, bool, int]]:
     return records
 
 
-def _scan_v2_date(header: bytes, records: list[tuple[str, bool, int]]) -> str:
+def _scan_v2_datetime(header: bytes, records: list[tuple[str, bool, int]]) -> str:
     """Recover the acquisition timestamp from the SCAN v2 header, best-effort.
 
     The header stores the acquisition time as a `uint64` Unix timestamp (full seconds
@@ -1152,7 +1152,7 @@ def _scan_v2_attrs(header: bytes, npose: int, n_time_total: int) -> dict[str, An
     -------
     dict
         Attributes for the DataArray: `affines` (empty), `iconeus_scan_format`,
-        `iconeus_scan_mode`, `iconeus_date`, the mapped provenance fields, and the raw
+        `iconeus_scan_mode`, `iconeus_datetime`, the mapped provenance fields, and the raw
         `iconeus_header_strings`.
     """
     if npose > 1:
@@ -1166,7 +1166,7 @@ def _scan_v2_attrs(header: bytes, npose: int, n_time_total: int) -> dict[str, An
         "affines": {},
         "iconeus_scan_format": "v2",
         "iconeus_scan_mode": scan_mode,
-        "iconeus_date": _scan_v2_date(header, records),
+        "iconeus_datetime": _scan_v2_datetime(header, records),
         "iconeus_header_strings": [text for text, _, _ in records],
     }
     attrs.update(_scan_v2_provenance(records))

--- a/src/confusius/io/scan.py
+++ b/src/confusius/io/scan.py
@@ -1,9 +1,18 @@
 """Utilities for loading Iconeus SCAN files.
 
-This module provides functions to load Iconeus SCAN (`.scan`) HDF5 files as lazy Xarray
-DataArrays using h5py and Dask for out-of-core processing.
+Iconeus ships two on-disk SCAN formats, both using the `.scan` extension:
+
+- **v1**: an HDF5 container (`acqMetaData`, `scanMetaData`, `/Data`). Loaded lazily with
+  h5py and Dask.
+- **v2**: a flat binary file with a variable-length header followed by a little-endian
+  `float64` power-Doppler payload. Loaded lazily with a NumPy memmap wrapped in Dask.
+
+`load_scan` sniffs the format and dispatches to the matching loader. The v2 loader is
+**experimental**: its field offsets were reverse-engineered from a small number of
+example files and may not cover every acquisition mode. See `_load_scan_v2` for details.
 """
 
+import struct
 from pathlib import Path
 from typing import Any
 
@@ -14,6 +23,32 @@ import numpy.typing as npt
 import xarray as xr
 
 from confusius.io.utils import check_path
+
+SCAN_V2_MAGIC = b"scan"
+"""Magic bytes at offset 0 identifying a binary SCAN v2 file."""
+
+_SCAN_V2_OFFSETS: dict[str, int] = {
+    "total_header_bytes": 0x20,
+    "payload_bytes": 0x28,
+    "size_x": 0x5C,
+    "size_y": 0x64,
+    "size_z": 0x6C,
+    "n_time": 0x74,
+    "npose": 0x7C,
+    "nblock_repeat": 0x84,
+    "dt": 0x94,
+    "x_voxel_m": 0xA4,
+    "y_voxel_m": 0xAC,
+    "z_voxel_m": 0xB4,
+    "time_coords": 0xD4,
+}
+"""Byte offsets of fixed-position fields in the SCAN v2 header.
+
+All fields listed here live before the first variable-length string in the header, so
+their absolute offsets are stable across files. Integer fields are little-endian
+`uint64`; `dt` and the voxel sizes are little-endian `float64`; `time_coords` is the
+start of an array of `n_time` little-endian `float64` values.
+"""
 
 PHYSICAL_TO_PROBE_PERMUTATION: npt.NDArray[np.float64] = np.array(
     [[0, 0, 1, 0], [1, 0, 0, 0], [0, -1, 0, 0], [0, 0, 0, 1]], dtype=float
@@ -247,13 +282,17 @@ def load_scan(
 ) -> xr.DataArray:
     """Load an Iconeus SCAN file as a lazy Xarray DataArray.
 
-    SCAN files (`.scan`) are HDF5 files produced by IcoScan/NeuroScan. They contain
-    power Doppler data and spatial/temporal metadata for 2D, 3D, or 3D+t fUSI volumes.
+    SCAN files (`.scan`) come in two on-disk formats, both handled here:
 
-    The returned DataArray wraps an open `h5py` file handle via a Dask array. The
-    file remains open while the Dask graph is un-computed. Call `.compute()` before
-    closing the file, or keep the returned DataArray in scope to prevent the handle from
-    being garbage-collected.
+    - **v1**: an HDF5 container produced by IcoScan/NeuroScan, holding power Doppler
+      data and spatial/temporal metadata for 2D, 3D, or 3D+t fUSI volumes. The returned
+      DataArray wraps an open `h5py` handle via a Dask array; keep it in scope (or call
+      `.compute()`) before the handle is garbage-collected.
+    - **v2**: a flat binary file (variable-length header + little-endian `float64`
+      payload). The returned DataArray wraps a NumPy memmap via a Dask array. Support is
+      **experimental** (see Notes); `bps_path` is not yet supported for v2.
+
+    `load_scan` sniffs the format automatically and dispatches accordingly.
 
     Parameters
     ----------
@@ -261,7 +300,8 @@ def load_scan(
         Path to the SCAN file (`.scan`).
     bps_path : str or pathlib.Path, optional
         Path to the corresponding BPS file (`.bps`). If provided, the BPS transformation
-        matrix will be added as an affine attribute to the returned DataArray.
+        matrix will be added as an affine attribute to the returned DataArray. Only
+        supported for v1 (HDF5) files.
     chunks : int or tuple[int, ...] or str or None, default: "auto"
         Dask chunk specification passed to `dask.array.from_array`. Accepted forms:
 
@@ -277,23 +317,35 @@ def load_scan(
     xarray.DataArray
         Lazy DataArray with dimensions and coordinates:
 
-        - `2Dscan` → `(time, z, y, x)`.
-        - `3Dscan` → `(pose, z, y, x)`.
-        - `4Dscan` → `(time, pose, z, y, x)`.
+        - v1 `2Dscan` → `(time, z, y, x)`.
+        - v1 `3Dscan` → `(pose, z, y, x)`.
+        - v1 `4Dscan` → `(time, pose, z, y, x)`.
+        - v2 single-pose → `(time, z, y, x)`.
+        - v2 multi-pose → `(time, pose, z, y, x)`.
 
         All spatial coordinates are in millimeters. The `time` coordinate is in
-        seconds. For `4Dscan`, a `pose_time` non-dimension coordinate of shape
+        seconds. For v1 `4Dscan`, a `pose_time` non-dimension coordinate of shape
         `(time, pose)` stores the actual per-pose acquisition timestamps.
 
     Raises
     ------
     ValueError
-        If `path` does not exist or is not a file, if the file is not an HDF5-based
-        SCAN file supported by ConfUSIus, or if the `acquisitionMode` stored in the
-        file is not one of `"2Dscan"`, `"3Dscan"`, or `"4Dscan"`.
+        If `path` does not exist or is not a file, if the file is neither an
+        HDF5-based SCAN (v1) nor a binary SCAN v2 file, if `bps_path` is passed for a
+        v2 file, or if a v1 `acquisitionMode` is not one of `"2Dscan"`, `"3Dscan"`, or
+        `"4Dscan"`.
 
     Notes
     -----
+    **v2 (experimental).** The v2 field offsets were reverse-engineered from a small
+    number of example files. Data, temporal geometry, and voxel spacing are recovered.
+    The depth (`y`) origin is read from the header when the depth range can be located;
+    the lateral (`x`) and elevation (`z`) origins are not encoded, so those axes are
+    centred on zero (correct spacing, arbitrary origin). No `probeToLab`-equivalent
+    affine has been located, so v2 DataArrays carry **no** `physical_to_lab` affine.
+    Multi-pose / multi-block v2 layouts are inferred by analogy with v1 and have not
+    been validated against real files.
+
     The `physical_to_lab` affine stored in `da.attrs["affines"]` maps ConfUSIus physical
     coordinates `(z, y, x)` to **ConfUSIus-ordered** Iconeus lab coordinates (mm). Apply
     as `da.attrs["affines"]["physical_to_lab"] @ np.array([z, y, x, 1.0])`. For
@@ -312,13 +364,68 @@ def load_scan(
     """
     path = check_path(path, type="file")
 
-    if not h5py.is_hdf5(path):
-        raise ValueError(
-            f"{path.name!r} is not an HDF5-based SCAN file supported by ConfUSIus. "
-            "It may be an Iconeus SCAN v2 file; convert it to NIfTI with Iconeus "
-            "tools first."
-        )
+    if h5py.is_hdf5(path):
+        return _load_scan_v1(path, bps_path, chunks)
 
+    with path.open("rb") as f:
+        magic = f.read(len(SCAN_V2_MAGIC))
+
+    if magic == SCAN_V2_MAGIC:
+        if bps_path is not None:
+            raise ValueError(
+                "bps_path is not supported for SCAN v2 files: the physical_to_lab "
+                "affine needed to compose the BPS transform has not yet been located "
+                "in the v2 header."
+            )
+        # v2 support is reverse-engineered and incomplete: re-raise any parse failure
+        # with a pointer to the issue tracker and the original error appended.
+        try:
+            return _load_scan_v2(path, chunks)
+        except Exception as error:
+            raise ValueError(
+                "Loading Iconeus SCAN v2 files is experimental and this file could "
+                "not be parsed. Please open an issue at "
+                "https://github.com/confusius-tools/confusius/issues (attaching an "
+                f"example file if possible).\n\nOriginal error: "
+                f"{type(error).__name__}: {error}"
+            ) from error
+
+    raise ValueError(
+        f"{path.name!r} is not a SCAN file recognised by ConfUSIus. Expected an "
+        f"HDF5-based SCAN (v1) or a binary SCAN v2 file starting with the magic bytes "
+        f"{SCAN_V2_MAGIC!r}."
+    )
+
+
+def _load_scan_v1(
+    path: Path,
+    bps_path: str | Path | None,
+    chunks: int | tuple[int, ...] | str | None,
+) -> xr.DataArray:
+    """Load an HDF5-based Iconeus SCAN (v1) file as a lazy DataArray.
+
+    Parameters
+    ----------
+    path : pathlib.Path
+        Path to the v1 SCAN file, already validated as HDF5.
+    bps_path : str or pathlib.Path, optional
+        Path to the corresponding BPS file (`.bps`). If provided, a `physical_to_brain`
+        affine is added to `da.attrs["affines"]`.
+    chunks : int or tuple[int, ...] or str or None
+        Dask chunk specification passed to `dask.array.from_array`.
+
+    Returns
+    -------
+    xarray.DataArray
+        Lazy DataArray whose dims depend on the file's `acquisitionMode`. See
+        `load_scan` for the full contract.
+
+    Raises
+    ------
+    ValueError
+        If the `acquisitionMode` stored in the file is not one of `"2Dscan"`,
+        `"3Dscan"`, or `"4Dscan"`.
+    """
     h5 = h5py.File(path, "r")
 
     try:
@@ -593,3 +700,371 @@ def _load_4dscan(
     return xr.DataArray(
         data_lazy, dims=["time", "pose", "z", "y", "x"], coords=coords, attrs=attrs
     )
+
+
+def _read_scan_v2_header(header: bytes) -> dict[str, Any]:
+    """Parse the fixed-position numeric fields of a SCAN v2 header.
+
+    Only the fields listed in `_SCAN_V2_OFFSETS` are read. These all live before the
+    first variable-length string, so their absolute offsets are stable across files.
+    Provenance strings, which follow the variable-length region, are handled separately
+    by `_scan_v2_strings`.
+
+    Parameters
+    ----------
+    header : bytes
+        The full header bytes (`total_header_bytes` long).
+
+    Returns
+    -------
+    dict
+        Parsed fields: `size_x`, `size_y`, `size_z`, `n_time`, `npose`,
+        `nblock_repeat`, `payload_bytes`, `total_header_bytes` (int); `dt`, `x_voxel_m`,
+        `y_voxel_m`, `z_voxel_m` (float); and `time_coords` (`(n_time,) numpy.ndarray`).
+
+    Raises
+    ------
+    ValueError
+        If the header is too short to contain the fixed fields, or if any dimension is
+        not a positive integer.
+    """
+    o = _SCAN_V2_OFFSETS
+
+    def u64(offset: int) -> int:
+        return int.from_bytes(header[offset : offset + 8], "little")
+
+    def f64(offset: int) -> float:
+        return float(struct.unpack_from("<d", header, offset)[0])
+
+    n_time = u64(o["n_time"])
+    time_end = o["time_coords"] + 8 * n_time
+    if n_time < 1 or time_end > len(header):
+        raise ValueError(
+            "SCAN v2 header is truncated or reports an implausible time-point count "
+            f"(n_time={n_time}, header={len(header)} bytes)."
+        )
+
+    fields: dict[str, Any] = {
+        "size_x": u64(o["size_x"]),
+        "size_y": u64(o["size_y"]),
+        "size_z": u64(o["size_z"]),
+        "n_time": n_time,
+        "npose": u64(o["npose"]),
+        "nblock_repeat": u64(o["nblock_repeat"]),
+        "payload_bytes": u64(o["payload_bytes"]),
+        "total_header_bytes": u64(o["total_header_bytes"]),
+        "dt": f64(o["dt"]),
+        "x_voxel_m": f64(o["x_voxel_m"]),
+        "y_voxel_m": f64(o["y_voxel_m"]),
+        "z_voxel_m": f64(o["z_voxel_m"]),
+        "time_coords": np.frombuffer(
+            header, dtype="<f8", count=n_time, offset=o["time_coords"]
+        ).copy(),
+    }
+
+    for key in ("size_x", "size_y", "size_z", "npose", "nblock_repeat"):
+        if fields[key] < 1:
+            raise ValueError(
+                f"SCAN v2 header reports a non-positive {key}={fields[key]}; the file "
+                "may be corrupt or use an unsupported layout."
+            )
+
+    return fields
+
+
+def _scan_v2_strings(header: bytes) -> list[str]:
+    """Extract length-prefixed strings from a SCAN v2 header, best-effort.
+
+    The provenance region stores strings as a `uint32` byte-length prefix followed by
+    that many ASCII bytes. This walker greedily collects every position whose prefix is
+    followed by a printable run of exactly the stated length. Some Iconeus fields store
+    the ASCII **as hex**; those are decoded once more so the readable text is returned.
+
+    Because the strings are variable-length and interleaved with numeric fields, this is
+    a heuristic recovery, not a schema parse: it may miss fields or pick up spurious
+    matches. It is used only to populate `iconeus_header_strings` for user inspection;
+    the data array and its geometry never depend on it.
+
+    Parameters
+    ----------
+    header : bytes
+        The full header bytes.
+
+    Returns
+    -------
+    list[str]
+        Decoded strings in the order they appear in the header.
+    """
+    strings: list[str] = []
+    i = 0
+    n = len(header)
+    while i + 4 <= n:
+        length = int.from_bytes(header[i : i + 4], "little")
+        if 1 <= length <= 256 and i + 4 + length <= n:
+            body = header[i + 4 : i + 4 + length]
+            if all(32 <= c < 127 for c in body):
+                text = body.decode("ascii")
+                # Some fields (serial number, hardware label) are stored as hex-encoded
+                # ASCII; decode a second time when the run is valid hex.
+                if length % 2 == 0:
+                    try:
+                        decoded = bytes.fromhex(text)
+                        if all(32 <= c < 127 for c in decoded):
+                            text = decoded.decode("ascii")
+                    except ValueError:
+                        pass
+                strings.append(text)
+                i += 4 + length
+                continue
+        i += 1
+    return strings
+
+
+def _load_scan_v2(
+    path: Path,
+    chunks: int | tuple[int, ...] | str | None,
+) -> xr.DataArray:
+    """Load a binary Iconeus SCAN v2 file as a lazy DataArray (experimental).
+
+    The v2 format is a flat binary file: a variable-length header followed by a
+    little-endian `float64` power-Doppler payload. Field offsets were reverse-engineered
+    from example files; see the module docstring and `load_scan` Notes for caveats.
+
+    The payload is wrapped in a NumPy memmap (never fully read here) and exposed lazily
+    through Dask, mirroring the laziness of the v1 loader.
+
+    Dimension handling follows the v1 convention. The header stores Iconeus-ordered
+    dimensions `(size_x=lateral, size_y=elevation, size_z=depth, n_time, npose,
+    nblock_repeat)`; the payload is C-ordered as
+    `(n_time, npose, nblock_repeat, size_z, size_y, size_x)`. Output dims:
+
+    - single-pose → `(time, z, y, x)`.
+    - multi-pose → `(time, pose, z, y, x)`.
+
+    where ConfUSIus `z` is elevation (`size_y`) and `y` is depth (`size_z`), so those two
+    payload axes are swapped. `nblock_repeat > 1` is folded into `time`, as in the v1
+    `4Dscan` loader.
+
+    Parameters
+    ----------
+    path : pathlib.Path
+        Path to the v2 SCAN file, already validated to start with `SCAN_V2_MAGIC`.
+    chunks : int or tuple[int, ...] or str or None
+        Dask chunk specification passed to `dask.array.from_array`.
+
+    Returns
+    -------
+    xarray.DataArray
+        Lazy DataArray with dims `(time, z, y, x)` or `(time, pose, z, y, x)` and
+        millimetre spatial coordinates (depth origin from the header when found;
+        lateral/elevation centred on zero — see `load_scan` Notes).
+
+    Raises
+    ------
+    ValueError
+        If the header is truncated, reports implausible dimensions, or if the reported
+        payload size does not match the product of the dimensions.
+    """
+    with path.open("rb") as f:
+        total_header_bytes = int.from_bytes(
+            f.read(_SCAN_V2_OFFSETS["total_header_bytes"] + 8)[-8:], "little"
+        )
+        f.seek(0)
+        header = f.read(total_header_bytes)
+
+    meta = _read_scan_v2_header(header)
+    size_x = meta["size_x"]
+    size_y = meta["size_y"]
+    size_z = meta["size_z"]
+    n_time = meta["n_time"]
+    npose = meta["npose"]
+    nblock_repeat = meta["nblock_repeat"]
+
+    n_elements = size_x * size_y * size_z * n_time * npose * nblock_repeat
+    if meta["payload_bytes"] != n_elements * 8:
+        raise ValueError(
+            f"SCAN v2 payload size ({meta['payload_bytes']} bytes) does not match the "
+            f"product of the header dimensions ({n_elements} float64 = "
+            f"{n_elements * 8} bytes). The file may be corrupt or use an unsupported "
+            "layout."
+        )
+
+    meta["depth_start_mm"] = _scan_v2_depth_start(
+        header, size_z, meta["z_voxel_m"] * 1e3
+    )
+
+    # The payload is memory-mapped (not read here); Dask keeps every downstream reshape
+    # and transpose lazy, so the array is only materialised on compute.
+    memmap = np.memmap(
+        path,
+        dtype="<f8",
+        mode="r",
+        offset=total_header_bytes,
+        shape=(n_time, npose, nblock_repeat, size_z, size_y, size_x),
+    )
+    raw_lazy = da.from_array(memmap, chunks=chunks)
+
+    n_time_total = n_time * nblock_repeat
+    if nblock_repeat == 1:
+        sq = da.squeeze(raw_lazy, axis=2)
+    else:
+        # Fold nblock_repeat into time: (n_time, nblock, npose, z, y, x) -> (T, npose, ...).
+        transposed = da.transpose(raw_lazy, [0, 2, 1, 3, 4, 5])
+        sq = transposed.reshape(n_time_total, npose, size_z, size_y, size_x)
+
+    # Swap depth (size_z) and elevation (size_y): payload order is (depth, elevation),
+    # ConfUSIus order is (z=elevation, y=depth).
+    data_lazy = da.transpose(sq, [0, 1, 3, 2, 4])
+
+    if npose == 1:
+        data_lazy = da.squeeze(data_lazy, axis=1)
+        dims = ["time", "z", "y", "x"]
+    else:
+        dims = ["time", "pose", "z", "y", "x"]
+
+    coords = _scan_v2_coords(meta, n_time_total, npose)
+    attrs = _scan_v2_attrs(header, npose, n_time_total)
+
+    data_array = xr.DataArray(data_lazy, dims=dims, coords=coords, attrs=attrs)
+    data_array.name = path.stem
+    return data_array
+
+
+def _scan_v2_depth_start(header: bytes, size_z: int, dz_mm: float) -> float:
+    """Recover the depth-axis origin (mm) from the SCAN v2 header, best-effort.
+
+    The header stores the imaging depth range as an adjacent `(start, end)` pair of
+    `float64` values in millimetres (grouped with the probe geometry). Its absolute
+    offset shifts between files because it follows variable-length fields, so instead of
+    seeking a fixed offset this scans the header for the first adjacent `float64` pair
+    `(a, b)` whose extent `b - a` matches the depth span implied by the voxel count and
+    spacing. That span is distinctive enough (metres apart from the plane-wave angles,
+    time steps, and TGC gains) to identify the pair unambiguously.
+
+    Parameters
+    ----------
+    header : bytes
+        The full header bytes.
+    size_z : int
+        Number of depth voxels.
+    dz_mm : float
+        Depth voxel spacing in millimetres.
+
+    Returns
+    -------
+    float
+        The depth-axis origin in millimetres, or `0.0` if no matching pair is found
+        (in which case the depth axis is left relative, starting at zero).
+    """
+    if size_z < 2 or dz_mm <= 0:
+        return 0.0
+
+    expected_span = (size_z - 1) * dz_mm
+    tolerance = max(0.1, dz_mm)
+    for offset in range(0, len(header) - 16):
+        start = struct.unpack_from("<d", header, offset)[0]
+        end = struct.unpack_from("<d", header, offset + 8)[0]
+        if 0.0 < start < end < 100.0 and abs((end - start) - expected_span) < tolerance:
+            return float(start)
+    return 0.0
+
+
+def _scan_v2_coords(
+    meta: dict[str, Any], n_time_total: int, npose: int
+) -> dict[str, xr.DataArray]:
+    """Build coordinate DataArrays for a SCAN v2 volume.
+
+    Spatial coordinates use the header voxel spacings (converted to millimetres). The
+    v2 header does not encode a lateral/elevation origin, so those axes (`x`, `z`) are
+    centred on zero. The depth (`y`) origin is recovered from the header when possible
+    (see `_scan_v2_depth_start`) and otherwise defaults to zero. Spacing is exact;
+    lateral/elevation absolute position is not (see `load_scan` Notes).
+
+    Parameters
+    ----------
+    meta : dict
+        Parsed header fields from `_read_scan_v2_header`.
+    n_time_total : int
+        Number of time points after folding `nblock_repeat` into time.
+    npose : int
+        Number of robot positions.
+
+    Returns
+    -------
+    dict[str, xarray.DataArray]
+        Coordinate DataArrays keyed by `"time"`, `"x"`, `"y"`, `"z"`, and `"pose"` when
+        `npose > 1`.
+    """
+    # Iconeus voxel axes map to ConfUSIus as: x_voxel=lateral->x, y_voxel=elevation->z,
+    # z_voxel=depth->y.
+    dx_mm = meta["x_voxel_m"] * 1e3
+    dz_mm = meta["y_voxel_m"] * 1e3
+    dy_mm = meta["z_voxel_m"] * 1e3
+
+    size_x = meta["size_x"]
+    size_y = meta["size_y"]
+    size_z = meta["size_z"]
+
+    x_vals = (np.arange(size_x) - (size_x - 1) / 2) * dx_mm
+    z_vals = (np.arange(size_y) - (size_y - 1) / 2) * dz_mm
+    y_vals = meta.get("depth_start_mm", 0.0) + np.arange(size_z) * dy_mm
+
+    time_vals = meta["time_coords"]
+    if time_vals.size != n_time_total:
+        # nblock_repeat > 1 (unobserved): the header only stores n_time timestamps, so
+        # fall back to a regular grid spaced by dt.
+        time_vals = np.arange(n_time_total) * meta["dt"]
+
+    time_attrs: dict[str, Any] = {
+        "units": "s",
+        "volume_acquisition_reference": "end",
+        "volume_acquisition_duration": float(time_vals.min())
+        if time_vals.size
+        else 0.0,
+    }
+
+    coords: dict[str, xr.DataArray] = {
+        "time": xr.DataArray(time_vals, dims=["time"], attrs=time_attrs),
+        "x": xr.DataArray(x_vals, dims=["x"], attrs={"units": "mm", "voxdim": dx_mm}),
+        "z": xr.DataArray(z_vals, dims=["z"], attrs={"units": "mm", "voxdim": dz_mm}),
+        "y": xr.DataArray(y_vals, dims=["y"], attrs={"units": "mm", "voxdim": dy_mm}),
+    }
+    if npose > 1:
+        coords["pose"] = xr.DataArray(np.arange(npose), dims=["pose"])
+    return coords
+
+
+def _scan_v2_attrs(header: bytes, npose: int, n_time_total: int) -> dict[str, Any]:
+    """Assemble provenance attributes for a SCAN v2 volume.
+
+    The v2 header carries no `probeToLab`-equivalent affine, so `affines` is left empty.
+    An inferred `iconeus_scan_mode` and the best-effort decoded header strings are
+    stored so users can recover subject/session/probe information manually.
+
+    Parameters
+    ----------
+    header : bytes
+        The full header bytes.
+    npose : int
+        Number of robot positions.
+    n_time_total : int
+        Number of time points after folding `nblock_repeat` into time.
+
+    Returns
+    -------
+    dict
+        Attributes for the DataArray, including `affines` (empty), `iconeus_scan_format`,
+        `iconeus_scan_mode`, and `iconeus_header_strings`.
+    """
+    if npose > 1:
+        scan_mode = "4Dscan" if n_time_total > 1 else "3Dscan"
+    else:
+        scan_mode = "2Dscan"
+
+    return {
+        # No physical_to_lab affine has been located in the v2 header yet.
+        "affines": {},
+        "iconeus_scan_format": "v2",
+        "iconeus_scan_mode": scan_mode,
+        "iconeus_header_strings": _scan_v2_strings(header),
+    }

--- a/src/confusius/io/scan.py
+++ b/src/confusius/io/scan.py
@@ -293,7 +293,8 @@ def load_scan(
       `.compute()`) before the handle is garbage-collected.
     - **v2**: a flat binary file (variable-length header + little-endian `float64`
       payload). The returned DataArray wraps a NumPy memmap via a Dask array. Support is
-      **experimental** (see Notes); `bps_path` is not yet supported for v2.
+      **experimental** (see Notes), including its `physical_to_lab` affine and, when a
+      `bps_path` is given, `physical_to_brain`.
 
     `load_scan` sniffs the format automatically and dispatches accordingly.
 

--- a/src/confusius/io/scan.py
+++ b/src/confusius/io/scan.py
@@ -13,6 +13,7 @@ example files and may not cover every acquisition mode. See `_load_scan_v2` for 
 """
 
 import struct
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -344,7 +345,10 @@ def load_scan(
     centred on zero (correct spacing, arbitrary origin). No `probeToLab`-equivalent
     affine has been located, so v2 DataArrays carry **no** `physical_to_lab` affine.
     Multi-pose / multi-block v2 layouts are inferred by analogy with v1 and have not
-    been validated against real files.
+    been validated against real files. Provenance strings are mapped to v1-style
+    `iconeus_*` fields heuristically (by position, with the hex-encoded serial/hardware
+    strings as anchors); the raw decoded strings are always kept in
+    `iconeus_header_strings` for manual re-mapping.
 
     The `physical_to_lab` affine stored in `da.attrs["affines"]` maps ConfUSIus physical
     coordinates `(z, y, x)` to **ConfUSIus-ordered** Iconeus lab coordinates (mm). Apply
@@ -772,18 +776,19 @@ def _read_scan_v2_header(header: bytes) -> dict[str, Any]:
     return fields
 
 
-def _scan_v2_strings(header: bytes) -> list[str]:
+def _scan_v2_strings(header: bytes) -> list[tuple[str, bool, int]]:
     """Extract length-prefixed strings from a SCAN v2 header, best-effort.
 
     The provenance region stores strings as a `uint32` byte-length prefix followed by
     that many ASCII bytes. This walker greedily collects every position whose prefix is
-    followed by a printable run of exactly the stated length. Some Iconeus fields store
-    the ASCII **as hex**; those are decoded once more so the readable text is returned.
+    followed by a non-empty printable run of exactly the stated length. Some Iconeus
+    fields store the ASCII **as hex** (e.g. serial number, hardware label); those are
+    decoded once more so the readable text is returned, and flagged as hex so callers
+    can use them as structural anchors.
 
     Because the strings are variable-length and interleaved with numeric fields, this is
     a heuristic recovery, not a schema parse: it may miss fields or pick up spurious
-    matches. It is used only to populate `iconeus_header_strings` for user inspection;
-    the data array and its geometry never depend on it.
+    matches. See `_scan_v2_provenance` for how the result is mapped to named fields.
 
     Parameters
     ----------
@@ -792,10 +797,12 @@ def _scan_v2_strings(header: bytes) -> list[str]:
 
     Returns
     -------
-    list[str]
-        Decoded strings in the order they appear in the header.
+    list[tuple[str, bool, int]]
+        `(text, is_hex, end)` triples in the order they appear in the header, where
+        `is_hex` marks values that were hex-decoded and `end` is the byte offset just
+        past the record (used to locate the trailing timestamp).
     """
-    strings: list[str] = []
+    records: list[tuple[str, bool, int]] = []
     i = 0
     n = len(header)
     while i + 4 <= n:
@@ -804,6 +811,7 @@ def _scan_v2_strings(header: bytes) -> list[str]:
             body = header[i + 4 : i + 4 + length]
             if all(32 <= c < 127 for c in body):
                 text = body.decode("ascii")
+                is_hex = False
                 # Some fields (serial number, hardware label) are stored as hex-encoded
                 # ASCII; decode a second time when the run is valid hex.
                 if length % 2 == 0:
@@ -811,13 +819,101 @@ def _scan_v2_strings(header: bytes) -> list[str]:
                         decoded = bytes.fromhex(text)
                         if all(32 <= c < 127 for c in decoded):
                             text = decoded.decode("ascii")
+                            is_hex = True
                     except ValueError:
                         pass
-                strings.append(text)
+                records.append((text, is_hex, i + 4 + length))
                 i += 4 + length
                 continue
         i += 1
-    return strings
+    return records
+
+
+def _scan_v2_date(header: bytes, records: list[tuple[str, bool, int]]) -> str:
+    """Recover the acquisition timestamp from the SCAN v2 header, best-effort.
+
+    The header stores the acquisition time as a `uint64` Unix timestamp (full seconds
+    precision), but its offset shifts between files and several unrelated fields fall in
+    a plausible date range, so a blind scan is unreliable. Instead this anchors on
+    structure: the acquisition timestamp is the first `uint64` in a plausible range
+    (years ~2015–2035) that follows the leading provenance strings, so the scan starts
+    at the end of the fifth plain string (species). A later, second timestamp — the file
+    save time — is deliberately skipped by starting after the acquisition one.
+
+    Parameters
+    ----------
+    header : bytes
+        The full header bytes.
+    records : list[tuple[str, bool, int]]
+        `(text, is_hex, end)` triples from `_scan_v2_strings`.
+
+    Returns
+    -------
+    str
+        The acquisition timestamp as an ISO 8601 UTC datetime (e.g.
+        `2026-07-14T05:00:00+00:00`), or an empty string if it cannot be located.
+    """
+    plain_ends = [end for text, is_hex, end in records if not is_hex]
+    start = plain_ends[4] if len(plain_ends) >= 5 else 0
+    for offset in range(start, len(header) - 7):
+        value = int.from_bytes(header[offset : offset + 8], "little")
+        if 1_420_000_000 <= value <= 2_050_000_000:
+            return datetime.fromtimestamp(value, UTC).isoformat()
+    return ""
+
+
+def _scan_v2_provenance(records: list[tuple[str, bool, int]]) -> dict[str, str]:
+    """Map decoded header strings to v1-style provenance fields, best-effort.
+
+    The provenance strings appear in a stable order:
+
+    `sequence, project, subject, session, species, <type>, scan, <unknown>, <unknown>,
+    experimenter, serial (hex), hardware (hex)`
+
+    The two trailing hex-decoded strings (serial, hardware) are used as structural
+    anchors; the leading fields are mapped positionally. This is heuristic and matches
+    a small number of example files — a field that is empty or absent in another file
+    would shift the positional mapping, so the raw strings are always kept alongside the
+    mapped fields (see `_scan_v2_attrs`).
+
+    Parameters
+    ----------
+    records : list[tuple[str, bool, int]]
+        `(text, is_hex, end)` triples from `_scan_v2_strings`.
+
+    Returns
+    -------
+    dict[str, str]
+        Provenance fields (`iconeus_subject`, `iconeus_session`, ...) that could be
+        recovered; missing fields are simply absent.
+    """
+    provenance: dict[str, str] = {}
+
+    hex_positions = [i for i, (_, is_hex, _) in enumerate(records) if is_hex]
+    if len(hex_positions) >= 2:
+        provenance["device_serial_number"] = records[hex_positions[-2]][0]
+        provenance["iconeus_hardware"] = records[hex_positions[-1]][0]
+        # The experimenter is the last plain string before the trailing hex pair.
+        plain_before = [
+            t for t, is_hex, _ in records[: hex_positions[-2]] if not is_hex
+        ]
+        if plain_before:
+            provenance["iconeus_experimenter"] = plain_before[-1]
+
+    plain = [text for text, is_hex, _ in records if not is_hex]
+    leading_fields = (
+        "iconeus_sequence",
+        "iconeus_project",
+        "iconeus_subject",
+        "iconeus_session",
+        "iconeus_species",
+    )
+    for field, value in zip(leading_fields, plain):
+        provenance[field] = value
+    if len(plain) > 6:
+        provenance["iconeus_scan"] = plain[6]
+
+    return provenance
 
 
 def _load_scan_v2(
@@ -926,7 +1022,7 @@ def _load_scan_v2(
     attrs = _scan_v2_attrs(header, npose, n_time_total)
 
     data_array = xr.DataArray(data_lazy, dims=dims, coords=coords, attrs=attrs)
-    data_array.name = path.stem
+    data_array.name = attrs.get("iconeus_scan") or path.stem
     return data_array
 
 
@@ -1038,8 +1134,10 @@ def _scan_v2_attrs(header: bytes, npose: int, n_time_total: int) -> dict[str, An
     """Assemble provenance attributes for a SCAN v2 volume.
 
     The v2 header carries no `probeToLab`-equivalent affine, so `affines` is left empty.
-    An inferred `iconeus_scan_mode` and the best-effort decoded header strings are
-    stored so users can recover subject/session/probe information manually.
+    Header strings are mapped to v1-style provenance fields (`iconeus_subject`,
+    `iconeus_session`, ...) on a best-effort basis (see `_scan_v2_provenance`); the raw
+    decoded strings are always kept in `iconeus_header_strings` so users can re-map them
+    if the heuristic mislabels a field.
 
     Parameters
     ----------
@@ -1053,18 +1151,23 @@ def _scan_v2_attrs(header: bytes, npose: int, n_time_total: int) -> dict[str, An
     Returns
     -------
     dict
-        Attributes for the DataArray, including `affines` (empty), `iconeus_scan_format`,
-        `iconeus_scan_mode`, and `iconeus_header_strings`.
+        Attributes for the DataArray: `affines` (empty), `iconeus_scan_format`,
+        `iconeus_scan_mode`, `iconeus_date`, the mapped provenance fields, and the raw
+        `iconeus_header_strings`.
     """
     if npose > 1:
         scan_mode = "4Dscan" if n_time_total > 1 else "3Dscan"
     else:
         scan_mode = "2Dscan"
 
-    return {
+    records = _scan_v2_strings(header)
+    attrs: dict[str, Any] = {
         # No physical_to_lab affine has been located in the v2 header yet.
         "affines": {},
         "iconeus_scan_format": "v2",
         "iconeus_scan_mode": scan_mode,
-        "iconeus_header_strings": _scan_v2_strings(header),
+        "iconeus_date": _scan_v2_date(header, records),
+        "iconeus_header_strings": [text for text, _, _ in records],
     }
+    attrs.update(_scan_v2_provenance(records))
+    return attrs

--- a/src/confusius/io/scan.py
+++ b/src/confusius/io/scan.py
@@ -344,8 +344,11 @@ def load_scan(
     number of example files. Data, temporal geometry, and voxel spacing are recovered.
     The depth (`y`) origin is read from the header when the depth range can be located;
     the lateral (`x`) and elevation (`z`) origins are not encoded, so those axes are
-    centred on zero (correct spacing, arbitrary origin). No `probeToLab`-equivalent
-    affine has been located, so v2 DataArrays carry **no** `physical_to_lab` affine.
+    centred on zero (correct spacing, arbitrary origin). A `physical_to_lab` affine is
+    built from a header block interpreted as a 6DOF probe pose (translation + rotation),
+    the v2 equivalent of SCAN v1's `probeToLab`; this interpretation is experimental
+    (validated on a single near-identity pose, assumed axis order and Euler convention)
+    and is omitted if the block cannot be validated.
     Multi-pose / multi-block v2 layouts are inferred by analogy with v1 and have not
     been validated against real files. Provenance strings are mapped to v1-style
     `iconeus_*` fields heuristically (by position, with the hex-encoded serial/hardware
@@ -387,9 +390,9 @@ def load_scan(
     if magic == SCAN_V2_MAGIC:
         if bps_path is not None:
             raise ValueError(
-                "bps_path is not supported for SCAN v2 files: the physical_to_lab "
-                "affine needed to compose the BPS transform has not yet been located "
-                "in the v2 header."
+                "bps_path is not yet supported for SCAN v2 files: the v2 "
+                "physical_to_lab affine is experimental (see load_scan Notes), so BPS "
+                "composition is deferred until it is validated."
             )
         # v2 support is reverse-engineered and incomplete: re-raise any parse failure
         # with a pointer to the issue tracker and the original error appended.
@@ -1036,7 +1039,11 @@ def _load_scan_v2(
 
     coords = _scan_v2_coords(meta, n_time_total, npose)
     attrs = _scan_v2_attrs(header, npose, n_time_total)
-    attrs.update(_scan_v2_acquisition(header, n_time, meta["depth_start_mm"]))
+    acquisition = _scan_v2_acquisition(header, n_time, meta["depth_start_mm"])
+    physical_to_lab = acquisition.pop("_physical_to_lab", None)
+    attrs.update(acquisition)
+    if physical_to_lab is not None:
+        attrs["affines"]["physical_to_lab"] = physical_to_lab
 
     data_array = xr.DataArray(data_lazy, dims=dims, coords=coords, attrs=attrs)
     data_array.name = attrs.get("iconeus_scan") or path.stem
@@ -1082,6 +1089,75 @@ def _scan_v2_depth_start(header: bytes, size_z: int, dz_mm: float) -> float:
     return 0.0
 
 
+def _rotation_matrix(rx: float, ry: float, rz: float) -> npt.NDArray[np.float64]:
+    """Build a 3x3 rotation matrix from intrinsic Z-Y-X Euler angles (radians).
+
+    The Euler convention (order Z-Y-X) is assumed, not confirmed: the only non-trivial
+    example so far has a single non-zero angle (`rz`), for which the order is irrelevant.
+
+    Parameters
+    ----------
+    rx, ry, rz : float
+        Rotation angles about the x, y, and z axes, in radians.
+
+    Returns
+    -------
+    (3, 3) numpy.ndarray
+        The composed rotation matrix `Rz @ Ry @ Rx`.
+    """
+    cx, sx = np.cos(rx), np.sin(rx)
+    cy, sy = np.cos(ry), np.sin(ry)
+    cz, sz = np.cos(rz), np.sin(rz)
+    rot_x = np.array([[1, 0, 0], [0, cx, -sx], [0, sx, cx]])
+    rot_y = np.array([[cy, 0, sy], [0, 1, 0], [-sy, 0, cy]])
+    rot_z = np.array([[cz, -sz, 0], [sz, cz, 0], [0, 0, 1]])
+    return rot_z @ rot_y @ rot_x
+
+
+def _scan_v2_physical_to_lab(
+    header: bytes, n_time: int
+) -> npt.NDArray[np.float64] | None:
+    """Build a `physical_to_lab` affine from the SCAN v2 6DOF probe-pose block.
+
+    The 64-byte orientation block preceding the frequency block holds eight `float64`
+    slots; the first six are interpreted as a rigid probe pose `(tx, ty, tz, rx, ry, rz)`
+    — translations in metres, rotations in radians — describing the probe in Iconeus lab
+    space (the v2 equivalent of SCAN v1's `probeToLab`). This is an **experimental**
+    interpretation validated on a single near-identity example; the axis order and Euler
+    convention are assumed.
+
+    The resulting `probeToLab` is converted to a ConfUSIus-ordered `physical_to_lab`
+    affine (millimetres) with the same permutation used by the v1 loader, so it is
+    directly comparable to v1 output.
+
+    Parameters
+    ----------
+    header : bytes
+        The full header bytes.
+    n_time : int
+        Number of stored time points, used to locate the pose block.
+
+    Returns
+    -------
+    (4, 4) numpy.ndarray or None
+        The `physical_to_lab` affine in millimetres, or `None` if the pose values are
+        implausible.
+    """
+    # The caller only invokes this after validating the acquisition block, which lies
+    # after the pose block, so `pose_offset` is guaranteed to be in range.
+    pose_offset = _SCAN_V2_OFFSETS["time_coords"] + 12 * n_time
+    tx, ty, tz, rx, ry, rz = struct.unpack_from("<6d", header, pose_offset)
+    if any(abs(t) >= 1.0 for t in (tx, ty, tz)) or any(
+        abs(a) > 2 * np.pi for a in (rx, ry, rz)
+    ):
+        return None
+
+    probe_to_lab = np.eye(4, dtype=np.float64)
+    probe_to_lab[:3, :3] = _rotation_matrix(rx, ry, rz)
+    probe_to_lab[:3, 3] = (tx, ty, tz)
+    return _build_physical_to_lab(probe_to_lab)
+
+
 def _scan_v2_acquisition(
     header: bytes, n_time: int, depth_start_mm: float
 ) -> dict[str, Any]:
@@ -1121,7 +1197,9 @@ def _scan_v2_acquisition(
     -------
     dict
         Acquisition attributes that could be recovered; fields whose block could not be
-        validated are simply absent.
+        validated are simply absent. When the block validates, a private
+        `_physical_to_lab` key holds the pose-derived affine for the caller to move into
+        `attrs["affines"]`.
     """
     o = _SCAN_V2_OFFSETS
 
@@ -1176,6 +1254,13 @@ def _scan_v2_acquisition(
             header, dtype="<f8", count=n_angles, offset=name_end + 52
         )
         result["plane_wave_angles"] = angles.tolist()
+
+    # The depth anchor confirms the n_time-derived layout, so the 6DOF pose block (in the
+    # same region) can be trusted; expose the affine it yields under a private key that
+    # the caller moves into `attrs["affines"]`.
+    physical_to_lab = _scan_v2_physical_to_lab(header, n_time)
+    if physical_to_lab is not None:
+        result["_physical_to_lab"] = physical_to_lab
 
     return result
 

--- a/src/confusius/io/scan.py
+++ b/src/confusius/io/scan.py
@@ -190,12 +190,12 @@ def _build_physical_to_lab(
     """Convert `probeToLab` to a ConfUSIus `physical_to_lab` affine in mm.
 
     `probeToLab` maps probe physical `(x_probe, y_probe, z_probe, 1)` to Iconeus lab
-    space `(x_lab, y_lab, z_lab, 1)` in metres. The Iconeus lab frame is a fixed scanner
+    space `(x_lab, y_lab, z_lab, 1)` in meters. The Iconeus lab frame is a fixed scanner
     frame; `probeToLab` carries any rotation of the probe within it.
 
     We want `physical_to_lab` to map ConfUSIus physical `(z_conf, y_conf, x_conf, 1)`
     (elevation, depth, lateral) to **ConfUSIus-ordered** lab space `(z_lab, y_lab,
-    x_lab)` in millimetres, using the same permutation `P` that maps between the two
+    x_lab)` in millimeters, using the same permutation `P` that maps between the two
     physical spaces:
 
     ```python
@@ -209,12 +209,12 @@ def _build_physical_to_lab(
     Parameters
     ----------
     probe_to_lab : (4, 4) or (npose, 4, 4) numpy.ndarray
-        `probeToLab` affine(s) from a SCAN file (units metres).
+        `probeToLab` affine(s) from a SCAN file (units meters).
 
     Returns
     -------
     numpy.ndarray
-        `physical_to_lab` affine(s) in millimetres. Shape matches input: `(4, 4)` for
+        `physical_to_lab` affine(s) in millimeters. Shape matches input: `(4, 4)` for
         `2Dscan` or `(npose, 4, 4)` for `3Dscan`/`4Dscan`.
     """
     physical_to_lab = (
@@ -240,8 +240,8 @@ def load_bps(bps_path: str | Path) -> npt.NDArray[np.float64]:
     (the brain coordinate units are not declared by the BPS format and are
     therefore not converted).
 
-    The change of basis from ConfUSIus-ordered millimetre lab coordinates to
-    Iconeus-ordered metre lab coordinates is
+    The change of basis from ConfUSIus-ordered millimeter lab coordinates to
+    Iconeus-ordered meter lab coordinates is
 
     ```
     confusius_lab_to_iconeus_lab = mm_to_m @ PHYSICAL_TO_PROBE_PERMUTATION
@@ -264,7 +264,7 @@ def load_bps(bps_path: str | Path) -> npt.NDArray[np.float64]:
     -------
     (4, 4) numpy.ndarray
         Affine mapping Iconeus brain coordinates to ConfUSIus-ordered Iconeus lab
-        coordinates `(z_lab, y_lab, x_lab, 1)` in millimetres.
+        coordinates `(z_lab, y_lab, x_lab, 1)` in millimeters.
     """
     bps_path = check_path(bps_path, label="bps_path", type="file")
 
@@ -345,7 +345,7 @@ def load_scan(
     number of example files. Data, temporal geometry, and voxel spacing are recovered.
     The depth (`y`) origin is read from the header when the depth range can be located;
     the lateral (`x`) and elevation (`z`) origins are not encoded, so those axes are
-    centred on zero (correct spacing, arbitrary origin). A `physical_to_lab` affine is
+    centered on zero (correct spacing, arbitrary origin). A `physical_to_lab` affine is
     built from a header block interpreted as a 6DOF probe pose (translation + rotation),
     the v2 equivalent of SCAN v1's `probeToLab`; this interpretation is experimental
     (validated on a single near-identity pose, assumed axis order and Euler convention)
@@ -417,7 +417,7 @@ def load_scan(
         return data_array
 
     raise ValueError(
-        f"{path.name!r} is not a SCAN file recognised by ConfUSIus. Expected an "
+        f"{path.name!r} is not a SCAN file recognized by ConfUSIus. Expected an "
         f"HDF5-based SCAN (v1) or a binary SCAN v2 file starting with the magic bytes "
         f"{SCAN_V2_MAGIC!r}."
     )
@@ -698,7 +698,7 @@ def _load_4dscan(
     data_lazy = da.transpose(sq, [0, 1, 3, 2, 4])
 
     # Raw time shape is (npose * nscanRepeat * nblockRepeat, 1) or its transpose;
-    # squeeze normalises both orientations before reshaping.
+    # squeeze normalizes both orientations before reshaping.
     time_raw: npt.NDArray[np.float64] = (
         np.array(h5["/acqMetaData/time"][()], dtype=np.float64)
         .squeeze()
@@ -980,8 +980,8 @@ def _load_scan_v2(
     -------
     xarray.DataArray
         Lazy DataArray with dims `(time, z, y, x)` or `(time, pose, z, y, x)` and
-        millimetre spatial coordinates (depth origin from the header when found;
-        lateral/elevation centred on zero — see `load_scan` Notes).
+        millimeter spatial coordinates (depth origin from the header when found;
+        lateral/elevation centered on zero — see `load_scan` Notes).
 
     Raises
     ------
@@ -1063,11 +1063,11 @@ def _scan_v2_depth_start(header: bytes, size_z: int, dz_mm: float) -> float:
     """Recover the depth-axis origin (mm) from the SCAN v2 header, best-effort.
 
     The header stores the imaging depth range as an adjacent `(start, end)` pair of
-    `float64` values in millimetres (grouped with the probe geometry). Its absolute
+    `float64` values in millimeters (grouped with the probe geometry). Its absolute
     offset shifts between files because it follows variable-length fields, so instead of
     seeking a fixed offset this scans the header for the first adjacent `float64` pair
     `(a, b)` whose extent `b - a` matches the depth span implied by the voxel count and
-    spacing. That span is distinctive enough (metres apart from the plane-wave angles,
+    spacing. That span is distinctive enough (meters apart from the plane-wave angles,
     time steps, and TGC gains) to identify the pair unambiguously.
 
     Parameters
@@ -1077,12 +1077,12 @@ def _scan_v2_depth_start(header: bytes, size_z: int, dz_mm: float) -> float:
     size_z : int
         Number of depth voxels.
     dz_mm : float
-        Depth voxel spacing in millimetres.
+        Depth voxel spacing in millimeters.
 
     Returns
     -------
     float
-        The depth-axis origin in millimetres, or `0.0` if no matching pair is found
+        The depth-axis origin in millimeters, or `0.0` if no matching pair is found
         (in which case the depth axis is left relative, starting at zero).
     """
     if size_z < 2 or dz_mm <= 0:
@@ -1130,13 +1130,13 @@ def _scan_v2_physical_to_lab(
 
     The 64-byte orientation block preceding the frequency block holds eight `float64`
     slots; the first six are interpreted as a rigid probe pose `(tx, ty, tz, rx, ry, rz)`
-    — translations in metres, rotations in radians — describing the probe in Iconeus lab
+    — translations in meters, rotations in radians — describing the probe in Iconeus lab
     space (the v2 equivalent of SCAN v1's `probeToLab`). This is an **experimental**
     interpretation validated on a single near-identity example; the axis order and Euler
     convention are assumed.
 
     The resulting `probeToLab` is converted to a ConfUSIus-ordered `physical_to_lab`
-    affine (millimetres) with the same permutation used by the v1 loader, so it is
+    affine (millimeters) with the same permutation used by the v1 loader, so it is
     directly comparable to v1 output.
 
     Parameters
@@ -1149,7 +1149,7 @@ def _scan_v2_physical_to_lab(
     Returns
     -------
     (4, 4) numpy.ndarray or None
-        The `physical_to_lab` affine in millimetres, or `None` if the pose values are
+        The `physical_to_lab` affine in millimeters, or `None` if the pose values are
         implausible.
     """
     # The caller only invokes this after validating the acquisition block, which lies
@@ -1279,9 +1279,9 @@ def _scan_v2_coords(
 ) -> dict[str, xr.DataArray]:
     """Build coordinate DataArrays for a SCAN v2 volume.
 
-    Spatial coordinates use the header voxel spacings (converted to millimetres). The
+    Spatial coordinates use the header voxel spacings (converted to millimeters). The
     v2 header does not encode a lateral/elevation origin, so those axes (`x`, `z`) are
-    centred on zero. The depth (`y`) origin is recovered from the header when possible
+    centered on zero. The depth (`y`) origin is recovered from the header when possible
     (see `_scan_v2_depth_start`) and otherwise defaults to zero. Spacing is exact;
     lateral/elevation absolute position is not (see `load_scan` Notes).
 

--- a/src/confusius/io/scan.py
+++ b/src/confusius/io/scan.py
@@ -1108,8 +1108,9 @@ def _scan_v2_coords(
     time_vals = meta["time_coords"]
     if time_vals.size != n_time_total:
         # nblock_repeat > 1 (unobserved): the header only stores n_time timestamps, so
-        # fall back to a regular grid spaced by dt.
-        time_vals = np.arange(n_time_total) * meta["dt"]
+        # fall back to a regular grid spaced by dt. Keep it end-referenced (first volume
+        # ends at dt) to stay consistent with volume_acquisition_reference below.
+        time_vals = meta["dt"] * (np.arange(n_time_total) + 1)
 
     time_attrs: dict[str, Any] = {
         "units": "s",

--- a/src/confusius/io/scan.py
+++ b/src/confusius/io/scan.py
@@ -452,8 +452,8 @@ def load_scan(
     Multi-pose / multi-block v2 layouts are inferred by analogy with v1 and have not
     been validated against real files. Provenance strings are mapped to v1-style
     `iconeus_*` fields heuristically (by position, with the hex-encoded serial/hardware
-    strings as anchors); the raw decoded strings are always kept in
-    `iconeus_header_strings` for manual re-mapping.
+    strings as anchors); the three still-unidentified plain-string slots are exposed as
+    `iconeus_unknown1`, `iconeus_unknown2`, and `iconeus_unknown3`.
 
     Acquisition settings that correspond to fUSI-BIDS fields are also surfaced as
     attributes, in native header units: `probe_model`, `probe_center_frequency` (MHz),
@@ -897,8 +897,9 @@ def _read_scan_v2_strings(header: bytes) -> list[tuple[str, bool, int]]:
     can use them as structural anchors.
 
     Because the strings are variable-length and interleaved with numeric fields, this is
-    a heuristic recovery, not a schema parse: it may miss fields or pick up spurious
-    matches. See `_map_scan_v2_provenance` for how the result is mapped to named fields.
+    still a heuristic recovery rather than a full schema parse: it trusts the inline
+    length prefixes, but it does not yet know the exact semantic type of every record.
+    See `_map_scan_v2_provenance` for how the result is mapped to named fields.
 
     Parameters
     ----------
@@ -977,14 +978,13 @@ def _map_scan_v2_provenance(records: list[tuple[str, bool, int]]) -> dict[str, s
 
     The provenance strings appear in a stable order:
 
-    `sequence, project, subject, session, species, <type>, scan, <unknown>, <unknown>,
-    experimenter, serial (hex), hardware (hex)`
+    `sequence, project, subject, session, species, <unknown1>, scan, <unknown2>,
+    <unknown3>, experimenter, serial (hex), hardware (hex)`
 
     The two trailing hex-decoded strings (serial, hardware) are used as structural
     anchors; the leading fields are mapped positionally. This is heuristic and matches
     a small number of example files — a field that is empty or absent in another file
-    would shift the positional mapping, so the raw strings are always kept alongside the
-    mapped fields (see `_build_scan_v2_attrs`).
+    would shift the positional mapping.
 
     Parameters
     ----------
@@ -1011,17 +1011,19 @@ def _map_scan_v2_provenance(records: list[tuple[str, bool, int]]) -> dict[str, s
             provenance["iconeus_experimenter"] = plain_before[-1]
 
     plain = [text for text, is_hex, _ in records if not is_hex]
-    leading_fields = (
+    indexed_fields = (
         "iconeus_sequence",
         "iconeus_project",
         "iconeus_subject",
         "iconeus_session",
         "iconeus_species",
+        "iconeus_unknown1",
+        "iconeus_scan",
+        "iconeus_unknown2",
+        "iconeus_unknown3",
     )
-    for field, value in zip(leading_fields, plain):
+    for field, value in zip(indexed_fields, plain):
         provenance[field] = value
-    if len(plain) > 6:
-        provenance["iconeus_scan"] = plain[6]
 
     return provenance
 
@@ -1419,11 +1421,10 @@ def _build_scan_v2_attrs(
 ) -> dict[str, Any]:
     """Assemble provenance attributes for a SCAN v2 volume.
 
-    The v2 header carries no `probeToLab`-equivalent affine, so `affines` is left empty.
     Header strings are mapped to v1-style provenance fields (`iconeus_subject`,
-    `iconeus_session`, ...) on a best-effort basis (see `_map_scan_v2_provenance`); the raw
-    decoded strings are always kept in `iconeus_header_strings` so users can re-map them
-    if the heuristic mislabels a field.
+    `iconeus_session`, ...) on a best-effort basis (see `_map_scan_v2_provenance`).
+    The three still-unidentified plain-string slots are surfaced explicitly as
+    `iconeus_unknown1`, `iconeus_unknown2`, and `iconeus_unknown3`.
 
     Parameters
     ----------
@@ -1437,9 +1438,8 @@ def _build_scan_v2_attrs(
     Returns
     -------
     dict
-        Attributes for the DataArray: `affines` (empty), `iconeus_scan_format`,
-        `iconeus_scan_mode`, `iconeus_datetime`, the mapped provenance fields, and the raw
-        `iconeus_header_strings`.
+        Attributes for the DataArray: `affines`, `iconeus_scan_format`,
+        `iconeus_scan_mode`, `iconeus_datetime`, and the mapped provenance fields.
     """
     if npose > 1:
         scan_mode = "4Dscan" if n_time_total > 1 else "3Dscan"
@@ -1448,12 +1448,10 @@ def _build_scan_v2_attrs(
 
     records = _read_scan_v2_strings(header)
     attrs: dict[str, Any] = {
-        # No physical_to_lab affine has been located in the v2 header yet.
         "affines": {},
         "iconeus_scan_format": "v2",
         "iconeus_scan_mode": scan_mode,
         "iconeus_datetime": _read_scan_v2_datetime(header, records),
-        "iconeus_header_strings": [text for text, _, _ in records],
     }
     attrs.update(_map_scan_v2_provenance(records))
     return attrs

--- a/src/confusius/io/scan.py
+++ b/src/confusius/io/scan.py
@@ -38,6 +38,8 @@ _SCAN_V2_OFFSETS: dict[str, int] = {
     "npose": 0x7C,
     "nblock_repeat": 0x84,
     "dt": 0x94,
+    "svd_clutter_cutoff": 0x9C,
+    "power_doppler_integration_window": 0xA0,
     "x_voxel_m": 0xA4,
     "y_voxel_m": 0xAC,
     "z_voxel_m": 0xB4,
@@ -349,6 +351,14 @@ def load_scan(
     `iconeus_*` fields heuristically (by position, with the hex-encoded serial/hardware
     strings as anchors); the raw decoded strings are always kept in
     `iconeus_header_strings` for manual re-mapping.
+
+    Acquisition settings that correspond to fUSI-BIDS fields are also surfaced as
+    attributes, in native header units: `probe_model`, `probe_center_frequency` (MHz),
+    `probe_pitch` (mm), `probe_focal_depth` (mm), `imaging_depth` (mm start/end),
+    `transmit_frequency` (MHz), `pulse_repetition_frequency` (Hz), `plane_wave_angles`
+    (deg), `svd_low_cutoff`, and `power_doppler_integration_window`. The probe/sequence
+    subset is parsed from a structured block whose layout is anchor-validated against the
+    depth origin; if that check fails, those fields are omitted rather than guessed.
 
     The `physical_to_lab` affine stored in `da.attrs["affines"]` maps ConfUSIus physical
     coordinates `(z, y, x)` to **ConfUSIus-ordered** Iconeus lab coordinates (mm). Apply
@@ -723,8 +733,9 @@ def _read_scan_v2_header(header: bytes) -> dict[str, Any]:
     -------
     dict
         Parsed fields: `size_x`, `size_y`, `size_z`, `n_time`, `npose`,
-        `nblock_repeat`, `payload_bytes`, `total_header_bytes` (int); `dt`, `x_voxel_m`,
-        `y_voxel_m`, `z_voxel_m` (float); and `time_coords` (`(n_time,) numpy.ndarray`).
+        `nblock_repeat`, `payload_bytes`, `total_header_bytes`, `svd_clutter_cutoff`,
+        `power_doppler_integration_window` (int); `dt`, `x_voxel_m`, `y_voxel_m`,
+        `z_voxel_m` (float); and `time_coords` (`(n_time,) numpy.ndarray`).
 
     Raises
     ------
@@ -733,6 +744,9 @@ def _read_scan_v2_header(header: bytes) -> dict[str, Any]:
         not a positive integer.
     """
     o = _SCAN_V2_OFFSETS
+
+    def u32(offset: int) -> int:
+        return int.from_bytes(header[offset : offset + 4], "little")
 
     def u64(offset: int) -> int:
         return int.from_bytes(header[offset : offset + 8], "little")
@@ -758,6 +772,8 @@ def _read_scan_v2_header(header: bytes) -> dict[str, Any]:
         "payload_bytes": u64(o["payload_bytes"]),
         "total_header_bytes": u64(o["total_header_bytes"]),
         "dt": f64(o["dt"]),
+        "svd_clutter_cutoff": u32(o["svd_clutter_cutoff"]),
+        "power_doppler_integration_window": u32(o["power_doppler_integration_window"]),
         "x_voxel_m": f64(o["x_voxel_m"]),
         "y_voxel_m": f64(o["y_voxel_m"]),
         "z_voxel_m": f64(o["z_voxel_m"]),
@@ -1020,6 +1036,7 @@ def _load_scan_v2(
 
     coords = _scan_v2_coords(meta, n_time_total, npose)
     attrs = _scan_v2_attrs(header, npose, n_time_total)
+    attrs.update(_scan_v2_acquisition(header, n_time, meta["depth_start_mm"]))
 
     data_array = xr.DataArray(data_lazy, dims=dims, coords=coords, attrs=attrs)
     data_array.name = attrs.get("iconeus_scan") or path.stem
@@ -1063,6 +1080,104 @@ def _scan_v2_depth_start(header: bytes, size_z: int, dz_mm: float) -> float:
         if 0.0 < start < end < 100.0 and abs((end - start) - expected_span) < tolerance:
             return float(start)
     return 0.0
+
+
+def _scan_v2_acquisition(
+    header: bytes, n_time: int, depth_start_mm: float
+) -> dict[str, Any]:
+    """Parse the acquisition-settings block of a SCAN v2 header, best-effort.
+
+    The probe- and sequence-related fields sit in a structured block whose position is
+    computable from `n_time` (the preceding time and frame-index arrays have `n_time`
+    elements each). The probe-name string is variable-length, so the fields after it are
+    located relative to its end.
+
+    Because the layout is inferred from a small number of example files, the walk is
+    **anchor-validated**: the depth range stored right after the probe name must match
+    the value found independently by `_scan_v2_depth_start`. If it does not, the block is
+    assumed misaligned and nothing is returned, so a mislaid offset never emits wrong
+    metadata. The two SVD/power-Doppler filter fields live at fixed offsets and are read
+    unconditionally.
+
+    Fields map to fUSI-BIDS as follows (values kept in native header units): `probe_model`
+    → `ProbeModel`; `probe_center_frequency` (MHz) → `ProbeCenterFrequency`; `probe_pitch`
+    (mm) → `ProbePitch`; `probe_focal_depth` (mm) → `ProbeFocalDepth`; `imaging_depth`
+    (mm start/end) → `Depth`; `transmit_frequency` (MHz) → `UltrasoundTransmitFrequency`;
+    `pulse_repetition_frequency` (Hz) → `UltrasoundPulseRepetitionFrequency`;
+    `plane_wave_angles` (deg) → `PlaneWaveAngles`. `svd_low_cutoff` is the low cutoff of
+    the SVD clutter filter (see `confusius.iq.clutter_filter_svd_from_indices`) and
+    `power_doppler_integration_window` relates to `PowerDopplerIntegrationDuration`.
+
+    Parameters
+    ----------
+    header : bytes
+        The full header bytes.
+    n_time : int
+        Number of stored time points (before folding `nblock_repeat`).
+    depth_start_mm : float
+        Depth origin found by `_scan_v2_depth_start`, used as the alignment anchor.
+
+    Returns
+    -------
+    dict
+        Acquisition attributes that could be recovered; fields whose block could not be
+        validated are simply absent.
+    """
+    o = _SCAN_V2_OFFSETS
+
+    def u16(offset: int) -> int:
+        return int.from_bytes(header[offset : offset + 2], "little")
+
+    def u32(offset: int) -> int:
+        return int.from_bytes(header[offset : offset + 4], "little")
+
+    def f64(offset: int) -> float:
+        return float(struct.unpack_from("<d", header, offset)[0])
+
+    # Filter fields at fixed absolute offsets, always available.
+    result: dict[str, Any] = {
+        "svd_low_cutoff": u32(o["svd_clutter_cutoff"]),
+        "power_doppler_integration_window": u32(o["power_doppler_integration_window"]),
+    }
+
+    # Structured block: after time_coords (n_time f64) and frame indices (n_time u32)
+    # come a 64-byte orientation block, then the frequency block, a 16-byte gap, and the
+    # probe-name string.
+    freq_off = o["time_coords"] + 12 * n_time + 64
+    name_off = freq_off + 48
+    if name_off + 2 > len(header):
+        return result
+
+    name_len = u16(name_off)
+    name_end = name_off + 2 + name_len
+    if not (1 <= name_len <= 64) or name_end + 52 > len(header):
+        return result
+    name_bytes = header[name_off + 2 : name_end]
+    if not all(32 <= c < 127 for c in name_bytes):
+        return result
+
+    # Anchor check: the depth range starts right after the probe name and must agree
+    # with the independently located depth origin.
+    depth_start = f64(name_end)
+    if not depth_start_mm or abs(depth_start - depth_start_mm) > 0.5:
+        return result
+
+    result["probe_model"] = name_bytes.decode("ascii")
+    result["probe_center_frequency"] = f64(freq_off)
+    result["probe_pitch"] = f64(freq_off + 8)
+    result["probe_focal_depth"] = f64(freq_off + 24)
+    result["imaging_depth"] = (depth_start, f64(name_end + 8))
+    result["transmit_frequency"] = f64(name_end + 16)
+    result["pulse_repetition_frequency"] = f64(name_end + 24)
+
+    n_angles = u32(name_end + 48)
+    if 1 <= n_angles <= 512 and name_end + 52 + 8 * n_angles <= len(header):
+        angles = np.frombuffer(
+            header, dtype="<f8", count=n_angles, offset=name_end + 52
+        )
+        result["plane_wave_angles"] = angles.tolist()
+
+    return result
 
 
 def _scan_v2_coords(

--- a/src/confusius/io/scan.py
+++ b/src/confusius/io/scan.py
@@ -302,9 +302,10 @@ def load_scan(
     path : str or pathlib.Path
         Path to the SCAN file (`.scan`).
     bps_path : str or pathlib.Path, optional
-        Path to the corresponding BPS file (`.bps`). If provided, the BPS transformation
-        matrix will be added as an affine attribute to the returned DataArray. Only
-        supported for v1 (HDF5) files.
+        Path to the corresponding BPS file (`.bps`). If provided, a `physical_to_brain`
+        affine is added to `da.attrs["affines"]`. For v2 files this requires the
+        (experimental) `physical_to_lab` affine to have been built; if it could not be,
+        passing `bps_path` raises.
     chunks : int or tuple[int, ...] or str or None, default: "auto"
         Dask chunk specification passed to `dask.array.from_array`. Accepted forms:
 
@@ -335,8 +336,8 @@ def load_scan(
     ValueError
         If `path` does not exist or is not a file, if the file is neither an
         HDF5-based SCAN (v1) nor a binary SCAN v2 file, if `bps_path` is passed for a
-        v2 file, or if a v1 `acquisitionMode` is not one of `"2Dscan"`, `"3Dscan"`, or
-        `"4Dscan"`.
+        v2 file whose `physical_to_lab` affine could not be built, or if a v1
+        `acquisitionMode` is not one of `"2Dscan"`, `"3Dscan"`, or `"4Dscan"`.
 
     Notes
     -----
@@ -388,16 +389,10 @@ def load_scan(
         magic = f.read(len(SCAN_V2_MAGIC))
 
     if magic == SCAN_V2_MAGIC:
-        if bps_path is not None:
-            raise ValueError(
-                "bps_path is not yet supported for SCAN v2 files: the v2 "
-                "physical_to_lab affine is experimental (see load_scan Notes), so BPS "
-                "composition is deferred until it is validated."
-            )
         # v2 support is reverse-engineered and incomplete: re-raise any parse failure
         # with a pointer to the issue tracker and the original error appended.
         try:
-            return _load_scan_v2(path, chunks)
+            data_array = _load_scan_v2(path, chunks)
         except Exception as error:
             raise ValueError(
                 "Loading Iconeus SCAN v2 files is experimental and this file could "
@@ -406,6 +401,20 @@ def load_scan(
                 f"example file if possible).\n\nOriginal error: "
                 f"{type(error).__name__}: {error}"
             ) from error
+
+        if bps_path is not None:
+            affines = data_array.attrs["affines"]
+            if "physical_to_lab" not in affines:
+                raise ValueError(
+                    "bps_path was given but no physical_to_lab affine could be built "
+                    "for this SCAN v2 file (the 6DOF probe-pose block was missing or "
+                    "implausible), so the BPS transform cannot be composed."
+                )
+            brain_to_lab = load_bps(bps_path)
+            affines["physical_to_brain"] = (
+                np.linalg.inv(brain_to_lab) @ affines["physical_to_lab"]
+            )
+        return data_array
 
     raise ValueError(
         f"{path.name!r} is not a SCAN file recognised by ConfUSIus. Expected an "

--- a/src/confusius/io/scan.py
+++ b/src/confusius/io/scan.py
@@ -55,7 +55,7 @@ of `n_time` little-endian `float64` values.
 """
 
 
-def _u16(buffer: bytes, offset: int) -> int:
+def _read_u16(buffer: bytes, offset: int) -> int:
     """Read a little-endian `uint16` from `buffer` at `offset`.
 
     Parameters
@@ -73,7 +73,7 @@ def _u16(buffer: bytes, offset: int) -> int:
     return int.from_bytes(buffer[offset : offset + 2], "little")
 
 
-def _u32(buffer: bytes, offset: int) -> int:
+def _read_u32(buffer: bytes, offset: int) -> int:
     """Read a little-endian `uint32` from `buffer` at `offset`.
 
     Parameters
@@ -91,7 +91,7 @@ def _u32(buffer: bytes, offset: int) -> int:
     return int.from_bytes(buffer[offset : offset + 4], "little")
 
 
-def _u64(buffer: bytes, offset: int) -> int:
+def _read_u64(buffer: bytes, offset: int) -> int:
     """Read a little-endian `uint64` from `buffer` at `offset`.
 
     Parameters
@@ -109,7 +109,7 @@ def _u64(buffer: bytes, offset: int) -> int:
     return int.from_bytes(buffer[offset : offset + 8], "little")
 
 
-def _f64(buffer: bytes, offset: int) -> float:
+def _read_f64(buffer: bytes, offset: int) -> float:
     """Read a little-endian `float64` from `buffer` at `offset`.
 
     Parameters
@@ -828,7 +828,7 @@ def _read_scan_v2_header(header: bytes) -> dict[str, Any]:
     Only the fields listed in `_SCAN_V2_OFFSETS` are read. These all live before the
     first variable-length string, so their absolute offsets are stable across files.
     Provenance strings, which follow the variable-length region, are handled separately
-    by `_scan_v2_strings`.
+    by `_read_scan_v2_strings`.
 
     Parameters
     ----------
@@ -850,7 +850,7 @@ def _read_scan_v2_header(header: bytes) -> dict[str, Any]:
     """
     o = _SCAN_V2_OFFSETS
 
-    n_time = _u64(header, o["n_time"])
+    n_time = _read_u64(header, o["n_time"])
     time_end = o["time_coords"] + 8 * n_time
     if n_time < 1 or time_end > len(header):
         raise ValueError(
@@ -859,18 +859,18 @@ def _read_scan_v2_header(header: bytes) -> dict[str, Any]:
         )
 
     fields: dict[str, Any] = {
-        "size_x": _u64(header, o["size_x"]),
-        "size_y": _u64(header, o["size_y"]),
-        "size_z": _u64(header, o["size_z"]),
+        "size_x": _read_u64(header, o["size_x"]),
+        "size_y": _read_u64(header, o["size_y"]),
+        "size_z": _read_u64(header, o["size_z"]),
         "n_time": n_time,
-        "npose": _u64(header, o["npose"]),
-        "nblock_repeat": _u64(header, o["nblock_repeat"]),
-        "payload_bytes": _u64(header, o["payload_bytes"]),
-        "total_header_bytes": _u64(header, o["total_header_bytes"]),
-        "dt": _f64(header, o["dt"]),
-        "x_voxel_m": _f64(header, o["x_voxel_m"]),
-        "y_voxel_m": _f64(header, o["y_voxel_m"]),
-        "z_voxel_m": _f64(header, o["z_voxel_m"]),
+        "npose": _read_u64(header, o["npose"]),
+        "nblock_repeat": _read_u64(header, o["nblock_repeat"]),
+        "payload_bytes": _read_u64(header, o["payload_bytes"]),
+        "total_header_bytes": _read_u64(header, o["total_header_bytes"]),
+        "dt": _read_f64(header, o["dt"]),
+        "x_voxel_m": _read_f64(header, o["x_voxel_m"]),
+        "y_voxel_m": _read_f64(header, o["y_voxel_m"]),
+        "z_voxel_m": _read_f64(header, o["z_voxel_m"]),
         "time_coords": np.frombuffer(
             header, dtype="<f8", count=n_time, offset=o["time_coords"]
         ).copy(),
@@ -886,7 +886,7 @@ def _read_scan_v2_header(header: bytes) -> dict[str, Any]:
     return fields
 
 
-def _scan_v2_strings(header: bytes) -> list[tuple[str, bool, int]]:
+def _read_scan_v2_strings(header: bytes) -> list[tuple[str, bool, int]]:
     """Extract length-prefixed strings from a SCAN v2 header, best-effort.
 
     The provenance region stores strings as a `uint32` byte-length prefix followed by
@@ -898,7 +898,7 @@ def _scan_v2_strings(header: bytes) -> list[tuple[str, bool, int]]:
 
     Because the strings are variable-length and interleaved with numeric fields, this is
     a heuristic recovery, not a schema parse: it may miss fields or pick up spurious
-    matches. See `_scan_v2_provenance` for how the result is mapped to named fields.
+    matches. See `_map_scan_v2_provenance` for how the result is mapped to named fields.
 
     Parameters
     ----------
@@ -916,7 +916,7 @@ def _scan_v2_strings(header: bytes) -> list[tuple[str, bool, int]]:
     i = 0
     n = len(header)
     while i + 4 <= n:
-        length = _u32(header, i)
+        length = _read_u32(header, i)
         if 1 <= length <= 256 and i + 4 + length <= n:
             body = header[i + 4 : i + 4 + length]
             if all(32 <= c < 127 for c in body):
@@ -939,7 +939,7 @@ def _scan_v2_strings(header: bytes) -> list[tuple[str, bool, int]]:
     return records
 
 
-def _scan_v2_datetime(header: bytes, records: list[tuple[str, bool, int]]) -> str:
+def _read_scan_v2_datetime(header: bytes, records: list[tuple[str, bool, int]]) -> str:
     """Recover the acquisition timestamp from the SCAN v2 header, best-effort.
 
     The header stores the acquisition time as a `uint64` Unix timestamp (full seconds
@@ -955,7 +955,7 @@ def _scan_v2_datetime(header: bytes, records: list[tuple[str, bool, int]]) -> st
     header : bytes
         The full header bytes.
     records : list[tuple[str, bool, int]]
-        `(text, is_hex, end)` triples from `_scan_v2_strings`.
+        `(text, is_hex, end)` triples from `_read_scan_v2_strings`.
 
     Returns
     -------
@@ -966,13 +966,13 @@ def _scan_v2_datetime(header: bytes, records: list[tuple[str, bool, int]]) -> st
     plain_ends = [end for text, is_hex, end in records if not is_hex]
     start = plain_ends[4] if len(plain_ends) >= 5 else 0
     for offset in range(start, len(header) - 7):
-        value = _u64(header, offset)
+        value = _read_u64(header, offset)
         if 1_420_000_000 <= value <= 2_050_000_000:
             return datetime.fromtimestamp(value, UTC).isoformat()
     return ""
 
 
-def _scan_v2_provenance(records: list[tuple[str, bool, int]]) -> dict[str, str]:
+def _map_scan_v2_provenance(records: list[tuple[str, bool, int]]) -> dict[str, str]:
     """Map decoded header strings to v1-style provenance fields, best-effort.
 
     The provenance strings appear in a stable order:
@@ -984,12 +984,12 @@ def _scan_v2_provenance(records: list[tuple[str, bool, int]]) -> dict[str, str]:
     anchors; the leading fields are mapped positionally. This is heuristic and matches
     a small number of example files — a field that is empty or absent in another file
     would shift the positional mapping, so the raw strings are always kept alongside the
-    mapped fields (see `_scan_v2_attrs`).
+    mapped fields (see `_build_scan_v2_attrs`).
 
     Parameters
     ----------
     records : list[tuple[str, bool, int]]
-        `(text, is_hex, end)` triples from `_scan_v2_strings`.
+        `(text, is_hex, end)` triples from `_read_scan_v2_strings`.
 
     Returns
     -------
@@ -1073,7 +1073,7 @@ def _load_scan_v2(
     """
     offset = _SCAN_V2_OFFSETS["total_header_bytes"]
     with path.open("rb") as f:
-        total_header_bytes = _u64(f.read(offset + 8), offset)
+        total_header_bytes = _read_u64(f.read(offset + 8), offset)
         f.seek(0)
         header = f.read(total_header_bytes)
 
@@ -1094,7 +1094,7 @@ def _load_scan_v2(
             "layout."
         )
 
-    meta["depth_start_mm"] = _scan_v2_depth_start(
+    meta["depth_start_mm"] = _find_scan_v2_depth_start(
         header, size_z, meta["z_voxel_m"] * 1e3
     )
 
@@ -1127,9 +1127,9 @@ def _load_scan_v2(
     else:
         dims = ["time", "pose", "z", "y", "x"]
 
-    coords = _scan_v2_coords(meta, n_time_total, npose)
-    attrs = _scan_v2_attrs(header, npose, n_time_total)
-    acquisition = _scan_v2_acquisition(header, n_time, meta["depth_start_mm"])
+    coords = _build_scan_v2_coords(meta, n_time_total, npose)
+    attrs = _build_scan_v2_attrs(header, npose, n_time_total)
+    acquisition = _read_scan_v2_acquisition(header, n_time, meta["depth_start_mm"])
     physical_to_lab = acquisition.pop("_physical_to_lab", None)
     attrs.update(acquisition)
     if physical_to_lab is not None:
@@ -1140,7 +1140,7 @@ def _load_scan_v2(
     return data_array
 
 
-def _scan_v2_depth_start(header: bytes, size_z: int, dz_mm: float) -> float:
+def _find_scan_v2_depth_start(header: bytes, size_z: int, dz_mm: float) -> float:
     """Recover the depth-axis origin (mm) from the SCAN v2 header, best-effort.
 
     The header stores the imaging depth range as an adjacent `(start, end)` pair of
@@ -1172,14 +1172,14 @@ def _scan_v2_depth_start(header: bytes, size_z: int, dz_mm: float) -> float:
     expected_span = (size_z - 1) * dz_mm
     tolerance = max(0.1, dz_mm)
     for offset in range(0, len(header) - 16):
-        start = _f64(header, offset)
-        end = _f64(header, offset + 8)
+        start = _read_f64(header, offset)
+        end = _read_f64(header, offset + 8)
         if 0.0 < start < end < 100.0 and abs((end - start) - expected_span) < tolerance:
             return float(start)
     return 0.0
 
 
-def _rotation_matrix(rx: float, ry: float, rz: float) -> npt.NDArray[np.float64]:
+def _build_rotation_matrix(rx: float, ry: float, rz: float) -> npt.NDArray[np.float64]:
     """Build a 3x3 rotation matrix from intrinsic Z-Y-X Euler angles (radians).
 
     The Euler convention (order Z-Y-X) is assumed, not confirmed: the only non-trivial
@@ -1204,7 +1204,7 @@ def _rotation_matrix(rx: float, ry: float, rz: float) -> npt.NDArray[np.float64]
     return rot_z @ rot_y @ rot_x
 
 
-def _scan_v2_physical_to_lab(
+def _build_scan_v2_physical_to_lab(
     header: bytes, n_time: int
 ) -> npt.NDArray[np.float64] | None:
     """Build a `physical_to_lab` affine from the SCAN v2 6DOF probe-pose block.
@@ -1243,12 +1243,12 @@ def _scan_v2_physical_to_lab(
         return None
 
     probe_to_lab = np.eye(4, dtype=np.float64)
-    probe_to_lab[:3, :3] = _rotation_matrix(rx, ry, rz)
+    probe_to_lab[:3, :3] = _build_rotation_matrix(rx, ry, rz)
     probe_to_lab[:3, 3] = (tx, ty, tz)
     return _build_physical_to_lab(probe_to_lab)
 
 
-def _scan_v2_acquisition(
+def _read_scan_v2_acquisition(
     header: bytes, n_time: int, depth_start_mm: float
 ) -> dict[str, Any]:
     """Parse the acquisition-settings block of a SCAN v2 header, best-effort.
@@ -1260,7 +1260,7 @@ def _scan_v2_acquisition(
 
     Because the layout is inferred from a small number of example files, the walk is
     **anchor-validated**: the depth range stored right after the probe name must match
-    the value found independently by `_scan_v2_depth_start`. If it does not, the block is
+    the value found independently by `_find_scan_v2_depth_start`. If it does not, the block is
     assumed misaligned and nothing is returned, so a mislaid offset never emits wrong
     metadata. The two SVD/power-Doppler filter fields live at fixed offsets and are read
     unconditionally.
@@ -1281,7 +1281,7 @@ def _scan_v2_acquisition(
     n_time : int
         Number of stored time points (before folding `nblock_repeat`).
     depth_start_mm : float
-        Depth origin found by `_scan_v2_depth_start`, used as the alignment anchor.
+        Depth origin found by `_find_scan_v2_depth_start`, used as the alignment anchor.
 
     Returns
     -------
@@ -1295,8 +1295,8 @@ def _scan_v2_acquisition(
 
     # Filter fields at fixed absolute offsets, always available.
     result: dict[str, Any] = {
-        "svd_low_cutoff": _u32(header, o["svd_clutter_cutoff"]),
-        "power_doppler_integration_window": _u32(
+        "svd_low_cutoff": _read_u32(header, o["svd_clutter_cutoff"]),
+        "power_doppler_integration_window": _read_u32(
             header, o["power_doppler_integration_window"]
         ),
     }
@@ -1309,7 +1309,7 @@ def _scan_v2_acquisition(
     if name_off + 2 > len(header):
         return result
 
-    name_len = _u16(header, name_off)
+    name_len = _read_u16(header, name_off)
     name_end = name_off + 2 + name_len
     if not (1 <= name_len <= 64) or name_end + 52 > len(header):
         return result
@@ -1319,19 +1319,19 @@ def _scan_v2_acquisition(
 
     # Anchor check: the depth range starts right after the probe name and must agree
     # with the independently located depth origin.
-    depth_start = _f64(header, name_end)
+    depth_start = _read_f64(header, name_end)
     if not depth_start_mm or abs(depth_start - depth_start_mm) > 0.5:
         return result
 
     result["probe_model"] = name_bytes.decode("ascii")
-    result["probe_center_frequency"] = _f64(header, freq_off)
-    result["probe_pitch"] = _f64(header, freq_off + 8)
-    result["probe_focal_depth"] = _f64(header, freq_off + 24)
-    result["imaging_depth"] = (depth_start, _f64(header, name_end + 8))
-    result["transmit_frequency"] = _f64(header, name_end + 16)
-    result["pulse_repetition_frequency"] = _f64(header, name_end + 24)
+    result["probe_center_frequency"] = _read_f64(header, freq_off)
+    result["probe_pitch"] = _read_f64(header, freq_off + 8)
+    result["probe_focal_depth"] = _read_f64(header, freq_off + 24)
+    result["imaging_depth"] = (depth_start, _read_f64(header, name_end + 8))
+    result["transmit_frequency"] = _read_f64(header, name_end + 16)
+    result["pulse_repetition_frequency"] = _read_f64(header, name_end + 24)
 
-    n_angles = _u32(header, name_end + 48)
+    n_angles = _read_u32(header, name_end + 48)
     if 1 <= n_angles <= 512 and name_end + 52 + 8 * n_angles <= len(header):
         angles = np.frombuffer(
             header, dtype="<f8", count=n_angles, offset=name_end + 52
@@ -1341,14 +1341,14 @@ def _scan_v2_acquisition(
     # The depth anchor confirms the n_time-derived layout, so the 6DOF pose block (in the
     # same region) can be trusted; expose the affine it yields under a private key that
     # the caller moves into `attrs["affines"]`.
-    physical_to_lab = _scan_v2_physical_to_lab(header, n_time)
+    physical_to_lab = _build_scan_v2_physical_to_lab(header, n_time)
     if physical_to_lab is not None:
         result["_physical_to_lab"] = physical_to_lab
 
     return result
 
 
-def _scan_v2_coords(
+def _build_scan_v2_coords(
     meta: dict[str, Any], n_time_total: int, npose: int
 ) -> dict[str, xr.DataArray]:
     """Build coordinate DataArrays for a SCAN v2 volume.
@@ -1356,7 +1356,7 @@ def _scan_v2_coords(
     Spatial coordinates use the header voxel spacings (converted to millimeters). The
     v2 header does not encode a lateral/elevation origin, so those axes (`x`, `z`) are
     centered on zero. The depth (`y`) origin is recovered from the header when possible
-    (see `_scan_v2_depth_start`) and otherwise defaults to zero. Spacing is exact;
+    (see `_find_scan_v2_depth_start`) and otherwise defaults to zero. Spacing is exact;
     lateral/elevation absolute position is not (see `load_scan` Notes).
 
     Parameters
@@ -1414,12 +1414,14 @@ def _scan_v2_coords(
     return coords
 
 
-def _scan_v2_attrs(header: bytes, npose: int, n_time_total: int) -> dict[str, Any]:
+def _build_scan_v2_attrs(
+    header: bytes, npose: int, n_time_total: int
+) -> dict[str, Any]:
     """Assemble provenance attributes for a SCAN v2 volume.
 
     The v2 header carries no `probeToLab`-equivalent affine, so `affines` is left empty.
     Header strings are mapped to v1-style provenance fields (`iconeus_subject`,
-    `iconeus_session`, ...) on a best-effort basis (see `_scan_v2_provenance`); the raw
+    `iconeus_session`, ...) on a best-effort basis (see `_map_scan_v2_provenance`); the raw
     decoded strings are always kept in `iconeus_header_strings` so users can re-map them
     if the heuristic mislabels a field.
 
@@ -1444,14 +1446,14 @@ def _scan_v2_attrs(header: bytes, npose: int, n_time_total: int) -> dict[str, An
     else:
         scan_mode = "2Dscan"
 
-    records = _scan_v2_strings(header)
+    records = _read_scan_v2_strings(header)
     attrs: dict[str, Any] = {
         # No physical_to_lab affine has been located in the v2 header yet.
         "affines": {},
         "iconeus_scan_format": "v2",
         "iconeus_scan_mode": scan_mode,
-        "iconeus_datetime": _scan_v2_datetime(header, records),
+        "iconeus_datetime": _read_scan_v2_datetime(header, records),
         "iconeus_header_strings": [text for text, _, _ in records],
     }
-    attrs.update(_scan_v2_provenance(records))
+    attrs.update(_map_scan_v2_provenance(records))
     return attrs

--- a/tests/unit/test_io/test_scan_v2.py
+++ b/tests/unit/test_io/test_scan_v2.py
@@ -32,7 +32,7 @@ _HARDWARE = "HW-1"
 _SVD_CUTOFF = 60
 _PD_WINDOW = 200
 # Acquisition-block values. Transmit frequency deliberately differs from the probe
-# centre frequency so tests prove the two distinct fields are read from the right spots.
+# center frequency so tests prove the two distinct fields are read from the right spots.
 _PROBE_MODEL = "IcoPrime"
 _CENTER_FREQ = 15.625
 _TRANSMIT_FREQ = 9.0
@@ -43,7 +43,7 @@ _PRF = 5500.0
 _ADC = 62.5
 _ANGLES = [-10.0, -8.0, -6.0, -4.0, -2.0, 0.0, 2.0, 4.0, 6.0, 8.0, 10.0]
 _ACQ_DEPTH_START = 1.0
-# 6DOF probe pose written into the orientation block: (tx, ty, tz) in metres,
+# 6DOF probe pose written into the orientation block: (tx, ty, tz) in meters,
 # (rx, ry, rz) in radians. A 90-degree rz gives a non-trivial rotation to validate.
 _POSE = (0.0007, 0.0026, 0.0, 0.0, 0.0, math.pi / 2)
 
@@ -54,7 +54,7 @@ def _acquisition_block(
     """Build the structured acquisition block the loader parses from `n_time`.
 
     Layout (immediately after the time-coordinate array): frame indices, a 64-byte
-    orientation block, the frequency block (centre freq, pitch, scan depth, focal depth),
+    orientation block, the frequency block (center freq, pitch, scan depth, focal depth),
     a 16-byte gap, the probe-name string, the depth range, the transmit/PRF/ADC block,
     then the plane-wave angle count and values.
 
@@ -530,7 +530,7 @@ class TestLoadScanV2Acquisition:
         return load_scan(path)
 
     def test_probe_fields(self, scan_v2_acq: xr.DataArray) -> None:
-        """Probe model, centre frequency, pitch, and focal depth are recovered."""
+        """Probe model, center frequency, pitch, and focal depth are recovered."""
         assert scan_v2_acq.attrs["probe_model"] == _PROBE_MODEL
         assert scan_v2_acq.attrs["probe_center_frequency"] == pytest.approx(
             _CENTER_FREQ
@@ -539,7 +539,7 @@ class TestLoadScanV2Acquisition:
         assert scan_v2_acq.attrs["probe_focal_depth"] == pytest.approx(_FOCAL_DEPTH)
 
     def test_transmit_distinct_from_center(self, scan_v2_acq: xr.DataArray) -> None:
-        """Transmit frequency is read from its own field, distinct from centre freq."""
+        """Transmit frequency is read from its own field, distinct from center freq."""
         assert scan_v2_acq.attrs["transmit_frequency"] == pytest.approx(_TRANSMIT_FREQ)
         assert scan_v2_acq.attrs["transmit_frequency"] != pytest.approx(_CENTER_FREQ)
 
@@ -654,7 +654,7 @@ class TestLoadScanV2Errors:
         """A non-HDF5 file without the SCAN magic raises a descriptive error."""
         path = tmp_path / "mystery.scan"
         path.write_bytes(b"XXXX not a scan file")
-        with pytest.raises(ValueError, match="not a SCAN file recognised"):
+        with pytest.raises(ValueError, match="not a SCAN file recognized"):
             load_scan(path)
 
     def test_payload_size_mismatch_raises(self, tmp_path: Path) -> None:

--- a/tests/unit/test_io/test_scan_v2.py
+++ b/tests/unit/test_io/test_scan_v2.py
@@ -429,13 +429,11 @@ class TestLoadScanV2:
         """Single-pose v2 is reported as 2Dscan."""
         assert scan_v2.attrs["iconeus_scan_mode"] == "2Dscan"
 
-    def test_header_strings_recovered(self, scan_v2: xr.DataArray) -> None:
-        """Plain header strings are recovered and hex fields decoded."""
-        header_strings = scan_v2.attrs["iconeus_header_strings"]
-        assert "sub-01" in header_strings
-        assert "scan-01" in header_strings
-        # The hex-encoded serial is stored decoded, not as its raw hex form.
-        assert _SERIAL in header_strings
+    def test_unknown_fields_mapped(self, scan_v2: xr.DataArray) -> None:
+        """The three unmapped plain-string slots are exposed explicitly."""
+        assert scan_v2.attrs["iconeus_unknown1"] == "T"
+        assert scan_v2.attrs["iconeus_unknown2"] == "none"
+        assert scan_v2.attrs["iconeus_unknown3"] == "None"
 
     def test_provenance_fields_mapped(self, scan_v2: xr.DataArray) -> None:
         """Header strings map to v1-style provenance fields."""
@@ -444,6 +442,7 @@ class TestLoadScanV2:
         assert scan_v2.attrs["iconeus_session"] == "ses-01"
         assert scan_v2.attrs["iconeus_scan"] == "scan-01"
         assert scan_v2.attrs["iconeus_experimenter"] == "user-01"
+        assert scan_v2.attrs["iconeus_species"] == "Rat"
 
     def test_serial_from_hex_anchor(self, scan_v2: xr.DataArray) -> None:
         """Serial number is recovered from the trailing hex-encoded field."""

--- a/tests/unit/test_io/test_scan_v2.py
+++ b/tests/unit/test_io/test_scan_v2.py
@@ -13,6 +13,7 @@ from confusius.io.scan import (
     PHYSICAL_TO_PROBE_PERMUTATION,
     _SCAN_V2_OFFSETS,
     SCAN_V2_MAGIC,
+    load_bps,
     load_scan,
 )
 
@@ -611,17 +612,43 @@ class TestLoadScanV2Acquisition:
         assert "svd_low_cutoff" in da.attrs
 
 
+class TestLoadScanV2WithBPS:
+    """Tests for BPS composition on v2 files (experimental affine)."""
+
+    @pytest.fixture
+    def scan_v2_acq_path(self, tmp_path: Path) -> Path:
+        """Path to a v2 file with a valid acquisition block (so an affine exists)."""
+        path = tmp_path / "scan_v2_acq_bps.scan"
+        _write_scan_v2(path, _raw_payload(), acquisition=True)
+        return path
+
+    def test_physical_to_brain_composed(
+        self, scan_v2_acq_path: Path, bps_path: Path
+    ) -> None:
+        """bps_path adds a physical_to_brain affine composed from physical_to_lab."""
+        physical_to_lab = np.asarray(
+            load_scan(scan_v2_acq_path).attrs["affines"]["physical_to_lab"]
+        )
+        da = load_scan(scan_v2_acq_path, bps_path=bps_path)
+        expected = np.linalg.inv(load_bps(bps_path)) @ physical_to_lab
+        np.testing.assert_allclose(
+            da.attrs["affines"]["physical_to_brain"], expected, atol=1e-12
+        )
+
+    def test_bps_rejected_without_affine(self, tmp_path: Path, bps_path: Path) -> None:
+        """bps_path raises when no physical_to_lab affine could be built."""
+        path = tmp_path / "scan_v2_noaffine.scan"
+        _write_scan_v2(
+            path, _raw_payload(), acquisition=True, corrupt_acquisition="pose"
+        )
+        with pytest.raises(
+            ValueError, match="no physical_to_lab affine could be built"
+        ):
+            load_scan(path, bps_path=bps_path)
+
+
 class TestLoadScanV2Errors:
     """Tests for v2 error handling and dispatch."""
-
-    def test_bps_path_rejected(self, scan_v2_path: Path, tmp_path: Path) -> None:
-        """bps_path is rejected for v2 files."""
-        bps = tmp_path / "sidecar.bps"
-        bps.write_bytes(b"")
-        with pytest.raises(
-            ValueError, match="bps_path is not yet supported for SCAN v2"
-        ):
-            load_scan(scan_v2_path, bps_path=bps)
 
     def test_unrecognized_format_raises(self, tmp_path: Path) -> None:
         """A non-HDF5 file without the SCAN magic raises a descriptive error."""

--- a/tests/unit/test_io/test_scan_v2.py
+++ b/tests/unit/test_io/test_scan_v2.py
@@ -1,0 +1,328 @@
+"""Unit tests for the binary SCAN v2 loader in confusius.io.scan."""
+
+import struct
+from pathlib import Path
+
+import dask.array as dask_array
+import numpy as np
+import pytest
+import xarray as xr
+
+from confusius.io.scan import _SCAN_V2_OFFSETS, SCAN_V2_MAGIC, load_scan
+
+_SIZE_X = 4
+_SIZE_Y = 1
+_SIZE_Z = 3
+_N_TIME = 5
+_NPOSE = 1
+_NBLOCK = 1
+_DT = 0.4
+_DX_M = 0.00011
+_DY_M = 0.0004
+_DZ_M = 0.00009856
+_STRINGS = ["default sequence", "proj-01", "sub-01", "ses-01"]
+
+
+def _write_scan_v2(
+    path: Path,
+    payload: np.ndarray,
+    *,
+    size_x: int = _SIZE_X,
+    size_y: int = _SIZE_Y,
+    size_z: int = _SIZE_Z,
+    n_time: int = _N_TIME,
+    npose: int = _NPOSE,
+    nblock_repeat: int = _NBLOCK,
+    dt: float = _DT,
+    times: np.ndarray | None = None,
+    strings: list[str] | None = None,
+    depth_start: float | None = None,
+    payload_bytes_override: int | None = None,
+) -> None:
+    """Write a synthetic binary SCAN v2 file.
+
+    The header reproduces the fixed-position layout the loader relies on (magic, sizes,
+    voxel spacings, time coordinates) followed by a block of `uint32`-length-prefixed
+    ASCII strings, then the little-endian `float64` payload.
+
+    Parameters
+    ----------
+    path : pathlib.Path
+        Destination file path.
+    payload : numpy.ndarray
+        Payload array; written in C order as little-endian float64.
+    size_x, size_y, size_z, n_time, npose, nblock_repeat : int
+        Dimension fields written into the header.
+    dt : float
+        Sampling period written into the header.
+    times : (n_time,) numpy.ndarray, optional
+        Time-coordinate values. If not provided, `dt * (arange(n_time) + 1)` is used.
+    strings : list[str], optional
+        Provenance strings appended as length-prefixed records. If not provided,
+        `_STRINGS` is used.
+    depth_start : float, optional
+        Depth-axis origin in mm. If provided, an adjacent `(start, end)` depth-range
+        pair is embedded so the loader can recover the depth origin. If not provided,
+        no depth range is written and the loader falls back to a zero origin.
+    payload_bytes_override : int, optional
+        Value to write into the payload-size header field instead of the true size.
+        Used to exercise the size-mismatch error path.
+
+    Returns
+    -------
+    None
+        The file is written as a side effect.
+    """
+    if times is None:
+        times = dt * (np.arange(n_time) + 1)
+    if strings is None:
+        strings = _STRINGS
+
+    o = _SCAN_V2_OFFSETS
+    time_end = o["time_coords"] + 8 * n_time
+
+    # Optional adjacent (start, end) depth-range pair, spaced by the depth voxel count,
+    # so the loader's span-search can recover the depth origin.
+    depth_bytes = b""
+    if depth_start is not None:
+        depth_end = depth_start + (size_z - 1) * _DZ_M * 1e3
+        depth_bytes = struct.pack("<dd", depth_start, depth_end)
+
+    string_bytes = bytearray()
+    for text in strings:
+        encoded = text.encode("ascii")
+        string_bytes += struct.pack("<I", len(encoded)) + encoded
+
+    total_header_bytes = time_end + len(depth_bytes) + len(string_bytes)
+    payload = np.ascontiguousarray(payload, dtype="<f8")
+    payload_bytes = (
+        payload_bytes_override if payload_bytes_override is not None else payload.nbytes
+    )
+
+    header = bytearray(total_header_bytes)
+    header[0 : len(SCAN_V2_MAGIC)] = SCAN_V2_MAGIC
+    struct.pack_into("<Q", header, o["total_header_bytes"], total_header_bytes)
+    struct.pack_into("<Q", header, o["payload_bytes"], payload_bytes)
+    struct.pack_into("<Q", header, o["size_x"], size_x)
+    struct.pack_into("<Q", header, o["size_y"], size_y)
+    struct.pack_into("<Q", header, o["size_z"], size_z)
+    struct.pack_into("<Q", header, o["n_time"], n_time)
+    struct.pack_into("<Q", header, o["npose"], npose)
+    struct.pack_into("<Q", header, o["nblock_repeat"], nblock_repeat)
+    struct.pack_into("<d", header, o["dt"], dt)
+    struct.pack_into("<d", header, o["x_voxel_m"], _DX_M)
+    struct.pack_into("<d", header, o["y_voxel_m"], _DY_M)
+    struct.pack_into("<d", header, o["z_voxel_m"], _DZ_M)
+    struct.pack_into(f"<{n_time}d", header, o["time_coords"], *times.tolist())
+    header[time_end : time_end + len(depth_bytes)] = depth_bytes
+    header[time_end + len(depth_bytes) : total_header_bytes] = string_bytes
+
+    path.write_bytes(bytes(header) + payload.tobytes())
+
+
+def _raw_payload(
+    size_x: int = _SIZE_X,
+    size_y: int = _SIZE_Y,
+    size_z: int = _SIZE_Z,
+    n_time: int = _N_TIME,
+    npose: int = _NPOSE,
+    nblock_repeat: int = _NBLOCK,
+) -> np.ndarray:
+    """Return a deterministic payload array in the SCAN v2 C-order layout.
+
+    Parameters
+    ----------
+    size_x, size_y, size_z, n_time, npose, nblock_repeat : int
+        Dimension sizes.
+
+    Returns
+    -------
+    numpy.ndarray
+        Array of shape `(n_time, npose, nblock_repeat, size_z, size_y, size_x)`.
+    """
+    shape = (n_time, npose, nblock_repeat, size_z, size_y, size_x)
+    return np.arange(int(np.prod(shape)), dtype=np.float64).reshape(shape)
+
+
+def _expected_confusius(raw: np.ndarray) -> np.ndarray:
+    """Transform a raw v2 payload into the expected ConfUSIus array.
+
+    Mirrors `_load_scan_v2`: squeeze `nblock_repeat`, swap depth/elevation, and squeeze
+    a singleton pose axis.
+
+    Parameters
+    ----------
+    raw : numpy.ndarray
+        Array of shape `(n_time, npose, nblock_repeat, size_z, size_y, size_x)` with
+        `nblock_repeat == 1`.
+
+    Returns
+    -------
+    numpy.ndarray
+        Expected array in ConfUSIus axis order.
+    """
+    sq = raw.squeeze(axis=2)
+    swapped = np.transpose(sq, [0, 1, 3, 2, 4])
+    if swapped.shape[1] == 1:
+        return swapped.squeeze(axis=1)
+    return swapped
+
+
+@pytest.fixture
+def scan_v2_path(tmp_path: Path) -> Path:
+    """Path to a synthetic single-pose 2D SCAN v2 file."""
+    path = tmp_path / "scan_v2_2d.scan"
+    _write_scan_v2(path, _raw_payload())
+    return path
+
+
+@pytest.fixture
+def scan_v2(scan_v2_path: Path) -> xr.DataArray:
+    """Loaded single-pose 2D SCAN v2 DataArray."""
+    return load_scan(scan_v2_path)
+
+
+@pytest.fixture
+def scan_v2_multipose_path(tmp_path: Path) -> Path:
+    """Path to a synthetic multi-pose SCAN v2 file (sizeY > 1, npose > 1)."""
+    path = tmp_path / "scan_v2_multipose.scan"
+    raw = _raw_payload(size_y=2, npose=2)
+    _write_scan_v2(path, raw, size_y=2, npose=2)
+    return path
+
+
+class TestLoadScanV2:
+    """Tests for load_scan dispatching to the binary v2 loader."""
+
+    def test_dims(self, scan_v2: xr.DataArray) -> None:
+        """Single-pose v2 produces dims (time, z, y, x)."""
+        assert scan_v2.dims == ("time", "z", "y", "x")
+
+    def test_shape(self, scan_v2: xr.DataArray) -> None:
+        """Shape maps Iconeus (sizeY, sizeZ, sizeX) to ConfUSIus (z, y, x)."""
+        assert scan_v2.shape == (_N_TIME, _SIZE_Y, _SIZE_Z, _SIZE_X)
+
+    def test_dtype_float64(self, scan_v2: xr.DataArray) -> None:
+        """v2 data is float64."""
+        assert scan_v2.dtype == np.float64
+
+    def test_lazy(self, scan_v2: xr.DataArray) -> None:
+        """v2 returns a lazy Dask-backed DataArray."""
+        assert isinstance(scan_v2.data, dask_array.Array)
+
+    def test_values(self, scan_v2: xr.DataArray) -> None:
+        """Loaded values match the depth/elevation-swapped payload."""
+        expected = _expected_confusius(_raw_payload())
+        np.testing.assert_array_equal(scan_v2.values, expected)
+
+    def test_time_coord(self, scan_v2: xr.DataArray) -> None:
+        """Time coordinate matches header values with end-referenced metadata."""
+        expected = _DT * (np.arange(_N_TIME) + 1)
+        np.testing.assert_allclose(scan_v2.coords["time"].values, expected)
+        assert scan_v2.coords["time"].attrs["units"] == "s"
+        assert scan_v2.coords["time"].attrs["volume_acquisition_reference"] == "end"
+
+    def test_spatial_voxdim(self, scan_v2: xr.DataArray) -> None:
+        """Voxel dimensions come from the header spacings, in mm."""
+        np.testing.assert_allclose(scan_v2.coords["x"].attrs["voxdim"], _DX_M * 1e3)
+        np.testing.assert_allclose(scan_v2.coords["z"].attrs["voxdim"], _DY_M * 1e3)
+        np.testing.assert_allclose(scan_v2.coords["y"].attrs["voxdim"], _DZ_M * 1e3)
+
+    def test_lateral_coord_centered(self, scan_v2: xr.DataArray) -> None:
+        """Lateral (x) coordinate is centered on zero with correct spacing."""
+        expected = (np.arange(_SIZE_X) - (_SIZE_X - 1) / 2) * _DX_M * 1e3
+        np.testing.assert_allclose(scan_v2.coords["x"].values, expected)
+
+    def test_depth_coord_from_zero(self, scan_v2: xr.DataArray) -> None:
+        """Depth (y) coordinate starts at zero when no depth range is in the header."""
+        expected = np.arange(_SIZE_Z) * _DZ_M * 1e3
+        np.testing.assert_allclose(scan_v2.coords["y"].values, expected)
+
+    def test_depth_origin_recovered(self, tmp_path: Path) -> None:
+        """Depth (y) origin is recovered from an embedded depth-range pair."""
+        path = tmp_path / "scan_v2_depth.scan"
+        _write_scan_v2(path, _raw_payload(), depth_start=1.0)
+        da = load_scan(path)
+        expected = 1.0 + np.arange(_SIZE_Z) * _DZ_M * 1e3
+        np.testing.assert_allclose(da.coords["y"].values, expected)
+
+    def test_spatial_units_mm(self, scan_v2: xr.DataArray) -> None:
+        """Spatial coordinates are in mm."""
+        for dim in ("x", "y", "z"):
+            assert scan_v2.coords[dim].attrs["units"] == "mm"
+
+    def test_no_physical_to_lab(self, scan_v2: xr.DataArray) -> None:
+        """v2 carries an empty affines dict (no physical_to_lab yet)."""
+        assert scan_v2.attrs["affines"] == {}
+
+    def test_scan_format_attr(self, scan_v2: xr.DataArray) -> None:
+        """v2 records its on-disk format."""
+        assert scan_v2.attrs["iconeus_scan_format"] == "v2"
+
+    def test_scan_mode_attr(self, scan_v2: xr.DataArray) -> None:
+        """Single-pose v2 is reported as 2Dscan."""
+        assert scan_v2.attrs["iconeus_scan_mode"] == "2Dscan"
+
+    def test_header_strings_recovered(self, scan_v2: xr.DataArray) -> None:
+        """Length-prefixed header strings are recovered best-effort."""
+        for text in _STRINGS:
+            assert text in scan_v2.attrs["iconeus_header_strings"]
+
+    def test_name_from_stem(self, scan_v2: xr.DataArray, scan_v2_path: Path) -> None:
+        """v2 DataArray name falls back to the file stem."""
+        assert scan_v2.name == scan_v2_path.stem
+
+
+class TestLoadScanV2Multipose:
+    """Tests for multi-pose v2 files (inferred layout)."""
+
+    def test_dims(self, scan_v2_multipose_path: Path) -> None:
+        """Multi-pose v2 produces dims (time, pose, z, y, x)."""
+        da = load_scan(scan_v2_multipose_path)
+        assert da.dims == ("time", "pose", "z", "y", "x")
+
+    def test_shape(self, scan_v2_multipose_path: Path) -> None:
+        """Multi-pose shape keeps pose and maps elevation to z."""
+        da = load_scan(scan_v2_multipose_path)
+        assert da.shape == (_N_TIME, 2, 2, _SIZE_Z, _SIZE_X)
+
+    def test_pose_coord(self, scan_v2_multipose_path: Path) -> None:
+        """Multi-pose v2 has an integer pose coordinate."""
+        da = load_scan(scan_v2_multipose_path)
+        np.testing.assert_array_equal(da.coords["pose"].values, np.arange(2))
+
+    def test_scan_mode_attr(self, scan_v2_multipose_path: Path) -> None:
+        """Multi-pose v2 with time is reported as 4Dscan."""
+        da = load_scan(scan_v2_multipose_path)
+        assert da.attrs["iconeus_scan_mode"] == "4Dscan"
+
+    def test_values(self, scan_v2_multipose_path: Path) -> None:
+        """Multi-pose loaded values match the swapped payload."""
+        da = load_scan(scan_v2_multipose_path)
+        expected = _expected_confusius(_raw_payload(size_y=2, npose=2))
+        np.testing.assert_array_equal(da.values, expected)
+
+
+class TestLoadScanV2Errors:
+    """Tests for v2 error handling and dispatch."""
+
+    def test_bps_path_rejected(self, scan_v2_path: Path, tmp_path: Path) -> None:
+        """bps_path is rejected for v2 files."""
+        bps = tmp_path / "sidecar.bps"
+        bps.write_bytes(b"")
+        with pytest.raises(ValueError, match="bps_path is not supported for SCAN v2"):
+            load_scan(scan_v2_path, bps_path=bps)
+
+    def test_unrecognized_format_raises(self, tmp_path: Path) -> None:
+        """A non-HDF5 file without the SCAN magic raises a descriptive error."""
+        path = tmp_path / "mystery.scan"
+        path.write_bytes(b"XXXX not a scan file")
+        with pytest.raises(ValueError, match="not a SCAN file recognised"):
+            load_scan(path)
+
+    def test_payload_size_mismatch_raises(self, tmp_path: Path) -> None:
+        """A payload-size field inconsistent with the dimensions raises."""
+        path = tmp_path / "bad_size.scan"
+        _write_scan_v2(path, _raw_payload(), payload_bytes_override=12345)
+        with pytest.raises(ValueError, match="does not match the product"):
+            load_scan(path)

--- a/tests/unit/test_io/test_scan_v2.py
+++ b/tests/unit/test_io/test_scan_v2.py
@@ -173,25 +173,52 @@ def _raw_payload(
 def _expected_confusius(raw: np.ndarray) -> np.ndarray:
     """Transform a raw v2 payload into the expected ConfUSIus array.
 
-    Mirrors `_load_scan_v2`: squeeze `nblock_repeat`, swap depth/elevation, and squeeze
-    a singleton pose axis.
+    Mirrors `_load_scan_v2`: fold `nblock_repeat` into time (or squeeze it when 1), swap
+    depth/elevation, and squeeze a singleton pose axis.
 
     Parameters
     ----------
     raw : numpy.ndarray
-        Array of shape `(n_time, npose, nblock_repeat, size_z, size_y, size_x)` with
-        `nblock_repeat == 1`.
+        Array of shape `(n_time, npose, nblock_repeat, size_z, size_y, size_x)`.
 
     Returns
     -------
     numpy.ndarray
         Expected array in ConfUSIus axis order.
     """
-    sq = raw.squeeze(axis=2)
+    n_time, npose, nblock, size_z, size_y, size_x = raw.shape
+    if nblock == 1:
+        sq = raw.squeeze(axis=2)
+    else:
+        sq = np.transpose(raw, [0, 2, 1, 3, 4, 5]).reshape(
+            n_time * nblock, npose, size_z, size_y, size_x
+        )
     swapped = np.transpose(sq, [0, 1, 3, 2, 4])
     if swapped.shape[1] == 1:
         return swapped.squeeze(axis=1)
     return swapped
+
+
+def _patch_u64(path: Path, offset: int, value: int) -> None:
+    """Overwrite a little-endian uint64 header field in an existing file.
+
+    Parameters
+    ----------
+    path : pathlib.Path
+        File to patch in place.
+    offset : int
+        Byte offset of the field.
+    value : int
+        New value to write.
+
+    Returns
+    -------
+    None
+        The file is modified as a side effect.
+    """
+    data = bytearray(path.read_bytes())
+    struct.pack_into("<Q", data, offset, value)
+    path.write_bytes(data)
 
 
 @pytest.fixture
@@ -214,6 +241,14 @@ def scan_v2_multipose_path(tmp_path: Path) -> Path:
     path = tmp_path / "scan_v2_multipose.scan"
     raw = _raw_payload(size_y=2, npose=2)
     _write_scan_v2(path, raw, size_y=2, npose=2)
+    return path
+
+
+@pytest.fixture
+def scan_v2_multiblock_path(tmp_path: Path) -> Path:
+    """Path to a synthetic SCAN v2 file with nblock_repeat > 1."""
+    path = tmp_path / "scan_v2_multiblock.scan"
+    _write_scan_v2(path, _raw_payload(nblock_repeat=2), nblock_repeat=2)
     return path
 
 
@@ -271,6 +306,13 @@ class TestLoadScanV2:
         da = load_scan(path)
         expected = 1.0 + np.arange(_SIZE_Z) * _DZ_M * 1e3
         np.testing.assert_allclose(da.coords["y"].values, expected)
+
+    def test_single_depth_voxel_zero_origin(self, tmp_path: Path) -> None:
+        """A single-depth-voxel file has no span to match, so the origin is zero."""
+        path = tmp_path / "scan_v2_depth1.scan"
+        _write_scan_v2(path, _raw_payload(size_z=1), size_z=1)
+        da = load_scan(path)
+        np.testing.assert_array_equal(da.coords["y"].values, [0.0])
 
     def test_spatial_units_mm(self, scan_v2: xr.DataArray) -> None:
         """Spatial coordinates are in mm."""
@@ -352,6 +394,29 @@ class TestLoadScanV2Multipose:
         np.testing.assert_array_equal(da.values, expected)
 
 
+class TestLoadScanV2Multiblock:
+    """Tests for nblock_repeat > 1, folded into the time dimension."""
+
+    def test_shape_folds_block_into_time(self, scan_v2_multiblock_path: Path) -> None:
+        """nblock_repeat is merged into time: T = n_time * nblock_repeat."""
+        da = load_scan(scan_v2_multiblock_path)
+        assert da.dims == ("time", "z", "y", "x")
+        assert da.shape == (_N_TIME * 2, _SIZE_Y, _SIZE_Z, _SIZE_X)
+
+    def test_values(self, scan_v2_multiblock_path: Path) -> None:
+        """Folded values match the transposed/reshaped payload."""
+        da = load_scan(scan_v2_multiblock_path)
+        expected = _expected_confusius(_raw_payload(nblock_repeat=2))
+        np.testing.assert_array_equal(da.values, expected)
+
+    def test_time_coord_falls_back_to_grid(self, scan_v2_multiblock_path: Path) -> None:
+        """With more time points than stored timestamps, time is a dt-spaced grid."""
+        da = load_scan(scan_v2_multiblock_path)
+        np.testing.assert_allclose(
+            da.coords["time"].values, np.arange(_N_TIME * 2) * _DT
+        )
+
+
 class TestLoadScanV2Errors:
     """Tests for v2 error handling and dispatch."""
 
@@ -375,3 +440,22 @@ class TestLoadScanV2Errors:
         _write_scan_v2(path, _raw_payload(), payload_bytes_override=12345)
         with pytest.raises(ValueError, match="does not match the product"):
             load_scan(path)
+
+    def test_truncated_header_raises(self, tmp_path: Path) -> None:
+        """An implausibly large n_time (header too short for it) raises."""
+        path = tmp_path / "truncated.scan"
+        _write_scan_v2(path, _raw_payload())
+        _patch_u64(path, _SCAN_V2_OFFSETS["n_time"], 10_000_000)
+        with pytest.raises(ValueError, match="experimental") as excinfo:
+            load_scan(path)
+        # The wrapped experimental error carries the underlying cause message.
+        assert "implausible time-point count" in str(excinfo.value)
+
+    def test_nonpositive_dimension_raises(self, tmp_path: Path) -> None:
+        """A zero dimension in the header raises."""
+        path = tmp_path / "zero_dim.scan"
+        _write_scan_v2(path, _raw_payload())
+        _patch_u64(path, _SCAN_V2_OFFSETS["size_x"], 0)
+        with pytest.raises(ValueError, match="experimental") as excinfo:
+            load_scan(path)
+        assert "non-positive" in str(excinfo.value)

--- a/tests/unit/test_io/test_scan_v2.py
+++ b/tests/unit/test_io/test_scan_v2.py
@@ -22,6 +22,70 @@ _DY_M = 0.0004
 _DZ_M = 0.00009856
 _SERIAL = "SN-0001"
 _HARDWARE = "HW-1"
+_SVD_CUTOFF = 60
+_PD_WINDOW = 200
+# Acquisition-block values. Transmit frequency deliberately differs from the probe
+# centre frequency so tests prove the two distinct fields are read from the right spots.
+_PROBE_MODEL = "IcoPrime"
+_CENTER_FREQ = 15.625
+_TRANSMIT_FREQ = 9.0
+_PITCH = 0.11
+_SCAN_DEPTH_CM = 1.5
+_FOCAL_DEPTH = 8.0
+_PRF = 5500.0
+_ADC = 62.5
+_ANGLES = [-10.0, -8.0, -6.0, -4.0, -2.0, 0.0, 2.0, 4.0, 6.0, 8.0, 10.0]
+_ACQ_DEPTH_START = 1.0
+
+
+def _acquisition_block(
+    n_time: int, size_z: int, depth_start: float, corrupt: str | None = None
+) -> bytes:
+    """Build the structured acquisition block the loader parses from `n_time`.
+
+    Layout (immediately after the time-coordinate array): frame indices, a 64-byte
+    orientation block, the frequency block (centre freq, pitch, scan depth, focal depth),
+    a 16-byte gap, the probe-name string, the depth range, the transmit/PRF/ADC block,
+    then the plane-wave angle count and values.
+
+    Parameters
+    ----------
+    n_time : int
+        Number of time points (matches the frame-index count).
+    size_z : int
+        Number of depth voxels, used to space the depth range.
+    depth_start : float
+        Depth origin in mm; the depth range is `(depth_start, depth_start + span)`.
+    corrupt : {"name", "depth"}, optional
+        Inject a defect to exercise the loader's degradation guards: `"name"` writes a
+        non-printable probe name, `"depth"` breaks the depth-range span so the loader's
+        span-search fails and the anchor check cannot confirm alignment.
+
+    Returns
+    -------
+    bytes
+        The packed acquisition block.
+    """
+    depth_end = depth_start + (size_z - 1) * _DZ_M * 1e3
+    if corrupt == "depth":
+        depth_end = depth_start + 99.0  # break the span so span-search finds no pair
+    name = _PROBE_MODEL.encode("ascii")
+    if corrupt == "name":
+        name = bytes(range(1, len(name) + 1))  # valid length, non-printable
+    return (
+        struct.pack(f"<{n_time}I", *range(n_time))  # frame indices
+        + bytes(64)  # orientation block
+        + struct.pack("<dddd", _CENTER_FREQ, _PITCH, _SCAN_DEPTH_CM, _FOCAL_DEPTH)
+        + bytes(16)  # unknown probe block
+        + struct.pack("<H", len(name))
+        + name
+        + struct.pack("<dd", depth_start, depth_end)
+        + struct.pack("<dddd", _TRANSMIT_FREQ, _PRF, _ADC, 1.0)
+        + struct.pack("<I", len(_ANGLES))
+        + struct.pack(f"<{len(_ANGLES)}d", *_ANGLES)
+    )
+
+
 # Provenance layout matching the observed on-disk order: sequence, project, subject,
 # session, species, <type>, scan, <unknown>, <unknown>, experimenter, then the two
 # hex-encoded trailing fields (serial, hardware).
@@ -56,6 +120,8 @@ def _write_scan_v2(
     strings: list[str] | None = None,
     depth_start: float | None = None,
     timestamp: int | None = None,
+    acquisition: bool = False,
+    corrupt_acquisition: str | None = None,
     payload_bytes_override: int | None = None,
 ) -> None:
     """Write a synthetic binary SCAN v2 file.
@@ -86,6 +152,12 @@ def _write_scan_v2(
     timestamp : int, optional
         Acquisition time as a Unix timestamp. If provided, it is written as a `uint64`
         after the string block so the loader can recover the acquisition datetime.
+    acquisition : bool, default: False
+        Whether to embed the full structured acquisition block (probe model, frequencies,
+        pitch, focal depth, depth range, plane-wave angles). When set, the block supplies
+        the depth range, so `depth_start` seeds it.
+    corrupt_acquisition : {"name", "depth"}, optional
+        Passed to `_acquisition_block` to inject a defect (only when `acquisition` is set).
     payload_bytes_override : int, optional
         Value to write into the payload-size header field instead of the true size.
         Used to exercise the size-mismatch error path.
@@ -103,12 +175,20 @@ def _write_scan_v2(
     o = _SCAN_V2_OFFSETS
     time_end = o["time_coords"] + 8 * n_time
 
-    # Optional adjacent (start, end) depth-range pair, spaced by the depth voxel count,
-    # so the loader's span-search can recover the depth origin.
-    depth_bytes = b""
-    if depth_start is not None:
+    if acquisition:
+        # Full structured acquisition block (includes its own depth range).
+        head_bytes: bytes = _acquisition_block(
+            n_time,
+            size_z,
+            _ACQ_DEPTH_START if depth_start is None else depth_start,
+            corrupt=corrupt_acquisition,
+        )
+    elif depth_start is not None:
+        # Just an adjacent (start, end) depth-range pair for the span-search.
         depth_end = depth_start + (size_z - 1) * _DZ_M * 1e3
-        depth_bytes = struct.pack("<dd", depth_start, depth_end)
+        head_bytes = struct.pack("<dd", depth_start, depth_end)
+    else:
+        head_bytes = b""
 
     string_bytes = bytearray()
     for text in strings:
@@ -118,7 +198,7 @@ def _write_scan_v2(
     # Optional acquisition timestamp (uint64 Unix seconds) after the string block.
     ts_bytes = struct.pack("<Q", timestamp) if timestamp is not None else b""
 
-    tail_bytes = bytes(depth_bytes) + bytes(string_bytes) + ts_bytes
+    tail_bytes = head_bytes + bytes(string_bytes) + ts_bytes
     total_header_bytes = time_end + len(tail_bytes)
     payload = np.ascontiguousarray(payload, dtype="<f8")
     payload_bytes = (
@@ -137,6 +217,8 @@ def _write_scan_v2(
     struct.pack_into("<Q", header, o["npose"], npose)
     struct.pack_into("<Q", header, o["nblock_repeat"], nblock_repeat)
     struct.pack_into("<d", header, o["dt"], dt)
+    struct.pack_into("<I", header, o["svd_clutter_cutoff"], _SVD_CUTOFF)
+    struct.pack_into("<I", header, o["power_doppler_integration_window"], _PD_WINDOW)
     struct.pack_into("<d", header, o["x_voxel_m"], _DX_M)
     struct.pack_into("<d", header, o["y_voxel_m"], _DY_M)
     struct.pack_into("<d", header, o["z_voxel_m"], _DZ_M)
@@ -419,6 +501,75 @@ class TestLoadScanV2Multiblock:
         assert da.coords["time"].attrs["volume_acquisition_duration"] == pytest.approx(
             _DT
         )
+
+
+class TestLoadScanV2Acquisition:
+    """Tests for BIDS-corresponding acquisition metadata."""
+
+    @pytest.fixture
+    def scan_v2_acq(self, tmp_path: Path) -> xr.DataArray:
+        """Loaded v2 DataArray with a full acquisition block."""
+        path = tmp_path / "scan_v2_acq.scan"
+        _write_scan_v2(path, _raw_payload(), acquisition=True)
+        return load_scan(path)
+
+    def test_probe_fields(self, scan_v2_acq: xr.DataArray) -> None:
+        """Probe model, centre frequency, pitch, and focal depth are recovered."""
+        assert scan_v2_acq.attrs["probe_model"] == _PROBE_MODEL
+        assert scan_v2_acq.attrs["probe_center_frequency"] == pytest.approx(
+            _CENTER_FREQ
+        )
+        assert scan_v2_acq.attrs["probe_pitch"] == pytest.approx(_PITCH)
+        assert scan_v2_acq.attrs["probe_focal_depth"] == pytest.approx(_FOCAL_DEPTH)
+
+    def test_transmit_distinct_from_center(self, scan_v2_acq: xr.DataArray) -> None:
+        """Transmit frequency is read from its own field, distinct from centre freq."""
+        assert scan_v2_acq.attrs["transmit_frequency"] == pytest.approx(_TRANSMIT_FREQ)
+        assert scan_v2_acq.attrs["transmit_frequency"] != pytest.approx(_CENTER_FREQ)
+
+    def test_sequence_fields(self, scan_v2_acq: xr.DataArray) -> None:
+        """PRF, plane-wave angles, and imaging depth are recovered."""
+        assert scan_v2_acq.attrs["pulse_repetition_frequency"] == pytest.approx(_PRF)
+        np.testing.assert_allclose(scan_v2_acq.attrs["plane_wave_angles"], _ANGLES)
+        np.testing.assert_allclose(
+            scan_v2_acq.attrs["imaging_depth"],
+            (_ACQ_DEPTH_START, _ACQ_DEPTH_START + (_SIZE_Z - 1) * _DZ_M * 1e3),
+        )
+
+    def test_filter_fields(self, scan_v2_acq: xr.DataArray) -> None:
+        """SVD low cutoff and power-Doppler window come from fixed offsets."""
+        assert scan_v2_acq.attrs["svd_low_cutoff"] == _SVD_CUTOFF
+        assert scan_v2_acq.attrs["power_doppler_integration_window"] == _PD_WINDOW
+
+    def test_acquisition_absent_when_block_missing(self, scan_v2: xr.DataArray) -> None:
+        """Without a valid acquisition block, probe/sequence fields are not emitted.
+
+        The fixed-offset filter fields are still present; only the anchor-validated
+        structured fields are withheld to avoid emitting misaligned metadata.
+        """
+        assert "probe_model" not in scan_v2.attrs
+        assert "transmit_frequency" not in scan_v2.attrs
+        assert "svd_low_cutoff" in scan_v2.attrs
+
+    def test_acquisition_skipped_on_nonprintable_name(self, tmp_path: Path) -> None:
+        """A non-printable probe name makes the loader skip the structured fields."""
+        path = tmp_path / "scan_v2_badname.scan"
+        _write_scan_v2(
+            path, _raw_payload(), acquisition=True, corrupt_acquisition="name"
+        )
+        da = load_scan(path)
+        assert "probe_model" not in da.attrs
+        assert "svd_low_cutoff" in da.attrs
+
+    def test_acquisition_skipped_on_depth_anchor_mismatch(self, tmp_path: Path) -> None:
+        """A broken depth range fails the anchor check, so the block is not trusted."""
+        path = tmp_path / "scan_v2_baddepth.scan"
+        _write_scan_v2(
+            path, _raw_payload(), acquisition=True, corrupt_acquisition="depth"
+        )
+        da = load_scan(path)
+        assert "probe_model" not in da.attrs
+        assert "svd_low_cutoff" in da.attrs
 
 
 class TestLoadScanV2Errors:

--- a/tests/unit/test_io/test_scan_v2.py
+++ b/tests/unit/test_io/test_scan_v2.py
@@ -315,7 +315,7 @@ class TestLoadScanV2:
         # 1784005200 == 2026-07-14T05:00:00+00:00.
         _write_scan_v2(path, _raw_payload(), timestamp=1784005200)
         da = load_scan(path)
-        assert da.attrs["iconeus_date"] == "2026-07-14T05:00:00+00:00"
+        assert da.attrs["iconeus_datetime"] == "2026-07-14T05:00:00+00:00"
 
     def test_name_from_scan_tag(self, scan_v2: xr.DataArray) -> None:
         """v2 DataArray name is taken from the recovered scan tag."""

--- a/tests/unit/test_io/test_scan_v2.py
+++ b/tests/unit/test_io/test_scan_v2.py
@@ -410,10 +410,14 @@ class TestLoadScanV2Multiblock:
         np.testing.assert_array_equal(da.values, expected)
 
     def test_time_coord_falls_back_to_grid(self, scan_v2_multiblock_path: Path) -> None:
-        """With more time points than stored timestamps, time is a dt-spaced grid."""
+        """With more time points than stored timestamps, time is an end-referenced grid."""
         da = load_scan(scan_v2_multiblock_path)
         np.testing.assert_allclose(
-            da.coords["time"].values, np.arange(_N_TIME * 2) * _DT
+            da.coords["time"].values, _DT * (np.arange(_N_TIME * 2) + 1)
+        )
+        assert da.coords["time"].attrs["volume_acquisition_reference"] == "end"
+        assert da.coords["time"].attrs["volume_acquisition_duration"] == pytest.approx(
+            _DT
         )
 
 

--- a/tests/unit/test_io/test_scan_v2.py
+++ b/tests/unit/test_io/test_scan_v2.py
@@ -1,5 +1,6 @@
 """Unit tests for the binary SCAN v2 loader in confusius.io.scan."""
 
+import math
 import struct
 from pathlib import Path
 
@@ -8,7 +9,12 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from confusius.io.scan import _SCAN_V2_OFFSETS, SCAN_V2_MAGIC, load_scan
+from confusius.io.scan import (
+    PHYSICAL_TO_PROBE_PERMUTATION,
+    _SCAN_V2_OFFSETS,
+    SCAN_V2_MAGIC,
+    load_scan,
+)
 
 _SIZE_X = 4
 _SIZE_Y = 1
@@ -36,6 +42,9 @@ _PRF = 5500.0
 _ADC = 62.5
 _ANGLES = [-10.0, -8.0, -6.0, -4.0, -2.0, 0.0, 2.0, 4.0, 6.0, 8.0, 10.0]
 _ACQ_DEPTH_START = 1.0
+# 6DOF probe pose written into the orientation block: (tx, ty, tz) in metres,
+# (rx, ry, rz) in radians. A 90-degree rz gives a non-trivial rotation to validate.
+_POSE = (0.0007, 0.0026, 0.0, 0.0, 0.0, math.pi / 2)
 
 
 def _acquisition_block(
@@ -56,10 +65,11 @@ def _acquisition_block(
         Number of depth voxels, used to space the depth range.
     depth_start : float
         Depth origin in mm; the depth range is `(depth_start, depth_start + span)`.
-    corrupt : {"name", "depth"}, optional
+    corrupt : {"name", "depth", "pose"}, optional
         Inject a defect to exercise the loader's degradation guards: `"name"` writes a
         non-printable probe name, `"depth"` breaks the depth-range span so the loader's
-        span-search fails and the anchor check cannot confirm alignment.
+        span-search fails and the anchor check cannot confirm alignment, `"pose"` writes
+        an implausible probe pose so no affine is built.
 
     Returns
     -------
@@ -72,9 +82,14 @@ def _acquisition_block(
     name = _PROBE_MODEL.encode("ascii")
     if corrupt == "name":
         name = bytes(range(1, len(name) + 1))  # valid length, non-printable
+    # Orientation block: 6DOF pose (6 f64) + a flag slot + padding = 64 bytes.
+    pose = (
+        (5.0, *_POSE[1:]) if corrupt == "pose" else _POSE
+    )  # 5 m translation: implausible
+    orientation = struct.pack("<6d", *pose) + struct.pack("<Q", 1) + bytes(8)
     return (
         struct.pack(f"<{n_time}I", *range(n_time))  # frame indices
-        + bytes(64)  # orientation block
+        + orientation
         + struct.pack("<dddd", _CENTER_FREQ, _PITCH, _SCAN_DEPTH_CM, _FOCAL_DEPTH)
         + bytes(16)  # unknown probe block
         + struct.pack("<H", len(name))
@@ -156,7 +171,7 @@ def _write_scan_v2(
         Whether to embed the full structured acquisition block (probe model, frequencies,
         pitch, focal depth, depth range, plane-wave angles). When set, the block supplies
         the depth range, so `depth_start` seeds it.
-    corrupt_acquisition : {"name", "depth"}, optional
+    corrupt_acquisition : {"name", "depth", "pose"}, optional
         Passed to `_acquisition_block` to inject a defect (only when `acquisition` is set).
     payload_bytes_override : int, optional
         Value to write into the payload-size header field instead of the true size.
@@ -541,6 +556,30 @@ class TestLoadScanV2Acquisition:
         assert scan_v2_acq.attrs["svd_low_cutoff"] == _SVD_CUTOFF
         assert scan_v2_acq.attrs["power_doppler_integration_window"] == _PD_WINDOW
 
+    def test_physical_to_lab_from_pose(self, scan_v2_acq: xr.DataArray) -> None:
+        """physical_to_lab is built from the 6DOF pose, matching the v1 permutation."""
+        tx, ty, tz, _, _, rz = _POSE
+        cz, sz = math.cos(rz), math.sin(rz)
+        probe_to_lab = np.eye(4)
+        probe_to_lab[:3, :3] = [[cz, -sz, 0], [sz, cz, 0], [0, 0, 1]]
+        probe_to_lab[:3, 3] = (tx, ty, tz)
+        perm = np.asarray(PHYSICAL_TO_PROBE_PERMUTATION)
+        expected = perm.T @ probe_to_lab @ perm
+        expected[:3, 3] *= 1e3
+
+        affine = np.asarray(scan_v2_acq.attrs["affines"]["physical_to_lab"])
+        np.testing.assert_allclose(affine, expected, atol=1e-9)
+
+    def test_affine_skipped_on_implausible_pose(self, tmp_path: Path) -> None:
+        """An implausible pose yields no affine, but other fields still load."""
+        path = tmp_path / "scan_v2_badpose.scan"
+        _write_scan_v2(
+            path, _raw_payload(), acquisition=True, corrupt_acquisition="pose"
+        )
+        da = load_scan(path)
+        assert "probe_model" in da.attrs
+        assert "physical_to_lab" not in da.attrs["affines"]
+
     def test_acquisition_absent_when_block_missing(self, scan_v2: xr.DataArray) -> None:
         """Without a valid acquisition block, probe/sequence fields are not emitted.
 
@@ -579,7 +618,9 @@ class TestLoadScanV2Errors:
         """bps_path is rejected for v2 files."""
         bps = tmp_path / "sidecar.bps"
         bps.write_bytes(b"")
-        with pytest.raises(ValueError, match="bps_path is not supported for SCAN v2"):
+        with pytest.raises(
+            ValueError, match="bps_path is not yet supported for SCAN v2"
+        ):
             load_scan(scan_v2_path, bps_path=bps)
 
     def test_unrecognized_format_raises(self, tmp_path: Path) -> None:

--- a/tests/unit/test_io/test_scan_v2.py
+++ b/tests/unit/test_io/test_scan_v2.py
@@ -20,7 +20,25 @@ _DT = 0.4
 _DX_M = 0.00011
 _DY_M = 0.0004
 _DZ_M = 0.00009856
-_STRINGS = ["default sequence", "proj-01", "sub-01", "ses-01"]
+_SERIAL = "SN-0001"
+_HARDWARE = "HW-1"
+# Provenance layout matching the observed on-disk order: sequence, project, subject,
+# session, species, <type>, scan, <unknown>, <unknown>, experimenter, then the two
+# hex-encoded trailing fields (serial, hardware).
+_STRINGS = [
+    "default sequence",
+    "proj-01",
+    "sub-01",
+    "ses-01",
+    "Rat",
+    "T",
+    "scan-01",
+    "none",
+    "None",
+    "user-01",
+    _SERIAL.encode("ascii").hex().upper(),
+    _HARDWARE.encode("ascii").hex().upper(),
+]
 
 
 def _write_scan_v2(
@@ -37,6 +55,7 @@ def _write_scan_v2(
     times: np.ndarray | None = None,
     strings: list[str] | None = None,
     depth_start: float | None = None,
+    timestamp: int | None = None,
     payload_bytes_override: int | None = None,
 ) -> None:
     """Write a synthetic binary SCAN v2 file.
@@ -64,6 +83,9 @@ def _write_scan_v2(
         Depth-axis origin in mm. If provided, an adjacent `(start, end)` depth-range
         pair is embedded so the loader can recover the depth origin. If not provided,
         no depth range is written and the loader falls back to a zero origin.
+    timestamp : int, optional
+        Acquisition time as a Unix timestamp. If provided, it is written as a `uint64`
+        after the string block so the loader can recover the acquisition datetime.
     payload_bytes_override : int, optional
         Value to write into the payload-size header field instead of the true size.
         Used to exercise the size-mismatch error path.
@@ -93,7 +115,11 @@ def _write_scan_v2(
         encoded = text.encode("ascii")
         string_bytes += struct.pack("<I", len(encoded)) + encoded
 
-    total_header_bytes = time_end + len(depth_bytes) + len(string_bytes)
+    # Optional acquisition timestamp (uint64 Unix seconds) after the string block.
+    ts_bytes = struct.pack("<Q", timestamp) if timestamp is not None else b""
+
+    tail_bytes = bytes(depth_bytes) + bytes(string_bytes) + ts_bytes
+    total_header_bytes = time_end + len(tail_bytes)
     payload = np.ascontiguousarray(payload, dtype="<f8")
     payload_bytes = (
         payload_bytes_override if payload_bytes_override is not None else payload.nbytes
@@ -101,6 +127,7 @@ def _write_scan_v2(
 
     header = bytearray(total_header_bytes)
     header[0 : len(SCAN_V2_MAGIC)] = SCAN_V2_MAGIC
+    struct.pack_into("<Q", header, 0x04, 1)  # version, as in real files
     struct.pack_into("<Q", header, o["total_header_bytes"], total_header_bytes)
     struct.pack_into("<Q", header, o["payload_bytes"], payload_bytes)
     struct.pack_into("<Q", header, o["size_x"], size_x)
@@ -114,8 +141,7 @@ def _write_scan_v2(
     struct.pack_into("<d", header, o["y_voxel_m"], _DY_M)
     struct.pack_into("<d", header, o["z_voxel_m"], _DZ_M)
     struct.pack_into(f"<{n_time}d", header, o["time_coords"], *times.tolist())
-    header[time_end : time_end + len(depth_bytes)] = depth_bytes
-    header[time_end + len(depth_bytes) : total_header_bytes] = string_bytes
+    header[time_end:total_header_bytes] = tail_bytes
 
     path.write_bytes(bytes(header) + payload.tobytes())
 
@@ -264,13 +290,36 @@ class TestLoadScanV2:
         assert scan_v2.attrs["iconeus_scan_mode"] == "2Dscan"
 
     def test_header_strings_recovered(self, scan_v2: xr.DataArray) -> None:
-        """Length-prefixed header strings are recovered best-effort."""
-        for text in _STRINGS:
-            assert text in scan_v2.attrs["iconeus_header_strings"]
+        """Plain header strings are recovered and hex fields decoded."""
+        header_strings = scan_v2.attrs["iconeus_header_strings"]
+        assert "sub-01" in header_strings
+        assert "scan-01" in header_strings
+        # The hex-encoded serial is stored decoded, not as its raw hex form.
+        assert _SERIAL in header_strings
 
-    def test_name_from_stem(self, scan_v2: xr.DataArray, scan_v2_path: Path) -> None:
-        """v2 DataArray name falls back to the file stem."""
-        assert scan_v2.name == scan_v2_path.stem
+    def test_provenance_fields_mapped(self, scan_v2: xr.DataArray) -> None:
+        """Header strings map to v1-style provenance fields."""
+        assert scan_v2.attrs["iconeus_project"] == "proj-01"
+        assert scan_v2.attrs["iconeus_subject"] == "sub-01"
+        assert scan_v2.attrs["iconeus_session"] == "ses-01"
+        assert scan_v2.attrs["iconeus_scan"] == "scan-01"
+        assert scan_v2.attrs["iconeus_experimenter"] == "user-01"
+
+    def test_serial_from_hex_anchor(self, scan_v2: xr.DataArray) -> None:
+        """Serial number is recovered from the trailing hex-encoded field."""
+        assert scan_v2.attrs["device_serial_number"] == _SERIAL
+
+    def test_acquisition_datetime_recovered(self, tmp_path: Path) -> None:
+        """Acquisition timestamp is recovered as a full ISO 8601 UTC datetime."""
+        path = tmp_path / "scan_v2_ts.scan"
+        # 1784005200 == 2026-07-14T05:00:00+00:00.
+        _write_scan_v2(path, _raw_payload(), timestamp=1784005200)
+        da = load_scan(path)
+        assert da.attrs["iconeus_date"] == "2026-07-14T05:00:00+00:00"
+
+    def test_name_from_scan_tag(self, scan_v2: xr.DataArray) -> None:
+        """v2 DataArray name is taken from the recovered scan tag."""
+        assert scan_v2.name == "scan-01"
 
 
 class TestLoadScanV2Multipose:


### PR DESCRIPTION
Adds support for binary Iconeus SCAN v2 files to `load_scan`, closing the gap where v2 files were rejected. 

Closes #316.

## What

- `load_scan` now sniffs the format and dispatches to `_load_scan_v1` (HDF5) or `_load_scan_v2` (binary).
- `_load_scan_v2` parses the reverse-engineered header, memory-maps the `float64` payload for lazy Dask access, and returns a DataArray in ConfUSIus `(time, z, y, x)` / `(time, pose, z, y, x)` order with millimetre coordinates.
- Depth origin is recovered from the header depth-range pair via a self-validating span search (falls back to a zero origin); lateral/elevation axes are centred.
- Verified end-to-end on the example file: `(38, 1, 92, 128)`, x ∈ [-6.985, 6.985] mm, depth ∈ [1.0, 9.97] mm, time 0.4–15.2 s.

## Caveats (experimental)

- No `physical_to_lab` affine located yet, so `bps_path` is rejected for v2.
- Multi-pose / multi-block layouts are inferred by analogy with v1, not yet validated against real files.
- Any parse failure is re-raised as an experimental notice pointing to the issue tracker.