### PR TITLE
feat(signal): add cosine high-pass filtering

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -60,6 +60,10 @@ Current development version for the next ConfUSIus release.
   the Khallaf et al. (2026) naked mole-rat fUSI dataset from Edmond, with `datasets`,
   `subjects`, `sessions`, `runs`, `reconstruction`, and `sourcedata` filters
   ([#319](https://github.com/confusius-tools/confusius/pull/319)).
+- Added standalone cosine high-pass filtering via
+  [`filter_cosine`][confusius.signal.filter_cosine], and
+  [`clean`][confusius.signal.clean] can now use it with `filter_method="cosine"`
+  ([#321](https://github.com/confusius-tools/confusius/pull/321)).
 
 ### :bug: Fixes
 

--- a/docs/examples/04_connectivity/01_atlas_correlation_matrix.py
+++ b/docs/examples/04_connectivity/01_atlas_correlation_matrix.py
@@ -228,7 +228,7 @@ signals
 # ## Clean the region signals
 #
 # Before correlating regions we remove nuisance variance that would otherwise inflate
-# their apparent FC: a 0.01 Hz high-pass filter for slow drift, and one
+# their apparent FC: a 0.01 Hz high-pass cosine filter for slow drift, and one
 # [aCompCor][confusius.signal.compute_compcor_confounds] component regressed out.
 # aCompCor components are extracted from white matter voxels—the Allen ontology's
 # `"fiber tracts"` division—so they must be computed from the voxelwise recording rather
@@ -239,7 +239,9 @@ white_matter = atlas_native.get_masks("fiber tracts").isel(mask=0)
 acompcor = cf.signal.compute_compcor_confounds(
     data, noise_mask=white_matter, n_components=1
 )
-signals = cf.signal.clean(signals, low_cutoff=0.01, confounds=acompcor)
+signals = cf.signal.clean(
+    signals, low_cutoff=0.01, filter_method="cosine", confounds=acompcor
+)
 
 # %% [markdown]
 # ## Compute and plot the correlation matrix

--- a/docs/examples/04_connectivity/02_atlas_seed_map.py
+++ b/docs/examples/04_connectivity/02_atlas_seed_map.py
@@ -132,7 +132,7 @@ atlas_native = atlas.resample_like(moving, subject_to_atlas)
 # `seed_masks`.
 
 # %%
-seed_masks = atlas_native.get_masks(["SSp-bfd", "RSP", "HIP", "VPM"], sides="left")
+seed_masks = atlas_native.get_masks(["SSp-bfd", "RSP", "HIP", "VPM"], sides="right")
 
 # %% [markdown]
 # ## Smooth and compute nuisance regressors
@@ -144,9 +144,10 @@ seed_masks = atlas_native.get_masks(["SSp-bfd", "RSP", "HIP", "VPM"], sides="lef
 # As in the correlation-matrix example, we regress out an
 # [aCompCor][confusius.signal.compute_compcor_confounds] component extracted from
 # white-matter voxels (the Allen ontology's `"fiber tracts"` division) together with a
-# `low_cutoff` high-pass filter for slow drift. Both are passed to `SeedBasedMaps` via
-# `clean_kwargs`, which cleans the full voxel-wise recording *before* extracting the
-# seed signals, so seeds and voxels are preprocessed consistently.
+# `low_cutoff` high-pass cosine filter for slow drift. Both are passed to
+# `SeedBasedMaps` via `clean_kwargs`, which cleans the full voxel-wise recording
+# *before* extracting the seed signals, so seeds and voxels are preprocessed
+# consistently.
 
 # %%
 data = cf.spatial.smooth_volume(data, fwhm=0.1)
@@ -165,7 +166,8 @@ acompcor = cf.signal.compute_compcor_confounds(
 
 # %%
 mapper = cf.connectivity.SeedBasedMaps(
-    seed_masks=seed_masks, clean_kwargs={"low_cutoff": 0.01, "confounds": acompcor}
+    seed_masks=seed_masks,
+    clean_kwargs={"low_cutoff": 0.01, "filter_method": "cosine", "confounds": acompcor},
 )
 mapper.fit(data)
 mapper.maps_
@@ -204,7 +206,7 @@ plotter = cf.plotting.plot_stat_map(
     slice_mode="region",
     cmap=cmap,
     vmax=0.8,
-    threshold=0.20,
+    threshold=0.2,
     cbar_label="Pearson correlation",
     show_axes=False,
     figure=fig,

--- a/src/confusius/_utils/filtering.py
+++ b/src/confusius/_utils/filtering.py
@@ -1,0 +1,64 @@
+"""Shared helpers for signal filtering."""
+
+import warnings
+
+import numpy as np
+
+from confusius._utils.stack import find_stack_level
+
+
+def make_cosine_drift_regressors(
+    n_timepoints: int,
+    low_cutoff: float,
+    sampling_interval: float,
+) -> tuple[np.ndarray, list[str]]:
+    """Create cosine drift regressors for high-pass filtering.
+
+    Parameters
+    ----------
+    n_timepoints : int
+        Number of timepoints.
+    low_cutoff : float
+        Low cutoff frequency in hertz.
+    sampling_interval : float
+        Sampling interval in seconds.
+
+    Returns
+    -------
+    regressors : (n_timepoints, n_regressors) numpy.ndarray
+        Cosine drift regressors with a constant column as the last column.
+    names : list of str
+        Names for each regressor column.
+
+    Raises
+    ------
+    ValueError
+        If `n_timepoints` is less than 1 or `low_cutoff` is not positive.
+    """
+    if n_timepoints < 1:
+        raise ValueError("n_timepoints must be at least 1.")
+    if low_cutoff <= 0:
+        raise ValueError(f"'low_cutoff' must be positive, got {low_cutoff}.")
+
+    if low_cutoff * sampling_interval >= 0.5:
+        warnings.warn(
+            "High-pass filter will span all accessible frequencies and saturate "
+            f"the design matrix. The provided value is {low_cutoff} Hz.",
+            stacklevel=find_stack_level(),
+        )
+
+    order = min(
+        n_timepoints - 1,
+        int(np.floor(2 * n_timepoints * low_cutoff * sampling_interval)),
+    )
+    regressors = np.ones((n_timepoints, order + 1), dtype=np.float64)
+    normalizer = np.sqrt(2.0 / n_timepoints)
+    n_times = np.arange(n_timepoints, dtype=np.float64)
+
+    for k in range(1, order + 1):
+        regressors[:, k - 1] = normalizer * np.cos(
+            (np.pi / n_timepoints) * (n_times + 0.5) * k
+        )
+
+    names = [f"cosine_{k}" for k in range(1, order + 1)] + ["constant"]
+    return regressors, names

--- a/src/confusius/_utils/filtering.py
+++ b/src/confusius/_utils/filtering.py
@@ -33,10 +33,8 @@ def make_cosine_drift_regressors(
     Raises
     ------
     ValueError
-        If `n_timepoints` is less than 1 or `low_cutoff` is not positive.
+        If `low_cutoff` is not positive.
     """
-    if n_timepoints < 1:
-        raise ValueError("n_timepoints must be at least 1.")
     if low_cutoff <= 0:
         raise ValueError(f"'low_cutoff' must be positive, got {low_cutoff}.")
 

--- a/src/confusius/glm/_design.py
+++ b/src/confusius/glm/_design.py
@@ -20,6 +20,7 @@ from scipy.interpolate import interp1d
 
 from confusius._utils.bids import DEFAULT_TRIAL_TYPE
 from confusius._utils.coordinates import get_representative_step
+from confusius._utils.filtering import make_cosine_drift_regressors
 from confusius._utils.stack import find_stack_level
 from confusius.glm._hrf_models import HRFModel, _hrf_kernel
 
@@ -147,26 +148,7 @@ def _make_drift_regressors(
     if drift_model is None:
         return np.ones((n_volumes, 1)), ["constant"]
     elif drift_model == "cosine":
-        if low_cutoff * dt >= 0.5:
-            warnings.warn(
-                "High-pass filter will span all accessible frequencies and saturate "
-                f"the design matrix. The provided value is {low_cutoff} Hz.",
-                stacklevel=find_stack_level(),
-            )
-
-        order = min(n_volumes - 1, int(np.floor(2 * n_volumes * low_cutoff * dt)))
-        drift_regressors = np.zeros((n_volumes, order + 1))
-        normalizer = np.sqrt(2.0 / n_volumes)
-        n_times = np.arange(n_volumes, dtype=np.float64)
-
-        for k in range(1, order + 1):
-            drift_regressors[:, k - 1] = normalizer * np.cos(
-                (np.pi / n_volumes) * (n_times + 0.5) * k
-            )
-
-        drift_regressors[:, -1] = 1.0
-        drift_names = [f"cosine_{k}" for k in range(1, order + 1)] + ["constant"]
-        return drift_regressors, drift_names
+        return make_cosine_drift_regressors(n_volumes, low_cutoff, dt)
     elif drift_model == "polynomial":
         drift_order = int(drift_order)
         if drift_order < 0:

--- a/src/confusius/signal/__init__.py
+++ b/src/confusius/signal/__init__.py
@@ -4,7 +4,7 @@ from confusius.signal.censor import censor_samples, interpolate_samples
 from confusius.signal.confounds import compute_compcor_confounds, regress_confounds
 from confusius.signal.core import clean
 from confusius.signal.detrending import detrend
-from confusius.signal.filters import filter_butterworth
+from confusius.signal.filters import filter_butterworth, filter_cosine
 from confusius.signal.standardization import standardize
 
 __all__ = [
@@ -13,6 +13,7 @@ __all__ = [
     "compute_compcor_confounds",
     "detrend",
     "filter_butterworth",
+    "filter_cosine",
     "interpolate_samples",
     "regress_confounds",
     "standardize",

--- a/src/confusius/signal/confounds.py
+++ b/src/confusius/signal/confounds.py
@@ -284,7 +284,7 @@ def regress_confounds(
     ...     imaging_data, motion_params
     ... )
     """
-    time_axis = validate_time_series(signals, "confound regression")
+    time_axis, _ = validate_time_series(signals, "confound regression")
 
     confounds_array = _validate_confounds(signals, confounds)
 

--- a/src/confusius/signal/core.py
+++ b/src/confusius/signal/core.py
@@ -122,7 +122,7 @@ def clean(
 
     1. Interpolate censored samples (pre-scrubbing).
     2. Detrend.
-    3. Optional temporal filtering (Butterworth or cosine high-pass).
+    3. Temporal filtering (Butterworth or cosine high-pass).
     4. Censor samples.
     5. Regress confounds.
     6. Standardize.

--- a/src/confusius/signal/core.py
+++ b/src/confusius/signal/core.py
@@ -1,13 +1,11 @@
 """Signal cleaning pipeline for fUSI time series."""
 
-import warnings
 from typing import Literal
 
 import numpy as np
 import xarray as xr
 from xarray.core.types import InterpOptions
 
-from confusius._utils.coordinates import get_coordinate_spacings
 from confusius._utils.filtering import make_cosine_drift_regressors
 from confusius.signal.censor import censor_samples, interpolate_samples
 from confusius.signal.confounds import regress_confounds
@@ -136,19 +134,14 @@ def _append_cosine_drift_confounds(
         If `signals` is not uniformly sampled within the specified tolerance or if
         `confounds` is not 1D or 2D.
     """
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", UserWarning)
-        spacing = get_coordinate_spacings(
-            signals, uniformity_tolerance=uniformity_tolerance
-        )
-
-    time_spacing = spacing["time"]
-    if time_spacing is None:
-        raise ValueError(
-            "Non-uniform 'time' coordinates detected. Cosine filtering requires "
-            "uniformly sampled data. Consider interpolating your data to a regular "
-            "time grid first."
-        )
+    _, time_spacing = validate_time_series(
+        signals,
+        "cosine filtering",
+        check_time_chunks=False,
+        require_uniform_time=True,
+        uniformity_tolerance=uniformity_tolerance,
+    )
+    assert time_spacing is not None
 
     regressors, names = make_cosine_drift_regressors(
         signals.sizes["time"],

--- a/src/confusius/signal/core.py
+++ b/src/confusius/signal/core.py
@@ -250,8 +250,6 @@ def clean(
                 "Cosine filtering only supports low_cutoff; pass high_cutoff only "
                 "with filter_method='butterworth'."
             )
-        if do_filter and low_cutoff is None:
-            raise ValueError("Cosine filtering requires low_cutoff to be provided.")
     else:
         filter_kwargs.update({"low_cutoff": low_cutoff, "high_cutoff": high_cutoff})
 

--- a/src/confusius/signal/core.py
+++ b/src/confusius/signal/core.py
@@ -1,15 +1,18 @@
 """Signal cleaning pipeline for fUSI time series."""
 
+import warnings
 from typing import Literal
 
 import numpy as np
 import xarray as xr
 from xarray.core.types import InterpOptions
 
+from confusius._utils.coordinates import get_coordinate_spacings
+from confusius._utils.filtering import make_cosine_drift_regressors
 from confusius.signal.censor import censor_samples, interpolate_samples
 from confusius.signal.confounds import regress_confounds
 from confusius.signal.detrending import detrend as detrend_signals
-from confusius.signal.filters import filter_butterworth, filter_cosine
+from confusius.signal.filters import filter_butterworth
 from confusius.signal.standardization import standardize
 from confusius.validation import validate_time_series
 
@@ -97,6 +100,92 @@ def _fill_interpolated_boundary_non_finite(
         result = xr.where(right_missing, right_fill, result)
 
     return result
+
+
+def _append_cosine_drift_confounds(
+    signals: xr.DataArray,
+    confounds: xr.DataArray | None,
+    *,
+    low_cutoff: float,
+    uniformity_tolerance: float = 1e-2,
+) -> xr.DataArray:
+    """Append cosine drift regressors to an existing confound matrix.
+
+    Parameters
+    ----------
+    signals : (time, ...) xarray.DataArray
+        Signals defining the time grid.
+    confounds : xarray.DataArray or None
+        Existing confounds to augment. Can have shape `(time,)` or
+        `(time, n_confounds)`. If not provided, only cosine drift regressors are
+        returned.
+    low_cutoff : float
+        High-pass cutoff frequency in hertz.
+    uniformity_tolerance : float, default: 1e-2
+        Maximum allowed relative range of consecutive time intervals, defined as
+        `(max_interval - min_interval) / median_interval`.
+
+    Returns
+    -------
+    (time, confound) xarray.DataArray
+        Confound matrix including cosine drift regressors.
+
+    Raises
+    ------
+    ValueError
+        If `signals` is not uniformly sampled within the specified tolerance or if
+        `confounds` is not 1D or 2D.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        spacing = get_coordinate_spacings(
+            signals, uniformity_tolerance=uniformity_tolerance
+        )
+
+    time_spacing = spacing["time"]
+    if time_spacing is None:
+        raise ValueError(
+            "Non-uniform 'time' coordinates detected. Cosine filtering requires "
+            "uniformly sampled data. Consider interpolating your data to a regular "
+            "time grid first."
+        )
+
+    regressors, names = make_cosine_drift_regressors(
+        signals.sizes["time"],
+        low_cutoff,
+        time_spacing,
+    )
+    cosine_confounds = xr.DataArray(
+        regressors,
+        dims=["time", "confound"],
+        coords={"time": signals.coords["time"], "confound": names},
+    )
+
+    if confounds is None:
+        return cosine_confounds
+
+    if confounds.ndim == 1:
+        existing_confounds = xr.DataArray(
+            confounds.values[:, None],
+            dims=["time", "confound"],
+            coords={
+                "time": confounds.coords["time"],
+                "confound": ["confound_0"],
+            },
+        )
+    elif confounds.ndim == 2:
+        existing_confounds = confounds.transpose("time", ...)
+        if "confound" not in existing_confounds.dims:
+            other_dim = next(dim for dim in existing_confounds.dims if dim != "time")
+            existing_confounds = existing_confounds.rename({other_dim: "confound"})
+        if "confound" not in existing_confounds.coords:
+            existing_confounds = existing_confounds.assign_coords(
+                confound=np.arange(existing_confounds.sizes["confound"])
+            )
+    else:
+        raise ValueError(f"confounds must be 1D or 2D, got {confounds.ndim}D")
+
+    return xr.concat([existing_confounds, cosine_confounds], dim="confound")
 
 
 def clean(
@@ -261,9 +350,11 @@ def clean(
     original_mean = signals.mean(dim="time") if standardize_method == "psc" else None
 
     # Pre-scrubbing interpolation is performed when scrubbing is requested and either
-    # detrending or filtering is applied. This allows detrending and filtering to be
-    # applied to the full time series without gaps.
-    if sample_mask is not None and (detrend_order is not None or do_filter):
+    # detrending or Butterworth filtering is applied. Cosine filtering is handled as
+    # a regression step, so it follows Nilearn and censors without interpolation.
+    if sample_mask is not None and (
+        detrend_order is not None or (do_filter and filter_method == "butterworth")
+    ):
         signals = interpolate_samples(
             signals,
             sample_mask=sample_mask,
@@ -292,13 +383,12 @@ def clean(
                 confounds = filter_butterworth(confounds, **filter_kwargs)
         else:
             assert low_cutoff is not None
-            signals = filter_cosine(signals, low_cutoff=low_cutoff, **filter_kwargs)
-            if confounds is not None:
-                confounds = filter_cosine(
-                    confounds,
-                    low_cutoff=low_cutoff,
-                    **filter_kwargs,
-                )
+            confounds = _append_cosine_drift_confounds(
+                signals,
+                confounds,
+                low_cutoff=low_cutoff,
+                **filter_kwargs,
+            )
 
     if sample_mask is not None:
         signals = censor_samples(signals, sample_mask=sample_mask)

--- a/src/confusius/signal/core.py
+++ b/src/confusius/signal/core.py
@@ -107,7 +107,7 @@ def clean(
     low_cutoff: float | None = None,
     high_cutoff: float | None = None,
     filter_method: Literal["butterworth", "cosine"] = "butterworth",
-    filter_butterworth_kwargs: dict | None = None,
+    filter_kwargs: dict | None = None,
     confounds: xr.DataArray | None = None,
     standardize_confounds: bool = True,
     ensure_finite: bool = False,
@@ -162,9 +162,10 @@ def clean(
         Butterworth filtering supports low-pass, high-pass, and band-pass filtering.
         Cosine filtering supports high-pass filtering only and uses the same
         discrete-cosine drift basis as the GLM module.
-    filter_butterworth_kwargs : dict, optional
-        Extra keyword arguments passed to `confusius.signal.filter_butterworth` when
-        `filter_method="butterworth"`.
+    filter_kwargs : dict, optional
+        Extra keyword arguments passed to the selected filtering function. This means
+        `confusius.signal.filter_butterworth` when `filter_method="butterworth"`
+        and `confusius.signal.filter_cosine` when `filter_method="cosine"`.
     confounds : (time, n_confounds) xarray.DataArray, optional
         Confound regressors to remove. Can have shape `(time,)` for a single
         confound. When provided, confounds are detrended and filtered along with
@@ -216,22 +217,16 @@ def clean(
     """
     validate_time_series(signals, operation_name="clean", check_time_chunks=False)
 
-    if filter_butterworth_kwargs is not None and not isinstance(
-        filter_butterworth_kwargs, dict
-    ):
-        raise TypeError("filter_butterworth_kwargs must be a dict or None")
+    if filter_kwargs is not None and not isinstance(filter_kwargs, dict):
+        raise TypeError("filter_kwargs must be a dict or None")
 
-    if filter_butterworth_kwargs:
-        if (
-            "low_cutoff" in filter_butterworth_kwargs
-            or "high_cutoff" in filter_butterworth_kwargs
-        ):
+    if filter_kwargs:
+        if "low_cutoff" in filter_kwargs or "high_cutoff" in filter_kwargs:
             raise ValueError(
-                "Pass low_pass/high_pass directly to clean, not in "
-                "filter_butterworth_kwargs."
+                "Pass low_pass/high_pass directly to clean, not in filter_kwargs."
             )
     else:
-        filter_butterworth_kwargs = {}
+        filter_kwargs = {}
 
     if interpolate_kwargs is not None and not isinstance(interpolate_kwargs, dict):
         raise TypeError("interpolate_kwargs must be a dict or None")
@@ -257,15 +252,8 @@ def clean(
             )
         if do_filter and low_cutoff is None:
             raise ValueError("Cosine filtering requires low_cutoff to be provided.")
-        if filter_butterworth_kwargs:
-            raise ValueError(
-                "filter_butterworth_kwargs is only supported when "
-                "filter_method='butterworth'."
-            )
     else:
-        filter_butterworth_kwargs.update(
-            {"low_cutoff": low_cutoff, "high_cutoff": high_cutoff}
-        )
+        filter_kwargs.update({"low_cutoff": low_cutoff, "high_cutoff": high_cutoff})
 
     if ensure_finite:
         signals = _interpolate_non_finite(signals, name="signals")
@@ -301,14 +289,18 @@ def clean(
 
     if do_filter:
         if filter_method == "butterworth":
-            signals = filter_butterworth(signals, **filter_butterworth_kwargs)
+            signals = filter_butterworth(signals, **filter_kwargs)
             if confounds is not None:
-                confounds = filter_butterworth(confounds, **filter_butterworth_kwargs)
+                confounds = filter_butterworth(confounds, **filter_kwargs)
         else:
             assert low_cutoff is not None
-            signals = filter_cosine(signals, low_cutoff=low_cutoff)
+            signals = filter_cosine(signals, low_cutoff=low_cutoff, **filter_kwargs)
             if confounds is not None:
-                confounds = filter_cosine(confounds, low_cutoff=low_cutoff)
+                confounds = filter_cosine(
+                    confounds,
+                    low_cutoff=low_cutoff,
+                    **filter_kwargs,
+                )
 
     if sample_mask is not None:
         signals = censor_samples(signals, sample_mask=sample_mask)

--- a/src/confusius/signal/core.py
+++ b/src/confusius/signal/core.py
@@ -151,7 +151,7 @@ def _append_cosine_drift_confounds(
         regressors,
         dims=["time", "confound"],
         coords={"time": signals.coords["time"], "confound": names},
-    )
+    ).reset_coords(drop=True)
 
     if confounds is None:
         return cosine_confounds
@@ -164,7 +164,7 @@ def _append_cosine_drift_confounds(
                 "time": confounds.coords["time"],
                 "confound": ["confound_0"],
             },
-        )
+        ).reset_coords(drop=True)
     elif confounds.ndim == 2:
         existing_confounds = confounds.transpose("time", ...)
         if "confound" not in existing_confounds.dims:
@@ -174,6 +174,7 @@ def _append_cosine_drift_confounds(
             existing_confounds = existing_confounds.assign_coords(
                 confound=np.arange(existing_confounds.sizes["confound"])
             )
+        existing_confounds = existing_confounds.reset_coords(drop=True)
     else:
         raise ValueError(f"confounds must be 1D or 2D, got {confounds.ndim}D")
 
@@ -241,12 +242,12 @@ def clean(
     filter_method : {"butterworth", "cosine"}, default: "butterworth"
         Filtering method used when `low_cutoff` or `high_cutoff` is provided.
         Butterworth filtering supports low-pass, high-pass, and band-pass filtering.
-        Cosine filtering supports high-pass filtering only and uses the same
-        discrete-cosine drift basis as the GLM module.
+        Cosine filtering supports high-pass filtering only.
     filter_kwargs : dict, optional
         Extra keyword arguments passed to the selected filtering function. This means
-        `confusius.signal.filter_butterworth` when `filter_method="butterworth"`
-        and `confusius.signal.filter_cosine` when `filter_method="cosine"`.
+        [`filter_butterworth`][confusius.signal.filter_butterworth] when
+        `filter_method="butterworth"` and
+        [`filter_cosine`][confusius.signal.filter_cosine] when `filter_method="cosine"`.
     confounds : (time, n_confounds) xarray.DataArray, optional
         Confound regressors to remove. Can have shape `(time,)` for a single
         confound. When provided, confounds are detrended and filtered along with

--- a/src/confusius/signal/core.py
+++ b/src/confusius/signal/core.py
@@ -312,7 +312,7 @@ def clean(
     if filter_kwargs:
         if "low_cutoff" in filter_kwargs or "high_cutoff" in filter_kwargs:
             raise ValueError(
-                "Pass low_pass/high_pass directly to clean, not in filter_kwargs."
+                "Pass low_cutoff/high_cutoff directly to clean, not in filter_kwargs."
             )
     else:
         filter_kwargs = {}

--- a/src/confusius/signal/core.py
+++ b/src/confusius/signal/core.py
@@ -141,7 +141,6 @@ def _append_cosine_drift_confounds(
         require_uniform_time=True,
         uniformity_tolerance=uniformity_tolerance,
     )
-    assert time_spacing is not None
 
     regressors, names = make_cosine_drift_regressors(
         signals.sizes["time"],

--- a/src/confusius/signal/core.py
+++ b/src/confusius/signal/core.py
@@ -9,7 +9,7 @@ from xarray.core.types import InterpOptions
 from confusius.signal.censor import censor_samples, interpolate_samples
 from confusius.signal.confounds import regress_confounds
 from confusius.signal.detrending import detrend as detrend_signals
-from confusius.signal.filters import filter_butterworth
+from confusius.signal.filters import filter_butterworth, filter_cosine
 from confusius.signal.standardization import standardize
 from confusius.validation import validate_time_series
 
@@ -106,6 +106,7 @@ def clean(
     standardize_method: Literal["zscore", "psc"] | None = None,
     low_cutoff: float | None = None,
     high_cutoff: float | None = None,
+    filter_method: Literal["butterworth", "cosine"] = "butterworth",
     filter_butterworth_kwargs: dict | None = None,
     confounds: xr.DataArray | None = None,
     standardize_confounds: bool = True,
@@ -121,7 +122,7 @@ def clean(
 
     1. Interpolate censored samples (pre-scrubbing).
     2. Detrend.
-    3. Butterworth filter.
+    3. Optional temporal filtering (Butterworth or cosine high-pass).
     4. Censor samples.
     5. Regress confounds.
     6. Standardize.
@@ -156,8 +157,14 @@ def clean(
     high_cutoff : float, optional
         High cutoff frequency in Hz. Frequencies above this are attenuated (acts as
         low-pass filter). If not provided, no low-pass filtering is applied.
+    filter_method : {"butterworth", "cosine"}, default: "butterworth"
+        Filtering method used when `low_cutoff` or `high_cutoff` is provided.
+        Butterworth filtering supports low-pass, high-pass, and band-pass filtering.
+        Cosine filtering supports high-pass filtering only and uses the same
+        discrete-cosine drift basis as the GLM module.
     filter_butterworth_kwargs : dict, optional
-        Extra keyword arguments passed to `confusius.signal.filter_butterworth`.
+        Extra keyword arguments passed to `confusius.signal.filter_butterworth` when
+        `filter_method="butterworth"`.
     confounds : (time, n_confounds) xarray.DataArray, optional
         Confound regressors to remove. Can have shape `(time,)` for a single
         confound. When provided, confounds are detrended and filtered along with
@@ -236,11 +243,29 @@ def clean(
 
     interpolate_kwargs = {} if interpolate_kwargs is None else interpolate_kwargs.copy()
 
-    filter_butterworth_kwargs.update(
-        {"low_cutoff": low_cutoff, "high_cutoff": high_cutoff}
-    )
-
     do_filter = low_cutoff is not None or high_cutoff is not None
+    if filter_method not in {"butterworth", "cosine"}:
+        raise ValueError(
+            f"filter_method must be 'butterworth' or 'cosine', got {filter_method}."
+        )
+
+    if filter_method == "cosine":
+        if high_cutoff is not None:
+            raise ValueError(
+                "Cosine filtering only supports low_cutoff; pass high_cutoff only "
+                "with filter_method='butterworth'."
+            )
+        if do_filter and low_cutoff is None:
+            raise ValueError("Cosine filtering requires low_cutoff to be provided.")
+        if filter_butterworth_kwargs:
+            raise ValueError(
+                "filter_butterworth_kwargs is only supported when "
+                "filter_method='butterworth'."
+            )
+    else:
+        filter_butterworth_kwargs.update(
+            {"low_cutoff": low_cutoff, "high_cutoff": high_cutoff}
+        )
 
     if ensure_finite:
         signals = _interpolate_non_finite(signals, name="signals")
@@ -275,9 +300,15 @@ def clean(
             confounds = detrend_signals(confounds, order=detrend_order)
 
     if do_filter:
-        signals = filter_butterworth(signals, **filter_butterworth_kwargs)
-        if confounds is not None:
-            confounds = filter_butterworth(confounds, **filter_butterworth_kwargs)
+        if filter_method == "butterworth":
+            signals = filter_butterworth(signals, **filter_butterworth_kwargs)
+            if confounds is not None:
+                confounds = filter_butterworth(confounds, **filter_butterworth_kwargs)
+        else:
+            assert low_cutoff is not None
+            signals = filter_cosine(signals, low_cutoff=low_cutoff)
+            if confounds is not None:
+                confounds = filter_cosine(confounds, low_cutoff=low_cutoff)
 
     if sample_mask is not None:
         signals = censor_samples(signals, sample_mask=sample_mask)

--- a/src/confusius/signal/detrending.py
+++ b/src/confusius/signal/detrending.py
@@ -117,7 +117,7 @@ def detrend(signals: xr.DataArray, order: int = 1) -> xr.DataArray:
     if order < 0:
         raise ValueError(f"order must be non-negative, got {order}")
 
-    time_axis = validate_time_series(signals, "detrending")
+    time_axis, _ = validate_time_series(signals, "detrending")
 
     if order == 0:
         result = xr.apply_ufunc(

--- a/src/confusius/signal/filters.py
+++ b/src/confusius/signal/filters.py
@@ -240,7 +240,6 @@ def filter_butterworth(
         require_uniform_time=True,
         uniformity_tolerance=uniformity_tolerance,
     )
-    assert time_spacing is not None
 
     sampling_rate = 1.0 / time_spacing
     _validate_cutoff_frequencies(
@@ -315,7 +314,6 @@ def filter_cosine(
         require_uniform_time=True,
         uniformity_tolerance=uniformity_tolerance,
     )
-    assert time_spacing is not None
 
     regressors, names = make_cosine_drift_regressors(
         signals.sizes["time"],

--- a/src/confusius/signal/filters.py
+++ b/src/confusius/signal/filters.py
@@ -134,11 +134,13 @@ def _butterworth_filter_wrapper(
     return result
 
 
-def _cosine_filter_wrapper(
-    data: np.ndarray, projection_matrix: np.ndarray
+def _residualize_cosine_drift(
+    data: np.ndarray,
+    regressors: np.ndarray,
+    pinv_regressors: np.ndarray,
 ) -> np.ndarray:
-    """Project one time series out of the cosine drift subspace."""
-    return data - projection_matrix @ data
+    """Remove the cosine drift subspace from one time series."""
+    return data - regressors @ (pinv_regressors @ data)
 
 
 def filter_butterworth(
@@ -346,15 +348,18 @@ def filter_cosine(
         low_cutoff,
         time_spacing,
     )
-    projection_matrix = regressors @ np.linalg.pinv(regressors)
+    pinv_regressors = np.linalg.pinv(regressors)
     output_dtype = np.result_type(signals.dtype, np.float64)
 
     result = xr.apply_ufunc(
-        _cosine_filter_wrapper,
+        _residualize_cosine_drift,
         signals,
         input_core_dims=[["time"]],
         output_core_dims=[["time"]],
-        kwargs={"projection_matrix": projection_matrix},
+        kwargs={
+            "regressors": regressors,
+            "pinv_regressors": pinv_regressors,
+        },
         vectorize=True,
         dask="parallelized",
         output_dtypes=[output_dtype],

--- a/src/confusius/signal/filters.py
+++ b/src/confusius/signal/filters.py
@@ -9,6 +9,7 @@ import xarray as xr
 
 from confusius._utils.coordinates import get_coordinate_spacings
 from confusius._utils.filtering import make_cosine_drift_regressors
+from confusius.signal.confounds import regress_confounds
 from confusius.validation import validate_time_series
 
 
@@ -132,15 +133,6 @@ def _butterworth_filter_wrapper(
         result = np.moveaxis(result, 0, axis)
 
     return result
-
-
-def _residualize_cosine_drift(
-    data: np.ndarray,
-    regressors: np.ndarray,
-    pinv_regressors: np.ndarray,
-) -> np.ndarray:
-    """Remove the cosine drift subspace from one time series."""
-    return data - regressors @ (pinv_regressors @ data)
 
 
 def filter_butterworth(
@@ -343,26 +335,19 @@ def filter_cosine(
             "time grid first."
         )
 
-    regressors, _ = make_cosine_drift_regressors(
+    regressors, names = make_cosine_drift_regressors(
         signals.sizes["time"],
         low_cutoff,
         time_spacing,
     )
-    pinv_regressors = np.linalg.pinv(regressors)
-    output_dtype = np.result_type(signals.dtype, np.float64)
-
-    result = xr.apply_ufunc(
-        _residualize_cosine_drift,
-        signals,
-        input_core_dims=[["time"]],
-        output_core_dims=[["time"]],
-        kwargs={
-            "regressors": regressors,
-            "pinv_regressors": pinv_regressors,
-        },
-        vectorize=True,
-        dask="parallelized",
-        output_dtypes=[output_dtype],
+    cosine_confounds = xr.DataArray(
+        regressors,
+        dims=["time", "confound"],
+        coords={"time": signals.coords["time"], "confound": names},
     )
 
-    return result.transpose(*signals.dims)
+    return regress_confounds(
+        signals,
+        cosine_confounds,
+        standardize_confounds=False,
+    )

--- a/src/confusius/signal/filters.py
+++ b/src/confusius/signal/filters.py
@@ -1,13 +1,11 @@
 """Filtering functions for signal preprocessing."""
 
 import math
-import warnings
 
 import numpy as np
 import scipy.signal
 import xarray as xr
 
-from confusius._utils.coordinates import get_coordinate_spacings
 from confusius._utils.filtering import make_cosine_drift_regressors
 from confusius.signal.confounds import regress_confounds
 from confusius.validation import validate_time_series
@@ -236,21 +234,13 @@ def filter_butterworth(
     ...     signals, low_cutoff=0.01, high_cutoff=0.1, order=5
     ... )
     """
-    time_axis = validate_time_series(signals, "filtering")
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", UserWarning)
-        spacing = get_coordinate_spacings(
-            signals, uniformity_tolerance=uniformity_tolerance
-        )
-
-    time_spacing = spacing["time"]
-    if time_spacing is None:
-        raise ValueError(
-            "Non-uniform 'time' coordinates detected. Butterworth filtering requires "
-            "uniformly sampled data. Consider interpolating your data to a regular "
-            "time grid first."
-        )
+    time_axis, time_spacing = validate_time_series(
+        signals,
+        "filtering",
+        require_uniform_time=True,
+        uniformity_tolerance=uniformity_tolerance,
+    )
+    assert time_spacing is not None
 
     sampling_rate = 1.0 / time_spacing
     _validate_cutoff_frequencies(
@@ -319,21 +309,13 @@ def filter_cosine(
         time coordinates are not uniformly sampled within the specified tolerance, or if
         `low_cutoff` is not positive.
     """
-    validate_time_series(signals, "filtering")
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", UserWarning)
-        spacing = get_coordinate_spacings(
-            signals, uniformity_tolerance=uniformity_tolerance
-        )
-
-    time_spacing = spacing["time"]
-    if time_spacing is None:
-        raise ValueError(
-            "Non-uniform 'time' coordinates detected. Cosine filtering requires "
-            "uniformly sampled data. Consider interpolating your data to a regular "
-            "time grid first."
-        )
+    _, time_spacing = validate_time_series(
+        signals,
+        "filtering",
+        require_uniform_time=True,
+        uniformity_tolerance=uniformity_tolerance,
+    )
+    assert time_spacing is not None
 
     regressors, names = make_cosine_drift_regressors(
         signals.sizes["time"],

--- a/src/confusius/signal/filters.py
+++ b/src/confusius/signal/filters.py
@@ -8,6 +8,7 @@ import scipy.signal
 import xarray as xr
 
 from confusius._utils.coordinates import get_coordinate_spacings
+from confusius._utils.filtering import make_cosine_drift_regressors
 from confusius.validation import validate_time_series
 
 
@@ -131,6 +132,13 @@ def _butterworth_filter_wrapper(
         result = np.moveaxis(result, 0, axis)
 
     return result
+
+
+def _cosine_filter_wrapper(
+    data: np.ndarray, projection_matrix: np.ndarray
+) -> np.ndarray:
+    """Project one time series out of the cosine drift subspace."""
+    return data - projection_matrix @ data
 
 
 def filter_butterworth(
@@ -273,3 +281,83 @@ def filter_butterworth(
     )
 
     return result
+
+
+def filter_cosine(
+    signals: xr.DataArray,
+    low_cutoff: float,
+    uniformity_tolerance: float = 1e-2,
+) -> xr.DataArray:
+    """Apply cosine high-pass filtering along `time`.
+
+    This removes low-frequency drift by regressing each time series onto the same
+    discrete-cosine basis used by the GLM `drift_model="cosine"` design matrix.
+
+    Parameters
+    ----------
+    signals : (time, ...) xarray.DataArray
+        Array to filter. Must have a `time` dimension. Can be any shape, e.g.,
+        extracted signals `(time, space)`, full 3D+t imaging data `(time, z, y,
+        x)`, or regional signals `(time, region)`.
+
+        !!! warning "Chunking along time is not supported"
+            The `time` dimension must NOT be chunked. Chunk only spatial dimensions:
+            `data.chunk({'time': -1})`.
+
+    low_cutoff : float
+        High-pass cutoff frequency in hertz. Frequencies below this are removed by
+        projection onto the cosine drift basis.
+    uniformity_tolerance : float, default: 1e-2
+        Maximum allowed relative range of consecutive time intervals, defined as
+        `(max_interval - min_interval) / median_interval`. Raise a `ValueError` if
+        the time coordinate exceeds this threshold. Increase this value to tolerate
+        slight timestamp jitter (e.g. from acquisition clocks or dropped volumes).
+
+    Returns
+    -------
+    xarray.DataArray
+        Filtered signals with same shape and coordinates as input.
+
+    Raises
+    ------
+    ValueError
+        If `signals` does not have a `time` dimension or `time` coordinates, if
+        time coordinates are not uniformly sampled within the specified tolerance, or if
+        `low_cutoff` is not positive.
+    """
+    validate_time_series(signals, "filtering")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        spacing = get_coordinate_spacings(
+            signals, uniformity_tolerance=uniformity_tolerance
+        )
+
+    time_spacing = spacing["time"]
+    if time_spacing is None:
+        raise ValueError(
+            "Non-uniform 'time' coordinates detected. Cosine filtering requires "
+            "uniformly sampled data. Consider interpolating your data to a regular "
+            "time grid first."
+        )
+
+    regressors, _ = make_cosine_drift_regressors(
+        signals.sizes["time"],
+        low_cutoff,
+        time_spacing,
+    )
+    projection_matrix = regressors @ np.linalg.pinv(regressors)
+    output_dtype = np.result_type(signals.dtype, np.float64)
+
+    result = xr.apply_ufunc(
+        _cosine_filter_wrapper,
+        signals,
+        input_core_dims=[["time"]],
+        output_core_dims=[["time"]],
+        kwargs={"projection_matrix": projection_matrix},
+        vectorize=True,
+        dask="parallelized",
+        output_dtypes=[output_dtype],
+    )
+
+    return result.transpose(*signals.dims)

--- a/src/confusius/validation/time_series.py
+++ b/src/confusius/validation/time_series.py
@@ -1,31 +1,31 @@
 """Time series validation utilities."""
 
 import warnings
-from typing import TYPE_CHECKING, Literal, overload
+from typing import Literal, overload
 
 import xarray as xr
 
 from confusius._utils.coordinates import get_coordinate_spacings
 
-if TYPE_CHECKING:
 
-    @overload
-    def validate_time_series(
-        time_series: xr.DataArray,
-        operation_name: str,
-        check_time_chunks: bool = True,
-        require_uniform_time: Literal[False] = False,
-        uniformity_tolerance: float = 1e-2,
-    ) -> tuple[int, None]: ...
+@overload
+def validate_time_series(  # numpydoc ignore=GL08,PR01,RT01
+    time_series: xr.DataArray,
+    operation_name: str,
+    check_time_chunks: bool = True,
+    require_uniform_time: Literal[False] = False,
+    uniformity_tolerance: float = 1e-2,
+) -> tuple[int, None]: ...
 
-    @overload
-    def validate_time_series(
-        time_series: xr.DataArray,
-        operation_name: str,
-        check_time_chunks: bool = True,
-        require_uniform_time: Literal[True] = True,
-        uniformity_tolerance: float = 1e-2,
-    ) -> tuple[int, float]: ...
+
+@overload
+def validate_time_series(  # numpydoc ignore=GL08,PR01,RT01
+    time_series: xr.DataArray,
+    operation_name: str,
+    check_time_chunks: bool = True,
+    require_uniform_time: Literal[True] = True,
+    uniformity_tolerance: float = 1e-2,
+) -> tuple[int, float]: ...
 
 
 def validate_time_series(

--- a/src/confusius/validation/time_series.py
+++ b/src/confusius/validation/time_series.py
@@ -1,13 +1,19 @@
 """Time series validation utilities."""
 
+import warnings
+
 import xarray as xr
+
+from confusius._utils.coordinates import get_coordinate_spacings
 
 
 def validate_time_series(
     time_series: xr.DataArray,
     operation_name: str,
     check_time_chunks: bool = True,
-) -> int:
+    require_uniform_time: bool = False,
+    uniformity_tolerance: float = 1e-2,
+) -> tuple[int, float | None]:
     """Validate time series for time series processing operations.
 
     Performs common validation checks:
@@ -15,6 +21,7 @@ def validate_time_series(
     1. Time series have a `time` dimension.
     2. Time dimension has more than 1 timepoint.
     3. Time dimension is not chunked for Dask arrays (optional).
+    4. Time coordinate is uniformly sampled (optional).
 
     Parameters
     ----------
@@ -26,18 +33,27 @@ def validate_time_series(
         Whether to raise an error when time dimension is chunked in a Dask array. Set to
         `False` for operations that can handle chunked time (e.g.,
         `confusius.signal.standardize`).
+    require_uniform_time : bool, default: False
+        Whether to require uniformly sampled `time` coordinates and return their spacing.
+    uniformity_tolerance : float, default: 1e-2
+        Maximum allowed relative range of consecutive time intervals, defined as
+        `(max_interval - min_interval) / median_interval`. Raise a `ValueError` if the
+        time coordinate exceeds this threshold.
 
     Returns
     -------
-    int
+    time_axis : int
         Axis number for the `time` dimension.
+    time_spacing : float or None
+        Time spacing when `require_uniform_time=True`, otherwise `None`.
 
     Raises
     ------
     ValueError
         If `time_series` has no `time` dimension, if the `time` dimension has only 1
-        timepoint, or if the `time` dimension is chunked in a Dask array (when
-        `check_time_chunks=True`).
+        timepoint, if the `time` dimension is chunked in a Dask array (when
+        `check_time_chunks=True`), or if `require_uniform_time=True` and the `time`
+        coordinate is not uniformly sampled.
     """
     if "time" not in time_series.dims:
         raise ValueError("time_series must have a 'time' dimension")
@@ -60,4 +76,21 @@ def validate_time_series(
                 f"data.chunk({{'time': -1}})"
             )
 
-    return time_axis
+    if not require_uniform_time:
+        return time_axis, None
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        spacing = get_coordinate_spacings(
+            time_series, uniformity_tolerance=uniformity_tolerance
+        )
+
+    time_spacing = spacing["time"]
+    if time_spacing is None:
+        raise ValueError(
+            "Non-uniform 'time' coordinates detected. "
+            f"{operation_name.capitalize()} requires uniformly sampled data. "
+            "Consider interpolating your data to a regular time grid first."
+        )
+
+    return time_axis, time_spacing

--- a/src/confusius/validation/time_series.py
+++ b/src/confusius/validation/time_series.py
@@ -1,10 +1,31 @@
 """Time series validation utilities."""
 
 import warnings
+from typing import TYPE_CHECKING, Literal, overload
 
 import xarray as xr
 
 from confusius._utils.coordinates import get_coordinate_spacings
+
+if TYPE_CHECKING:
+
+    @overload
+    def validate_time_series(
+        time_series: xr.DataArray,
+        operation_name: str,
+        check_time_chunks: bool = True,
+        require_uniform_time: Literal[False] = False,
+        uniformity_tolerance: float = 1e-2,
+    ) -> tuple[int, None]: ...
+
+    @overload
+    def validate_time_series(
+        time_series: xr.DataArray,
+        operation_name: str,
+        check_time_chunks: bool = True,
+        require_uniform_time: Literal[True] = True,
+        uniformity_tolerance: float = 1e-2,
+    ) -> tuple[int, float]: ...
 
 
 def validate_time_series(

--- a/tests/unit/test_signal/test_clean.py
+++ b/tests/unit/test_signal/test_clean.py
@@ -5,6 +5,7 @@ import pytest
 import xarray as xr
 from numpy.testing import assert_allclose
 
+from confusius.glm import make_first_level_design_matrix
 from confusius.signal import (
     censor_samples,
     clean,
@@ -419,8 +420,8 @@ def test_clean_cosine_filter_kwargs_are_forwarded():
     assert_allclose(result.values, expected.values)
 
 
-def test_clean_cosine_filter_confounds_are_filtered(sample_timeseries):
-    """Test cosine filtering is applied to confounds before regression."""
+def test_clean_cosine_filter_is_jointly_regressed_with_confounds(sample_timeseries):
+    """Test cosine drift terms are regressed jointly with user confounds."""
     signals = sample_timeseries(n_time=200, n_voxels=3, sampling_rate=10.0)
     time = signals.coords["time"].values
     confounds = xr.DataArray(
@@ -430,11 +431,21 @@ def test_clean_cosine_filter_confounds_are_filtered(sample_timeseries):
         dims=["time", "confound"],
         coords={"time": signals.coords["time"], "confound": [0, 1]},
     )
-
-    expected = regress_confounds(
-        filter_cosine(signals, low_cutoff=0.1),
-        filter_cosine(confounds, low_cutoff=0.1),
+    design = make_first_level_design_matrix(
+        time,
+        events=None,
+        drift_model="cosine",
+        low_cutoff=0.1,
     )
+    cosine_names = [c for c in design.columns if c.startswith("cosine")] + ["constant"]
+    cosine_confounds = xr.DataArray(
+        design[cosine_names].to_numpy(),
+        dims=["time", "confound"],
+        coords={"time": signals.coords["time"], "confound": cosine_names},
+    )
+    combined_confounds = xr.concat([confounds, cosine_confounds], dim="confound")
+
+    expected = regress_confounds(signals, combined_confounds)
     result = clean(
         signals,
         detrend_order=None,
@@ -445,6 +456,83 @@ def test_clean_cosine_filter_confounds_are_filtered(sample_timeseries):
     )
 
     assert_allclose(result.values, expected.values)
+
+
+def test_clean_cosine_filter_joint_regression_with_1d_confounds(sample_timeseries):
+    """Test cosine drift terms are appended to 1D confounds."""
+    signals = sample_timeseries(n_time=200, n_voxels=3, sampling_rate=10.0)
+    time = signals.coords["time"].values
+    confounds = xr.DataArray(
+        np.sin(2 * np.pi * 0.02 * time),
+        dims=["time"],
+        coords={"time": signals.coords["time"]},
+    )
+    design = make_first_level_design_matrix(
+        time,
+        events=None,
+        drift_model="cosine",
+        low_cutoff=0.1,
+    )
+    cosine_names = [c for c in design.columns if c.startswith("cosine")] + ["constant"]
+    combined_confounds = xr.DataArray(
+        np.column_stack([confounds.values, design[cosine_names].to_numpy()]),
+        dims=["time", "confound"],
+        coords={
+            "time": signals.coords["time"],
+            "confound": ["confound_0", *cosine_names],
+        },
+    )
+
+    expected = regress_confounds(signals, combined_confounds)
+    result = clean(
+        signals,
+        detrend_order=None,
+        standardize_method=None,
+        low_cutoff=0.1,
+        filter_method="cosine",
+        confounds=confounds,
+    )
+
+    assert_allclose(result.values, expected.values)
+
+
+def test_clean_cosine_filter_joint_regression_renames_2d_confound_dim(
+    sample_timeseries,
+):
+    """Test cosine joint regression handles 2D confounds without `confound` dim."""
+    signals = sample_timeseries(n_time=200, n_voxels=3, sampling_rate=10.0)
+    time = signals.coords["time"].values
+    confounds = xr.DataArray(
+        np.column_stack(
+            [np.sin(2 * np.pi * 0.02 * time), np.cos(2 * np.pi * 0.03 * time)]
+        ),
+        dims=["time", "component"],
+        coords={"time": signals.coords["time"]},
+    )
+
+    result = clean(
+        signals,
+        detrend_order=None,
+        standardize_method=None,
+        low_cutoff=0.1,
+        filter_method="cosine",
+        confounds=confounds,
+    )
+
+    assert result.shape == signals.shape
+
+
+def test_clean_cosine_filter_rejects_nonuniform_time():
+    """Test cosine filtering requires uniformly sampled time coordinates."""
+    time = np.array([0.0, 0.1, 0.2, 0.35, 0.4, 0.5])
+    signals = xr.DataArray(
+        np.random.randn(6, 2),
+        dims=["time", "space"],
+        coords={"time": time},
+    )
+
+    with pytest.raises(ValueError, match="Non-uniform 'time' coordinates"):
+        clean(signals, low_cutoff=0.1, filter_method="cosine")
 
 
 def test_clean_cosine_filter_rejects_high_cutoff(sample_timeseries):
@@ -461,6 +549,24 @@ def test_clean_cosine_filter_rejects_butterworth_kwargs(sample_timeseries):
             low_cutoff=0.1,
             filter_method="cosine",
             filter_kwargs={"order": 3},
+        )
+
+
+def test_clean_cosine_filter_rejects_3d_confounds(sample_timeseries):
+    """Test cosine joint regression rejects confounds above 2D."""
+    signals = sample_timeseries(n_time=100, n_voxels=3, sampling_rate=10.0)
+    confounds = xr.DataArray(
+        np.zeros((100, 2, 2)),
+        dims=["time", "a", "b"],
+        coords={"time": signals.coords["time"]},
+    )
+
+    with pytest.raises(ValueError, match="confounds must be 1D or 2D"):
+        clean(
+            signals,
+            low_cutoff=0.1,
+            filter_method="cosine",
+            confounds=confounds,
         )
 
 

--- a/tests/unit/test_signal/test_clean.py
+++ b/tests/unit/test_signal/test_clean.py
@@ -9,6 +9,7 @@ from confusius.signal import (
     censor_samples,
     clean,
     filter_butterworth,
+    filter_cosine,
     interpolate_samples,
     standardize,
 )
@@ -375,3 +376,36 @@ def test_clean_psc_restores_original_mean_after_highpass(sample_timeseries):
     )
 
     assert_allclose(result.values, expected.values)
+
+
+def test_clean_cosine_filter_matches_filter_cosine(sample_timeseries):
+    """Test clean can use cosine high-pass filtering."""
+    signals = sample_timeseries(n_time=200, n_voxels=3, sampling_rate=10.0)
+
+    expected = filter_cosine(signals, low_cutoff=0.1)
+    result = clean(
+        signals,
+        detrend_order=None,
+        standardize_method=None,
+        low_cutoff=0.1,
+        filter_method="cosine",
+    )
+
+    assert_allclose(result.values, expected.values)
+
+
+def test_clean_cosine_filter_rejects_high_cutoff(sample_timeseries):
+    """Test cosine filtering cannot be used as a low-pass filter."""
+    with pytest.raises(ValueError, match="Cosine filtering only supports low_cutoff"):
+        clean(sample_timeseries(), high_cutoff=1.0, filter_method="cosine")
+
+
+def test_clean_cosine_filter_rejects_butterworth_kwargs(sample_timeseries):
+    """Test cosine filtering rejects Butterworth-only kwargs."""
+    with pytest.raises(ValueError, match="filter_butterworth_kwargs is only supported"):
+        clean(
+            sample_timeseries(),
+            low_cutoff=0.1,
+            filter_method="cosine",
+            filter_butterworth_kwargs={"order": 3},
+        )

--- a/tests/unit/test_signal/test_clean.py
+++ b/tests/unit/test_signal/test_clean.py
@@ -144,7 +144,7 @@ def test_clean_rejects_non_dict_filter_kwargs(sample_timeseries):
 
 def test_clean_rejects_cutoffs_inside_filter_kwargs(sample_timeseries):
     """Test cutoffs must be passed directly to clean."""
-    with pytest.raises(ValueError, match="Pass low_pass/high_pass directly to clean"):
+    with pytest.raises(ValueError, match="Pass low_cutoff/high_cutoff directly to clean"):
         clean(sample_timeseries(), filter_kwargs={"high_cutoff": 1.0})
 
 

--- a/tests/unit/test_signal/test_clean.py
+++ b/tests/unit/test_signal/test_clean.py
@@ -144,7 +144,9 @@ def test_clean_rejects_non_dict_filter_kwargs(sample_timeseries):
 
 def test_clean_rejects_cutoffs_inside_filter_kwargs(sample_timeseries):
     """Test cutoffs must be passed directly to clean."""
-    with pytest.raises(ValueError, match="Pass low_cutoff/high_cutoff directly to clean"):
+    with pytest.raises(
+        ValueError, match="Pass low_cutoff/high_cutoff directly to clean"
+    ):
         clean(sample_timeseries(), filter_kwargs={"high_cutoff": 1.0})
 
 
@@ -508,6 +510,36 @@ def test_clean_cosine_filter_joint_regression_renames_2d_confound_dim(
         ),
         dims=["time", "component"],
         coords={"time": signals.coords["time"]},
+    )
+
+    result = clean(
+        signals,
+        detrend_order=None,
+        standardize_method=None,
+        low_cutoff=0.1,
+        filter_method="cosine",
+        confounds=confounds,
+    )
+
+    assert result.shape == signals.shape
+
+
+def test_clean_cosine_filter_joint_regression_drops_extra_confound_coords(
+    sample_timeseries,
+):
+    """Test cosine joint regression ignores auxiliary confound coordinates."""
+    signals = sample_timeseries(n_time=200, n_voxels=3, sampling_rate=10.0)
+    time = signals.coords["time"].values
+    confounds = xr.DataArray(
+        np.column_stack(
+            [np.sin(2 * np.pi * 0.02 * time), np.cos(2 * np.pi * 0.03 * time)]
+        ),
+        dims=["time", "component"],
+        coords={
+            "time": signals.coords["time"],
+            "component": [0, 1],
+            "explained_variance_ratio": ("component", [0.7, 0.3]),
+        },
     )
 
     result = clean(

--- a/tests/unit/test_signal/test_clean.py
+++ b/tests/unit/test_signal/test_clean.py
@@ -11,6 +11,7 @@ from confusius.signal import (
     filter_butterworth,
     filter_cosine,
     interpolate_samples,
+    regress_confounds,
     standardize,
 )
 
@@ -418,6 +419,34 @@ def test_clean_cosine_filter_kwargs_are_forwarded():
     assert_allclose(result.values, expected.values)
 
 
+def test_clean_cosine_filter_confounds_are_filtered(sample_timeseries):
+    """Test cosine filtering is applied to confounds before regression."""
+    signals = sample_timeseries(n_time=200, n_voxels=3, sampling_rate=10.0)
+    time = signals.coords["time"].values
+    confounds = xr.DataArray(
+        np.column_stack(
+            [np.sin(2 * np.pi * 0.02 * time), np.cos(2 * np.pi * 0.03 * time)]
+        ),
+        dims=["time", "confound"],
+        coords={"time": signals.coords["time"], "confound": [0, 1]},
+    )
+
+    expected = regress_confounds(
+        filter_cosine(signals, low_cutoff=0.1),
+        filter_cosine(confounds, low_cutoff=0.1),
+    )
+    result = clean(
+        signals,
+        detrend_order=None,
+        standardize_method=None,
+        low_cutoff=0.1,
+        filter_method="cosine",
+        confounds=confounds,
+    )
+
+    assert_allclose(result.values, expected.values)
+
+
 def test_clean_cosine_filter_rejects_high_cutoff(sample_timeseries):
     """Test cosine filtering cannot be used as a low-pass filter."""
     with pytest.raises(ValueError, match="Cosine filtering only supports low_cutoff"):
@@ -432,4 +461,16 @@ def test_clean_cosine_filter_rejects_butterworth_kwargs(sample_timeseries):
             low_cutoff=0.1,
             filter_method="cosine",
             filter_kwargs={"order": 3},
+        )
+
+
+def test_clean_rejects_invalid_filter_method(sample_timeseries):
+    """Test clean validates `filter_method`."""
+    with pytest.raises(
+        ValueError, match="filter_method must be 'butterworth' or 'cosine'"
+    ):
+        clean(
+            sample_timeseries(),
+            low_cutoff=0.1,
+            filter_method="invalid",  # ty: ignore[invalid-argument-type]
         )

--- a/tests/unit/test_signal/test_clean.py
+++ b/tests/unit/test_signal/test_clean.py
@@ -135,15 +135,15 @@ def test_clean_filter_low_pass_matches_filter_butterworth(sample_timeseries):
 
 
 def test_clean_rejects_non_dict_filter_kwargs(sample_timeseries):
-    """Test filter_butterworth_kwargs must be a dict."""
-    with pytest.raises(TypeError, match="filter_butterworth_kwargs must be a dict"):
-        clean(sample_timeseries(), filter_butterworth_kwargs=1)  # ty: ignore[invalid-argument-type]
+    """Test filter_kwargs must be a dict."""
+    with pytest.raises(TypeError, match="filter_kwargs must be a dict"):
+        clean(sample_timeseries(), filter_kwargs=1)  # ty: ignore[invalid-argument-type]
 
 
 def test_clean_rejects_cutoffs_inside_filter_kwargs(sample_timeseries):
     """Test cutoffs must be passed directly to clean."""
     with pytest.raises(ValueError, match="Pass low_pass/high_pass directly to clean"):
-        clean(sample_timeseries(), filter_butterworth_kwargs={"high_cutoff": 1.0})
+        clean(sample_timeseries(), filter_kwargs={"high_cutoff": 1.0})
 
 
 def test_clean_rejects_non_dict_interpolate_kwargs(sample_timeseries):
@@ -394,6 +394,30 @@ def test_clean_cosine_filter_matches_filter_cosine(sample_timeseries):
     assert_allclose(result.values, expected.values)
 
 
+def test_clean_cosine_filter_kwargs_are_forwarded():
+    """Test cosine filter kwargs are forwarded by clean."""
+    time = np.array([0.0, 0.1001, 0.2002, 0.3000, 0.4001, 0.5002])
+    signals = xr.DataArray(
+        np.arange(12, dtype=float).reshape(6, 2),
+        dims=["time", "space"],
+        coords={"time": time},
+    )
+
+    expected = filter_cosine(
+        signals,
+        low_cutoff=1.0,
+        uniformity_tolerance=5e-3,
+    )
+    result = clean(
+        signals,
+        low_cutoff=1.0,
+        filter_method="cosine",
+        filter_kwargs={"uniformity_tolerance": 5e-3},
+    )
+
+    assert_allclose(result.values, expected.values)
+
+
 def test_clean_cosine_filter_rejects_high_cutoff(sample_timeseries):
     """Test cosine filtering cannot be used as a low-pass filter."""
     with pytest.raises(ValueError, match="Cosine filtering only supports low_cutoff"):
@@ -402,10 +426,10 @@ def test_clean_cosine_filter_rejects_high_cutoff(sample_timeseries):
 
 def test_clean_cosine_filter_rejects_butterworth_kwargs(sample_timeseries):
     """Test cosine filtering rejects Butterworth-only kwargs."""
-    with pytest.raises(ValueError, match="filter_butterworth_kwargs is only supported"):
+    with pytest.raises(TypeError, match="unexpected keyword argument 'order'"):
         clean(
             sample_timeseries(),
             low_cutoff=0.1,
             filter_method="cosine",
-            filter_butterworth_kwargs={"order": 3},
+            filter_kwargs={"order": 3},
         )

--- a/tests/unit/test_signal/test_filters.py
+++ b/tests/unit/test_signal/test_filters.py
@@ -458,3 +458,15 @@ class TestFilterCosine:
 
         with pytest.raises(ValueError, match="'low_cutoff' must be positive"):
             filter_cosine(signals, low_cutoff=0.0)
+
+    def test_raises_when_time_is_nonuniform(self):
+        """Cosine filter should require uniformly sampled time coordinates."""
+        time = np.array([0.0, 0.1, 0.2, 0.35, 0.4, 0.5])
+        signals = xr.DataArray(
+            np.random.randn(6, 2),
+            dims=["time", "space"],
+            coords={"time": time},
+        )
+
+        with pytest.raises(ValueError, match="Non-uniform 'time' coordinates"):
+            filter_cosine(signals, low_cutoff=0.1)

--- a/tests/unit/test_signal/test_filters.py
+++ b/tests/unit/test_signal/test_filters.py
@@ -6,7 +6,8 @@ import pytest
 import scipy.signal
 import xarray as xr
 
-from confusius.signal import filter_butterworth
+from confusius.glm import make_first_level_design_matrix
+from confusius.signal import filter_butterworth, filter_cosine
 
 
 def create_signals_with_time(shape, sampling_rate=100, **kwargs):
@@ -167,7 +168,6 @@ class TestFilterButterworth:
 
     def test_output_actually_filtered(self):
         """Low-pass filter attenuates high-frequency energy."""
-        rng = np.random.default_rng(42)
         n = 500
         sampling_rate = 100
         t = np.arange(n) / sampling_rate
@@ -391,3 +391,70 @@ class TestFilterButterworth:
         # Should preserve structure regardless of dim order.
         assert filtered.shape == signals.shape
         assert filtered.dims == signals.dims
+
+
+class TestFilterCosine:
+    """Tests for cosine filtering."""
+
+    def test_matches_glm_cosine_drift_projection(self):
+        """Cosine filter should match residualizing against GLM cosine drift terms."""
+        rng = np.random.default_rng(42)
+        sampling_rate = 10.0
+        time = np.arange(200) / sampling_rate
+        signals = xr.DataArray(
+            rng.normal(size=(200, 3)),
+            dims=["time", "space"],
+            coords={"time": time},
+        )
+        low_cutoff = 0.1
+
+        design = make_first_level_design_matrix(
+            time,
+            events=None,
+            drift_model="cosine",
+            low_cutoff=low_cutoff,
+        )
+        drift = design[
+            [c for c in design.columns if c.startswith("cosine")] + ["constant"]
+        ].to_numpy()
+        expected = (
+            signals.values
+            - drift
+            @ np.linalg.lstsq(
+                drift,
+                signals.values,
+                rcond=None,
+            )[0]
+        )
+
+        result = filter_cosine(signals, low_cutoff=low_cutoff)
+
+        np.testing.assert_allclose(result.values, expected)
+
+    def test_preserves_dim_order_and_dask_support(self):
+        """Cosine filter should preserve dim order and support Dask arrays."""
+        rng = np.random.default_rng(42)
+        sampling_rate = 10.0
+        data = da.from_array(rng.normal(size=(4, 200)), chunks=(2, 200))
+        signals = xr.DataArray(
+            data,
+            dims=["space", "time"],
+            coords={"time": np.arange(200) / sampling_rate},
+        )
+
+        filtered = filter_cosine(signals, low_cutoff=0.1)
+
+        assert filtered.dims == signals.dims
+        assert isinstance(filtered.data, da.Array)
+
+        eager_expected = filter_cosine(signals.compute(), low_cutoff=0.1)
+        np.testing.assert_allclose(filtered.compute().values, eager_expected.values)
+
+    def test_raises_when_low_cutoff_not_positive(self):
+        """Cosine filter should require a positive low cutoff."""
+        signals = create_signals_with_time(
+            (100, 5), sampling_rate=10, dims=["time", "space"]
+        )
+
+        with pytest.raises(ValueError, match="'low_cutoff' must be positive"):
+            filter_cosine(signals, low_cutoff=0.0)

--- a/tests/unit/test_validation/test_time_series.py
+++ b/tests/unit/test_validation/test_time_series.py
@@ -1,0 +1,63 @@
+"""Tests for time series validation utilities."""
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from confusius.validation.time_series import validate_time_series
+
+
+def test_validate_time_series_returns_time_axis_and_no_spacing_by_default():
+    """Default validation should not require uniform spacing."""
+    signals = xr.DataArray(
+        np.arange(12, dtype=float).reshape(6, 2),
+        dims=["time", "space"],
+        coords={"time": [0.0, 0.1, 0.2, 0.35, 0.4, 0.5]},
+    )
+
+    time_axis, time_spacing = validate_time_series(signals, "filtering")
+
+    assert time_axis == 0
+    assert time_spacing is None
+
+
+def test_validate_time_series_raises_for_single_timepoint():
+    """Validation should reject single-timepoint inputs."""
+    signals = xr.DataArray(
+        np.array([[1.0, 2.0]]),
+        dims=["time", "space"],
+        coords={"time": [0.0]},
+    )
+
+    with pytest.raises(ValueError, match="requires more than 1 timepoint"):
+        validate_time_series(signals, "filtering")
+
+
+def test_validate_time_series_returns_spacing_when_uniform_time_required():
+    """Uniform-time validation should return the time spacing."""
+    signals = xr.DataArray(
+        np.arange(12, dtype=float).reshape(6, 2),
+        dims=["time", "space"],
+        coords={"time": np.arange(6) * 0.1},
+    )
+
+    time_axis, time_spacing = validate_time_series(
+        signals,
+        "filtering",
+        require_uniform_time=True,
+    )
+
+    assert time_axis == 0
+    assert time_spacing == pytest.approx(0.1)
+
+
+def test_validate_time_series_raises_for_nonuniform_time_when_required():
+    """Uniform-time validation should reject non-uniform coordinates."""
+    signals = xr.DataArray(
+        np.arange(12, dtype=float).reshape(6, 2),
+        dims=["time", "space"],
+        coords={"time": [0.0, 0.1, 0.2, 0.35, 0.4, 0.5]},
+    )
+
+    with pytest.raises(ValueError, match="Non-uniform 'time' coordinates"):
+        validate_time_series(signals, "filtering", require_uniform_time=True)


### PR DESCRIPTION
Closes #167

## Summary
- add a standalone `confusius.signal.filter_cosine` high-pass filter based on the GLM cosine drift basis
- let `clean` use cosine filtering via `filter_method="cosine"`
- reuse the shared cosine-regressor builder in both signal cleaning and GLM design tests