### PR TITLE
fix(napari): warn on irregular video sync

### DIFF
--- a/src/confusius/_napari/_video/_video_panel.py
+++ b/src/confusius/_napari/_video/_video_panel.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING
 import numpy as np
 from napari.utils.notifications import show_error, show_info
 from napari_video.napari_video import VideoReaderNP
+
+from confusius.timing import get_representative_time_step
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import (
     QAbstractItemView,
@@ -29,6 +31,13 @@ from qtpy.QtWidgets import (
 if TYPE_CHECKING:
     import napari
     import napari.layers
+
+
+_IRREGULAR_TIME_WARNING = (
+    "Reference layer time axis is not regularly sampled; "
+    "video synchronization uses a linear approximation and may drift."
+)
+"""Warning shown when a video is synchronized against irregular time samples."""
 
 
 class _VideoArray:
@@ -305,6 +314,12 @@ class VideoPanel(QWidget):
         # input, never as a side-effect of layer inserts or removals.
         self._ref_combo.activated.connect(self._on_user_ref_changed)
         ref_layout.addWidget(self._ref_combo)
+
+        self._ref_warning = QLabel(_IRREGULAR_TIME_WARNING)
+        self._ref_warning.setWordWrap(True)
+        self._ref_warning.hide()
+        ref_layout.addWidget(self._ref_warning)
+
         layout.addWidget(ref_group)
 
         # Video file selector.
@@ -432,6 +447,7 @@ class VideoPanel(QWidget):
         has_path = bool(self._path_edit.text().strip())
         has_ref = self._ref_combo.currentIndex() >= 0
         self._load_btn.setEnabled(has_ref and has_path)
+        self._update_ref_warning(self._get_ref_layer())
 
     def _on_user_ref_changed(self, _idx: int | None = None) -> None:
         """Handle user-initiated reference layer changes in the combo.
@@ -459,6 +475,7 @@ class VideoPanel(QWidget):
                         self._ref_combo.setCurrentIndex(idx)
                     finally:
                         self._ref_combo.blockSignals(False)
+            self._update_ref_warning(self._get_ref_layer())
             return
 
         self._update_shared_ref_state(new_ref)
@@ -474,6 +491,16 @@ class VideoPanel(QWidget):
         )
         self._axis_labels = tuple(ref_xr.dims)
         self._units = list(getattr(ref_layer, "units", [None] * ref_layer.ndim))
+
+    def _update_ref_warning(self, ref_layer) -> None:
+        """Show a warning when the selected reference has irregular timing."""
+        visible = False
+        if ref_layer is not None:
+            xr_da = ref_layer.metadata.get("xarray")
+            if xr_da is not None and "time" in xr_da.coords:
+                _, approximate = get_representative_time_step(xr_da)
+                visible = approximate
+        self._ref_warning.setVisible(visible)
 
     def _get_ref_layer(self):
         """Return the layer currently selected in the combo, or None."""

--- a/src/confusius/_napari/_video/_video_panel.py
+++ b/src/confusius/_napari/_video/_video_panel.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import numpy as np
-from napari.utils.notifications import show_error, show_info
+from napari.utils.notifications import show_error, show_info, show_warning
 from napari_video.napari_video import VideoReaderNP
 
 from confusius.timing import get_representative_time_step
@@ -314,12 +314,6 @@ class VideoPanel(QWidget):
         # input, never as a side-effect of layer inserts or removals.
         self._ref_combo.activated.connect(self._on_user_ref_changed)
         ref_layout.addWidget(self._ref_combo)
-
-        self._ref_warning = QLabel(_IRREGULAR_TIME_WARNING)
-        self._ref_warning.setWordWrap(True)
-        self._ref_warning.hide()
-        ref_layout.addWidget(self._ref_warning)
-
         layout.addWidget(ref_group)
 
         # Video file selector.
@@ -447,7 +441,6 @@ class VideoPanel(QWidget):
         has_path = bool(self._path_edit.text().strip())
         has_ref = self._ref_combo.currentIndex() >= 0
         self._load_btn.setEnabled(has_ref and has_path)
-        self._update_ref_warning(self._get_ref_layer())
 
     def _on_user_ref_changed(self, _idx: int | None = None) -> None:
         """Handle user-initiated reference layer changes in the combo.
@@ -475,10 +468,10 @@ class VideoPanel(QWidget):
                         self._ref_combo.setCurrentIndex(idx)
                     finally:
                         self._ref_combo.blockSignals(False)
-            self._update_ref_warning(self._get_ref_layer())
             return
 
         self._update_shared_ref_state(new_ref)
+        self._warn_if_irregular_reference(new_ref)
         self._rebuild_all_entries()
 
     def _update_shared_ref_state(self, ref_layer) -> None:
@@ -492,15 +485,16 @@ class VideoPanel(QWidget):
         self._axis_labels = tuple(ref_xr.dims)
         self._units = list(getattr(ref_layer, "units", [None] * ref_layer.ndim))
 
-    def _update_ref_warning(self, ref_layer) -> None:
-        """Show a warning when the selected reference has irregular timing."""
-        visible = False
-        if ref_layer is not None:
-            xr_da = ref_layer.metadata.get("xarray")
-            if xr_da is not None and "time" in xr_da.coords:
-                _, approximate = get_representative_time_step(xr_da)
-                visible = approximate
-        self._ref_warning.setVisible(visible)
+    def _warn_if_irregular_reference(self, ref_layer) -> None:
+        """Show a toast when the selected reference has irregular timing."""
+        if ref_layer is None:
+            return
+        xr_da = ref_layer.metadata.get("xarray")
+        if xr_da is None or "time" not in xr_da.coords:
+            return
+        _, approximate = get_representative_time_step(xr_da)
+        if approximate:
+            show_warning(_IRREGULAR_TIME_WARNING)
 
     def _get_ref_layer(self):
         """Return the layer currently selected in the combo, or None."""
@@ -571,6 +565,7 @@ class VideoPanel(QWidget):
         # enables grid mode.
         if not self._videos:
             self._update_shared_ref_state(ref_layer)
+            self._warn_if_irregular_reference(ref_layer)
             order = self._viewer.dims.order
             self._displayed_dims = (order[-2], order[-1])
 

--- a/tests/unit/test_napari/test_video_panel.py
+++ b/tests/unit/test_napari/test_video_panel.py
@@ -339,11 +339,25 @@ def loaded_panel(panel, viewer):
 
 
 class TestReferenceWarning:
-    def test_regular_reference_keeps_warning_hidden(self, panel):
-        assert panel._ref_warning.text() == _IRREGULAR_TIME_WARNING
-        assert panel._ref_warning.isHidden()
+    def test_regular_reference_does_not_warn(self, panel, monkeypatch):
+        warnings_seen: list[str] = []
+        monkeypatch.setattr(
+            "confusius._napari._video._video_panel.show_warning",
+            warnings_seen.append,
+        )
 
-    def test_irregular_reference_shows_warning(self, panel, viewer, sample_3dt_volume):
+        panel._warn_if_irregular_reference(panel._ref_layer)
+
+        assert warnings_seen == []
+
+    def test_irregular_reference_warns(
+        self, panel, viewer, sample_3dt_volume, monkeypatch
+    ):
+        warnings_seen: list[str] = []
+        monkeypatch.setattr(
+            "confusius._napari._video._video_panel.show_warning",
+            warnings_seen.append,
+        )
         time_values = sample_3dt_volume.coords["time"].values.astype(np.float64).copy()
         time_values[2:] += 0.02
         irregular = sample_3dt_volume.assign_coords(time=("time", time_values))
@@ -354,11 +368,43 @@ class TestReferenceWarning:
                 show_colorbar=False,
                 show_scale_bar=False,
             )
-        idx = panel._ref_combo.findText(irregular_layer.name)
-        panel._ref_combo.setCurrentIndex(idx)
 
-        assert idx >= 0
-        assert not panel._ref_warning.isHidden()
+        panel._warn_if_irregular_reference(irregular_layer)
+
+        assert warnings_seen == [_IRREGULAR_TIME_WARNING]
+
+    def test_add_video_warns_for_irregular_reference(
+        self, panel, viewer, sample_3dt_volume, monkeypatch, tmp_path
+    ):
+        warnings_seen: list[str] = []
+        monkeypatch.setattr(
+            "confusius._napari._video._video_panel.show_warning",
+            warnings_seen.append,
+        )
+        monkeypatch.setattr(
+            "confusius._napari._video._video_panel.show_info",
+            lambda *_args, **_kwargs: None,
+        )
+        monkeypatch.setattr(
+            "confusius._napari._video._video_panel.VideoReaderNP",
+            lambda *_args, **_kwargs: _FakeVideo(n_frames=10, h=48, w=64, rgb=True),
+        )
+        time_values = sample_3dt_volume.coords["time"].values.astype(np.float64).copy()
+        time_values[2:] += 0.02
+        irregular = sample_3dt_volume.assign_coords(time=("time", time_values))
+        with pytest.warns(UserWarning, match="non-uniform spacing"):
+            _, irregular_layer = plot_napari(
+                irregular,
+                viewer=viewer,
+                show_colorbar=False,
+                show_scale_bar=False,
+            )
+
+        video_path = tmp_path / "video.mp4"
+        video_path.touch()
+        panel._add_video(video_path, irregular_layer)
+
+        assert warnings_seen == [_IRREGULAR_TIME_WARNING]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_napari/test_video_panel.py
+++ b/tests/unit/test_napari/test_video_panel.py
@@ -16,6 +16,7 @@ import pytest
 
 from confusius._napari._video._video_panel import (
     VideoPanel,
+    _IRREGULAR_TIME_WARNING,
     _VideoArray,
     _VideoEntry,
 )
@@ -335,6 +336,29 @@ def loaded_panel(panel, viewer):
     panel._guarding_order = True
 
     return panel
+
+
+class TestReferenceWarning:
+    def test_regular_reference_keeps_warning_hidden(self, panel):
+        assert panel._ref_warning.text() == _IRREGULAR_TIME_WARNING
+        assert panel._ref_warning.isHidden()
+
+    def test_irregular_reference_shows_warning(self, panel, viewer, sample_3dt_volume):
+        time_values = sample_3dt_volume.coords["time"].values.astype(np.float64).copy()
+        time_values[2:] += 0.02
+        irregular = sample_3dt_volume.assign_coords(time=("time", time_values))
+        with pytest.warns(UserWarning, match="non-uniform spacing"):
+            _, irregular_layer = plot_napari(
+                irregular,
+                viewer=viewer,
+                show_colorbar=False,
+                show_scale_bar=False,
+            )
+        idx = panel._ref_combo.findText(irregular_layer.name)
+        panel._ref_combo.setCurrentIndex(idx)
+
+        assert idx >= 0
+        assert not panel._ref_warning.isHidden()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- show a warning in the video panel when the selected reference layer has irregular time sampling
- keep the warning synced when the reference selection changes
- add napari tests for regular and irregular reference layers

Closes #315