### PR TITLE
feat(docs): show example summary on gallery card hover

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -133,6 +133,9 @@ Current development version for the next ConfUSIus release.
   `collapse` cell tag, with optional custom title and type (`collapse[<type>]:
   <title>`), i.e. `# %% tags=["collapse[warning]: Collapsed warning"]`
   ([#309](https://github.com/confusius-tools/confusius/pull/309)).
+- [Example Gallery]: Hovering a gallery card reveals the example's first paragraph as
+  an overlay over the card
+  ([#325](https://github.com/confusius-tools/confusius/pull/325)).
 
 ## 0.5.2
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -135,7 +135,7 @@ Current development version for the next ConfUSIus release.
   ([#309](https://github.com/confusius-tools/confusius/pull/309)).
 - [Example Gallery]: Hovering a gallery card reveals the example's first paragraph as
   an overlay over the card
-  ([#325](https://github.com/confusius-tools/confusius/pull/325)).
+  ([#327](https://github.com/confusius-tools/confusius/pull/327)).
 
 ## 0.5.2
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -443,11 +443,46 @@
 
 .grid.cards.examples-cards > ul > li {
   max-width: 14.5rem;
+  /* Positioning context and clip for the hover overlay below. */
+  position: relative;
+  overflow: hidden;
 }
 
 .grid.cards.examples-cards img {
   aspect-ratio: 4 / 3;
   object-fit: cover;
+}
+
+/* Hover overlay carrying the example's first paragraph, mirroring sphinx-gallery's
+   thumbnail tooltip: the card blurs away behind a near-opaque tint while the summary
+   fades in. `pointer-events: none` keeps the thumbnail and title links underneath
+   clickable through the overlay. Tint values are sphinx-gallery's `--sg-tooltip-*`. */
+.examples-card-summary {
+  position: absolute;
+  inset: 0;
+  padding: 0.6rem;
+  font-size: 0.62rem;
+  line-height: 1.5;
+  color: var(--md-default-fg-color);
+  background-color: rgba(250, 250, 250, 0.92);
+  backdrop-filter: blur(3px);
+  opacity: 0;
+  transition: opacity 300ms ease;
+  pointer-events: none;
+  /* Ellipsize a long first paragraph rather than cutting it mid-line. */
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 10;
+  overflow: hidden;
+}
+
+[data-md-color-scheme="slate"] .examples-card-summary {
+  background-color: rgba(10, 10, 10, 0.92);
+}
+
+.grid.cards.examples-cards > ul > li:hover .examples-card-summary,
+.grid.cards.examples-cards > ul > li:focus-within .examples-card-summary {
+  opacity: 1;
 }
 
 /* Rich-rendered text (e.g. the dataset citation banner the fetchers print) embeds

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -460,42 +460,61 @@
   line-height: 0;
 }
 
-/* Hover overlay carrying the example's first paragraph, mirroring sphinx-gallery's
-   thumbnail tooltip: the thumbnail blurs away behind a near-opaque tint while the
-   summary fades in. `pointer-events: none` keeps the thumbnail link underneath
-   clickable through the overlay. Tint values are sphinx-gallery's `--sg-tooltip-*`. */
-.examples-card-summary {
+/* Hover overlay mirroring sphinx-gallery's thumbnail tooltip: the thumbnail blurs away
+   behind a near-opaque tint while the example's first paragraph fades in over it. Tint
+   values are sphinx-gallery's `--sg-tooltip-*`.
+
+   The tint is a pseudo-element rather than a background on the text span, so that the
+   span can size itself to its text and centre with `translateY`. Centring it with flex
+   instead would make every inline node Markdown leaves in the summary (`abbr`, `code`,
+   emphasis) a separate flex item, laid out side by side rather than as running text. */
+/* `:has()` keeps the tint off an example that has no summary to show. */
+.grid.cards.examples-cards > ul > li:has(.examples-card-summary) > p:first-child::before {
+  content: "";
   position: absolute;
   inset: 0;
-  display: flex;
-  align-items: center;
-  padding: 0.9rem;
-  font-size: 0.8rem;
-  line-height: 1.5;
-  color: var(--md-default-fg-color);
   background-color: rgba(250, 250, 250, 0.92);
   backdrop-filter: blur(3px);
   opacity: 0;
   transition: opacity 300ms ease;
+  /* The tint is hit-testable like any other box, and would otherwise swallow clicks
+     meant for the thumbnail link it covers. */
   pointer-events: none;
 }
 
-/* Ellipsize a long first paragraph rather than cutting it mid-line. The clamp needs
-   the legacy `-webkit-box`, which ignores the centring above, so it lives on an inner
-   span that the outer flex box centres. Without the clamp, an overflowing summary
-   would be centred and so clipped at the top too, starting mid-sentence. */
-.examples-card-summary > span {
+[data-md-color-scheme="slate"]
+  .grid.cards.examples-cards
+  > ul
+  > li:has(.examples-card-summary)
+  > p:first-child::before {
+  background-color: rgba(10, 10, 10, 0.92);
+}
+
+/* `pointer-events: none` keeps the thumbnail link underneath clickable through the
+   overlay. The clamp bounds the text to less than the thumbnail's height, so centring
+   it can never crop the opening line; a longer paragraph ellipsizes instead. */
+.examples-card-summary {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  right: 0;
+  transform: translateY(-50%);
+  padding: 0 0.9rem;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  color: var(--md-default-fg-color);
+  opacity: 0;
+  transition: opacity 300ms ease;
+  pointer-events: none;
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 6;
   overflow: hidden;
 }
 
-[data-md-color-scheme="slate"] .examples-card-summary {
-  background-color: rgba(10, 10, 10, 0.92);
-}
-
 /* Hovering anywhere on the card, title included, reveals the thumbnail's overlay. */
+.grid.cards.examples-cards > ul > li:hover > p:first-child::before,
+.grid.cards.examples-cards > ul > li:focus-within > p:first-child::before,
 .grid.cards.examples-cards > ul > li:hover .examples-card-summary,
 .grid.cards.examples-cards > ul > li:focus-within .examples-card-summary {
   opacity: 1;

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -443,9 +443,6 @@
 
 .grid.cards.examples-cards > ul > li {
   max-width: 14.5rem;
-  /* Positioning context and clip for the hover overlay below. */
-  position: relative;
-  overflow: hidden;
 }
 
 .grid.cards.examples-cards img {
@@ -453,15 +450,27 @@
   object-fit: cover;
 }
 
+/* The thumbnail's paragraph is the positioning context for the hover overlay below.
+   `line-height: 0` collapses the descender gap under the inline thumbnail, which the
+   overlay would otherwise cover; the overlay sets its own line height. Note the
+   thumbnail cannot simply be `display: block`, as that outranks the
+   `img[src$="#only-dark"]` theme rules above and would show both thumbnails. */
+.grid.cards.examples-cards > ul > li > p:first-child {
+  position: relative;
+  line-height: 0;
+}
+
 /* Hover overlay carrying the example's first paragraph, mirroring sphinx-gallery's
-   thumbnail tooltip: the card blurs away behind a near-opaque tint while the summary
-   fades in. `pointer-events: none` keeps the thumbnail and title links underneath
+   thumbnail tooltip: the thumbnail blurs away behind a near-opaque tint while the
+   summary fades in. `pointer-events: none` keeps the thumbnail link underneath
    clickable through the overlay. Tint values are sphinx-gallery's `--sg-tooltip-*`. */
 .examples-card-summary {
   position: absolute;
   inset: 0;
-  padding: 0.6rem;
-  font-size: 0.62rem;
+  display: flex;
+  align-items: center;
+  padding: 0.9rem;
+  font-size: 0.8rem;
   line-height: 1.5;
   color: var(--md-default-fg-color);
   background-color: rgba(250, 250, 250, 0.92);
@@ -469,10 +478,16 @@
   opacity: 0;
   transition: opacity 300ms ease;
   pointer-events: none;
-  /* Ellipsize a long first paragraph rather than cutting it mid-line. */
+}
+
+/* Ellipsize a long first paragraph rather than cutting it mid-line. The clamp needs
+   the legacy `-webkit-box`, which ignores the centring above, so it lives on an inner
+   span that the outer flex box centres. Without the clamp, an overflowing summary
+   would be centred and so clipped at the top too, starting mid-sentence. */
+.examples-card-summary > span {
   display: -webkit-box;
   -webkit-box-orient: vertical;
-  -webkit-line-clamp: 10;
+  -webkit-line-clamp: 6;
   overflow: hidden;
 }
 
@@ -480,6 +495,7 @@
   background-color: rgba(10, 10, 10, 0.92);
 }
 
+/* Hovering anywhere on the card, title included, reveals the thumbnail's overlay. */
 .grid.cards.examples-cards > ul > li:hover .examples-card-summary,
 .grid.cards.examples-cards > ul > li:focus-within .examples-card-summary {
   opacity: 1;

--- a/tests/unit/test_gallery/test_index.py
+++ b/tests/unit/test_gallery/test_index.py
@@ -63,10 +63,15 @@ def test_build_index_groups_cards_by_section(tmp_path: Path) -> None:
     # Cards include thumbnail and title links.
     assert "load_autc_thumb_light.png#only-light" in index_md
     assert "load_autc_thumb_dark.png#only-dark" in index_md
-    assert "Quick AUTC demo." not in index_md
     # Falls back to default thumb for examples without one.
     assert "_assets/default_thumb.svg#only-light" in index_md
     assert "_assets/default_thumb_dark.svg#only-dark" in index_md
+    # The summary rides along as a hover overlay, only where there is one.
+    assert (
+        '<span class="examples-card-summary" aria-hidden="true">Quick AUTC demo.</span>'
+        in index_md
+    )
+    assert index_md.count("examples-card-summary") == 2
 
 
 def test_build_index_preserves_section_order_from_input(tmp_path: Path) -> None:
@@ -103,6 +108,50 @@ def test_build_index_preserves_section_order_from_input(tmp_path: Path) -> None:
 
     md = build_index(rendered, root=tmp_path)
     assert md.index("## IO") < md.index("## DECOMPOSITION")
+
+
+def test_build_index_flattens_links_in_card_overlays(tmp_path: Path) -> None:
+    """Relative links in a summary are flattened so they can't break the index page.
+
+    Overlays are copied verbatim onto the index page at the examples root, where an
+    example's relative cross-links (written against its own built page) would not
+    resolve and would fail ``zensical build --strict``.
+    """
+    src = tmp_path / "decomposition" / "nmf.py"
+    src.parent.mkdir(parents=True, exist_ok=True)
+    src.touch()
+    rendered = [
+        RenderedExample(
+            spec=_spec(src, "decomposition"),
+            title="NMF",
+            summary="Complements the [PCA](pca_single_recording.md) example.",
+            md_path=src.with_suffix(".md"),
+            thumbnail_light=None,
+            thumbnail_dark=None,
+        ),
+    ]
+    md = build_index(rendered, root=tmp_path)
+    assert "](pca_single_recording.md)" not in md
+    assert "Complements the PCA example.</span>" in md
+
+
+def test_build_index_escapes_html_in_card_overlays(tmp_path: Path) -> None:
+    """Summary text is escaped so it cannot inject markup into the overlay span."""
+    src = tmp_path / "io" / "ex.py"
+    src.parent.mkdir(parents=True, exist_ok=True)
+    src.touch()
+    rendered = [
+        RenderedExample(
+            spec=_spec(src, "io"),
+            title="Ex",
+            summary='Uses <div> & "quotes".',
+            md_path=src.with_suffix(".md"),
+            thumbnail_light=None,
+            thumbnail_dark=None,
+        ),
+    ]
+    md = build_index(rendered, root=tmp_path)
+    assert "Uses &lt;div&gt; &amp; &quot;quotes&quot;.</span>" in md
 
 
 def test_build_index_demotes_h1_section_intros(tmp_path: Path) -> None:

--- a/tests/unit/test_gallery/test_index.py
+++ b/tests/unit/test_gallery/test_index.py
@@ -68,8 +68,8 @@ def test_build_index_groups_cards_by_section(tmp_path: Path) -> None:
     assert "_assets/default_thumb_dark.svg#only-dark" in index_md
     # The summary rides along as a hover overlay, only where there is one.
     assert (
-        '<span class="examples-card-summary" aria-hidden="true">Quick AUTC demo.</span>'
-        in index_md
+        '<span class="examples-card-summary" aria-hidden="true">'
+        "<span>Quick AUTC demo.</span></span>" in index_md
     )
     assert index_md.count("examples-card-summary") == 2
 
@@ -132,7 +132,7 @@ def test_build_index_flattens_links_in_card_overlays(tmp_path: Path) -> None:
     ]
     md = build_index(rendered, root=tmp_path)
     assert "](pca_single_recording.md)" not in md
-    assert "Complements the PCA example.</span>" in md
+    assert "<span>Complements the PCA example.</span>" in md
 
 
 def test_build_index_escapes_html_in_card_overlays(tmp_path: Path) -> None:
@@ -151,7 +151,7 @@ def test_build_index_escapes_html_in_card_overlays(tmp_path: Path) -> None:
         ),
     ]
     md = build_index(rendered, root=tmp_path)
-    assert "Uses &lt;div&gt; &amp; &quot;quotes&quot;.</span>" in md
+    assert "<span>Uses &lt;div&gt; &amp; &quot;quotes&quot;.</span>" in md
 
 
 def test_build_index_demotes_h1_section_intros(tmp_path: Path) -> None:

--- a/tests/unit/test_gallery/test_index.py
+++ b/tests/unit/test_gallery/test_index.py
@@ -68,8 +68,8 @@ def test_build_index_groups_cards_by_section(tmp_path: Path) -> None:
     assert "_assets/default_thumb_dark.svg#only-dark" in index_md
     # The summary rides along as a hover overlay, only where there is one.
     assert (
-        '<span class="examples-card-summary" aria-hidden="true">'
-        "<span>Quick AUTC demo.</span></span>" in index_md
+        '<span class="examples-card-summary" aria-hidden="true">Quick AUTC demo.</span>'
+        in index_md
     )
     assert index_md.count("examples-card-summary") == 2
 
@@ -111,11 +111,12 @@ def test_build_index_preserves_section_order_from_input(tmp_path: Path) -> None:
 
 
 def test_build_index_flattens_links_in_card_overlays(tmp_path: Path) -> None:
-    """Relative links in a summary are flattened so they can't break the index page.
+    """Both link forms in a summary are flattened to their text.
 
     Overlays are copied verbatim onto the index page at the examples root, where an
     example's relative cross-links (written against its own built page) would not
-    resolve and would fail ``zensical build --strict``.
+    resolve and would fail ``zensical build --strict``. A mkdocstrings cross-reference
+    resolves, but would render as a link inside an overlay that is inert by design.
     """
     src = tmp_path / "decomposition" / "nmf.py"
     src.parent.mkdir(parents=True, exist_ok=True)
@@ -124,7 +125,10 @@ def test_build_index_flattens_links_in_card_overlays(tmp_path: Path) -> None:
         RenderedExample(
             spec=_spec(src, "decomposition"),
             title="NMF",
-            summary="Complements the [PCA](pca_single_recording.md) example.",
+            summary=(
+                "Uses [FastICA][confusius.decomposition.FastICA]. Complements the "
+                "[PCA](pca_single_recording.md) example."
+            ),
             md_path=src.with_suffix(".md"),
             thumbnail_light=None,
             thumbnail_dark=None,
@@ -132,11 +136,17 @@ def test_build_index_flattens_links_in_card_overlays(tmp_path: Path) -> None:
     ]
     md = build_index(rendered, root=tmp_path)
     assert "](pca_single_recording.md)" not in md
-    assert "<span>Complements the PCA example.</span>" in md
+    assert "confusius.decomposition.FastICA" not in md
+    assert "Uses FastICA. Complements the PCA example.</span>" in md
 
 
 def test_build_index_escapes_html_in_card_overlays(tmp_path: Path) -> None:
-    """Summary text is escaped so it cannot inject markup into the overlay span."""
+    """Summary text is escaped so it cannot inject markup into the overlay span.
+
+    Quotes are left alone: they need no escaping in text content, and an escaped one
+    survives a code span, which escapes the entity's ``&`` in turn and shows it
+    verbatim.
+    """
     src = tmp_path / "io" / "ex.py"
     src.parent.mkdir(parents=True, exist_ok=True)
     src.touch()
@@ -144,14 +154,14 @@ def test_build_index_escapes_html_in_card_overlays(tmp_path: Path) -> None:
         RenderedExample(
             spec=_spec(src, "io"),
             title="Ex",
-            summary='Uses <div> & "quotes".',
+            summary='Uses <div> & `mode="temporal"`.',
             md_path=src.with_suffix(".md"),
             thumbnail_light=None,
             thumbnail_dark=None,
         ),
     ]
     md = build_index(rendered, root=tmp_path)
-    assert "<span>Uses &lt;div&gt; &amp; &quot;quotes&quot;.</span>" in md
+    assert 'Uses &lt;div&gt; &amp; `mode="temporal"`.</span>' in md
 
 
 def test_build_index_demotes_h1_section_intros(tmp_path: Path) -> None:

--- a/tools/gallery/index.py
+++ b/tools/gallery/index.py
@@ -12,25 +12,28 @@ from ._types import RenderedExample
 _DEFAULT_THUMB_LIGHT = "_assets/default_thumb.svg"
 _DEFAULT_THUMB_DARK = "_assets/default_thumb_dark.svg"
 
-# Markdown inline link: [text](url). Card overlays are copied verbatim onto the gallery
-# index page (at the examples root), where an example's relative links — written against
-# its own built page — would not resolve and fail `zensical build --strict`. The full
-# links still render on the example's own page.
-_INLINE_LINK = re.compile(r"\[([^\]]+)\]\([^)]+\)")
+# Markdown inline link `[text](url)`, and mkdocstrings cross-reference `[text][ident]`.
+# Card overlays are copied verbatim onto the gallery index page (at the examples root),
+# where an example's relative links — written against its own built page — would not
+# resolve and fail `zensical build --strict`. A cross-reference does resolve, but it
+# would render as a link inside an overlay that is inert by design. The full links still
+# render on the example's own page.
+_INLINE_LINK = re.compile(r"\[([^\]]+)\](?:\([^)]*\)|\[[^\]]*\])")
 
 
 def _flatten_links(text: str) -> str:
-    """Replace Markdown inline links with their visible text.
+    """Replace Markdown inline links and cross-references with their visible text.
 
     Parameters
     ----------
     text : str
-        Markdown text that may contain inline links.
+        Markdown text that may contain inline links or cross-references.
 
     Returns
     -------
     str
-        The text with every `[label](target)` reduced to `label`.
+        The text with every `[label](target)` and `[label][identifier]` reduced to
+        `label`.
     """
     return _INLINE_LINK.sub(r"\1", text)
 
@@ -65,10 +68,14 @@ def _card_image_markdown(rex: RenderedExample, *, root: Path, href: str) -> str:
 def _card_overlay_markdown(rex: RenderedExample) -> str:
     """Return the hover-overlay markup carrying an example's summary.
 
-    The outer span is absolutely positioned over the card's thumbnail by `extra.css` and
-    revealed on hover, mirroring sphinx-gallery's thumbnail tooltip; the inner span
-    carries the line clamp, which cannot share an element with the centring. The markup
-    stays in the thumbnail's paragraph so it adds no vertical space to the card.
+    The span is centred over the card's thumbnail by `extra.css` and revealed on hover,
+    mirroring sphinx-gallery's thumbnail tooltip. It stays in the thumbnail's paragraph
+    so it adds no vertical space to the card.
+
+    The summary keeps whatever inline markup Markdown gives it (`abbr` for the glossary
+    terms in `docs/includes/abbreviations.md`, `code` for backticks), so `extra.css` has
+    to lay the overlay out as flowing text. Do not wrap the text in an inner element:
+    the pipeline drops a nested bare span, and the CSS is written not to need one.
 
     Parameters
     ----------
@@ -82,11 +89,10 @@ def _card_overlay_markdown(rex: RenderedExample) -> str:
     """
     if not rex.summary:
         return ""
-    summary = html_lib.escape(_flatten_links(rex.summary))
-    return (
-        f'<span class="examples-card-summary" aria-hidden="true">'
-        f"<span>{summary}</span></span>"
-    )
+    # Text content, so quotes are left alone: escaping them here would survive a code
+    # span, which escapes the `&` of the entity in turn and shows it verbatim.
+    summary = html_lib.escape(_flatten_links(rex.summary), quote=False)
+    return f'<span class="examples-card-summary" aria-hidden="true">{summary}</span>'
 
 
 def build_index(rendered: list[RenderedExample], *, root: Path) -> str:

--- a/tools/gallery/index.py
+++ b/tools/gallery/index.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import html as html_lib
+import re
 from collections import defaultdict
 from pathlib import Path
 
@@ -10,6 +11,28 @@ from ._types import RenderedExample
 
 _DEFAULT_THUMB_LIGHT = "_assets/default_thumb.svg"
 _DEFAULT_THUMB_DARK = "_assets/default_thumb_dark.svg"
+
+# Markdown inline link: [text](url). Card overlays are copied verbatim onto the gallery
+# index page (at the examples root), where an example's relative links — written against
+# its own built page — would not resolve and fail `zensical build --strict`. The full
+# links still render on the example's own page.
+_INLINE_LINK = re.compile(r"\[([^\]]+)\]\([^)]+\)")
+
+
+def _flatten_links(text: str) -> str:
+    """Replace Markdown inline links with their visible text.
+
+    Parameters
+    ----------
+    text : str
+        Markdown text that may contain inline links.
+
+    Returns
+    -------
+    str
+        The text with every `[label](target)` reduced to `label`.
+    """
+    return _INLINE_LINK.sub(r"\1", text)
 
 
 def _demote_h1(text: str) -> str:
@@ -39,6 +62,29 @@ def _card_image_markdown(rex: RenderedExample, *, root: Path, href: str) -> str:
     )
 
 
+def _card_overlay_markdown(rex: RenderedExample) -> str:
+    """Return the hover-overlay markup carrying an example's summary.
+
+    The span is absolutely positioned over the whole card by `extra.css` and revealed on
+    hover, mirroring sphinx-gallery's thumbnail tooltip. It stays in the thumbnail's
+    paragraph so it adds no vertical space to the card.
+
+    Parameters
+    ----------
+    rex : RenderedExample
+        The example whose summary is shown on hover.
+
+    Returns
+    -------
+    str
+        The overlay markup, or an empty string for an example without a summary.
+    """
+    if not rex.summary:
+        return ""
+    summary = html_lib.escape(_flatten_links(rex.summary))
+    return f'<span class="examples-card-summary" aria-hidden="true">{summary}</span>'
+
+
 def build_index(rendered: list[RenderedExample], *, root: Path) -> str:
     """Return the Markdown text of the gallery index page."""
     by_section: dict[str, list[RenderedExample]] = defaultdict(list)
@@ -63,8 +109,10 @@ def build_index(rendered: list[RenderedExample], *, root: Path) -> str:
         for rendered_example in sorted(items, key=lambda item: item.spec.source.name):
             href = rendered_example.md_path.relative_to(root).as_posix()
             image = _card_image_markdown(rendered_example, root=root, href=href)
+            overlay = _card_overlay_markdown(rendered_example)
             card = (
-                f"-   {image}\n\n    ---\n\n    **[{rendered_example.title}]({href})**"
+                f"-   {image}{overlay}\n\n    ---\n\n"
+                f"    **[{rendered_example.title}]({href})**"
             )
             parts.append(card + "\n\n")
         parts.append("</div>\n\n")

--- a/tools/gallery/index.py
+++ b/tools/gallery/index.py
@@ -65,9 +65,10 @@ def _card_image_markdown(rex: RenderedExample, *, root: Path, href: str) -> str:
 def _card_overlay_markdown(rex: RenderedExample) -> str:
     """Return the hover-overlay markup carrying an example's summary.
 
-    The span is absolutely positioned over the whole card by `extra.css` and revealed on
-    hover, mirroring sphinx-gallery's thumbnail tooltip. It stays in the thumbnail's
-    paragraph so it adds no vertical space to the card.
+    The outer span is absolutely positioned over the card's thumbnail by `extra.css` and
+    revealed on hover, mirroring sphinx-gallery's thumbnail tooltip; the inner span
+    carries the line clamp, which cannot share an element with the centring. The markup
+    stays in the thumbnail's paragraph so it adds no vertical space to the card.
 
     Parameters
     ----------
@@ -82,7 +83,10 @@ def _card_overlay_markdown(rex: RenderedExample) -> str:
     if not rex.summary:
         return ""
     summary = html_lib.escape(_flatten_links(rex.summary))
-    return f'<span class="examples-card-summary" aria-hidden="true">{summary}</span>'
+    return (
+        f'<span class="examples-card-summary" aria-hidden="true">'
+        f"<span>{summary}</span></span>"
+    )
 
 
 def build_index(rendered: list[RenderedExample], *, root: Path) -> str:


### PR DESCRIPTION
Hovering an example gallery card now fades its first paragraph in over the thumbnail, mirroring the sphinx-gallery/nilearn tooltip.

- The summary is centered over the thumbnail as flowing text (so inline links, abbreviations, and code render inline), behind a near-opaque, theme-aware tint that blurs the thumbnail; the title stays readable below and the thumbnail link stays clickable through the overlay.
- Cross-references and inline links in the summary are flattened to plain text, since they would either not resolve from the index page or render as live links inside an overlay that is inert by design.
- Overlay text is size-matched to the docs' body prose and clamped to the thumbnail height, ellipsizing a long paragraph rather than overflowing.


https://github.com/user-attachments/assets/ad5bc2fc-f56f-48cc-89f2-4f4f2ffa648f

