### PR TITLE
feat(plotting): add plot_design_matrix and plot_contrast_matrix

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -75,6 +75,14 @@ Current development version for the next ConfUSIus release.
   visualize motion-correction summaries from `motion_params` tables returned by
   [`register_volumewise`][confusius.registration.register_volumewise]
   ([#302](https://github.com/confusius-tools/confusius/pull/302)).
+- Added [`plot_design_matrix`][confusius.plotting.plot_design_matrix] to visualize a
+  first-level GLM design matrix as a heatmap, with regressor names along the top and an
+  optional acquisition-time y-axis (`index_yaxis`)
+  ([#331](https://github.com/confusius-tools/confusius/pull/331)).
+- Added [`plot_contrast_matrix`][confusius.plotting.plot_contrast_matrix] to visualize a
+  GLM contrast, given as a string expression or a numeric vector/matrix, as a weight strip
+  aligned with the design regressors
+  ([#331](https://github.com/confusius-tools/confusius/pull/331)).
 - [`create_motion_dataframe`][confusius.registration.create_motion_dataframe] now always
   reports all named rotation / translation axes exposed by the affine dimensionality,
   even when one spatial axis is singleton

--- a/src/confusius/plotting/__init__.py
+++ b/src/confusius/plotting/__init__.py
@@ -6,6 +6,8 @@ __all__ = [
     "plot_carpet",
     "plot_composite",
     "plot_contours",
+    "plot_contrast_matrix",
+    "plot_design_matrix",
     "plot_matrix",
     "plot_motion_diagnostics",
     "plot_napari",
@@ -22,7 +24,11 @@ from confusius.plotting.image import (
     plot_stat_map,
     plot_volume,
 )
-from confusius.plotting.matrix import plot_matrix
+from confusius.plotting.matrix import (
+    plot_contrast_matrix,
+    plot_design_matrix,
+    plot_matrix,
+)
 from confusius.plotting.motion import plot_motion_diagnostics
 from confusius.plotting.napari import (
     draw_napari_labels,

--- a/src/confusius/plotting/matrix.py
+++ b/src/confusius/plotting/matrix.py
@@ -685,13 +685,13 @@ def plot_contrast_matrix(
     column_width: float = 0.6,
     ax: "Axes | None" = None,
 ) -> tuple["Figure | SubFigure", "Axes"]:
-    """Plot a GLM contrast as a strip of weights aligned with the design regressors.
+    """Plot a GLM contrast as an array of weights aligned with the design regressors.
 
     Visualizes the same `contrast_def` you would pass to
     [`compute_contrast`][confusius.glm.first_level.FirstLevelModel.compute_contrast],
-    laid out under `design_matrix`'s regressor columns. Each contrast is drawn as one row
-    of a heatmap on a symmetric range `[-m, m]` (`m = max(|weights|)`), so positive and
-    negative weights read symmetrically.
+    laid out under `design_matrix`'s regressor columns. Each contrast is drawn as one
+    column of a heatmap on a symmetric range `[-m, m]` (`m = max(|weights|)`), so
+    positive and negative weights read symmetrically.
 
     Parameters
     ----------
@@ -729,8 +729,7 @@ def plot_contrast_matrix(
         floored at 2 inches.
     column_width : float, default: 0.6
         Figure width contributed per regressor, in inches, used only when `ax` is not
-        provided. The width is `column_width * n_regressors`, floored at 4 inches so a
-        few-column design does not render as a sliver.
+        provided. The width is `column_width * n_regressors`, floored at 4 inches.
     ax : matplotlib.axes.Axes, optional
         Axes to plot on. If not provided, creates a new figure and axes sized from
         `row_height` and `column_width`.
@@ -770,7 +769,7 @@ def plot_contrast_matrix(
     title_fontsize, label_fontsize, tick_fontsize = _resolve_font_sizes(fontsize)
 
     if ax is None:
-        # Floor both dims so a single-row, few-column contrast is not a sliver. The
+        # Floor both dims so a single-row, few-column contrast is not too thin. The
         # 1.5 in base leaves room for the rotated regressor labels below the strip and
         # a colorbar taller than the (equal-aspect) strip itself.
         width = max(4.0, column_width * n_columns)
@@ -902,7 +901,7 @@ def plot_design_matrix(
 ) -> tuple["Figure | SubFigure", "Axes"]:
     """Plot a first-level GLM design matrix as a heatmap.
 
-    Renders each regressor (column) against acquisition time (row). Values are shown on a
+    Renders each regressor (column) against acquisition volumes (row). Values are shown on a
     norm centered at zero, so positive and negative regressor weights read symmetrically.
     When `ax` is not provided, the figure width scales with the number of regressors so
     wide designs stay legible.
@@ -944,8 +943,7 @@ def plot_design_matrix(
         Figure height in inches, used only when `ax` is not provided.
     column_width : float, default: 0.6
         Figure width contributed per regressor, in inches, used only when `ax` is not
-        provided. The width is `column_width * n_regressors`, floored at 4 inches so a
-        few-column design does not render as a sliver.
+        provided. The width is `column_width * n_regressors`, floored at 4 inches.
     ax : matplotlib.axes.Axes, optional
         Axes to plot on. If not provided, creates a new figure and axes sized from
         `height` and `column_width`.

--- a/src/confusius/plotting/matrix.py
+++ b/src/confusius/plotting/matrix.py
@@ -690,7 +690,7 @@ def plot_contrast_matrix(
     Visualizes the same `contrast_def` you would pass to
     [`compute_contrast`][confusius.glm.first_level.FirstLevelModel.compute_contrast],
     laid out under `design_matrix`'s regressor columns. Each contrast is drawn as one
-    column of a heatmap on a symmetric range `[-m, m]` (`m = max(|weights|)`), so
+    row of a heatmap on a symmetric range `[-m, m]` (`m = max(|weights|)`), so
     positive and negative weights read symmetrically.
 
     Parameters

--- a/src/confusius/plotting/matrix.py
+++ b/src/confusius/plotting/matrix.py
@@ -993,16 +993,17 @@ def plot_design_matrix(
             color=text_color,
         )
     if index_yaxis and frame_times is not None:
-        # Rows are drawn at integer positions 0..n-1; relabel the auto-placed y ticks
-        # with the corresponding acquisition time rather than the raw volume index.
+        # Rows are drawn at integer positions 0..n-1; relabel auto-placed y ticks by
+        # interpolating between acquisition times rather than rounding half-row ticks.
         from matplotlib.ticker import FuncFormatter
 
+        row_positions = np.arange(len(frame_times))
         default_ylabel = "Time (s)"
         ax.yaxis.set_major_formatter(
             FuncFormatter(
                 lambda pos, _: (
-                    f"{frame_times[round(pos)]:g}"
-                    if 0 <= round(pos) < len(frame_times)
+                    f"{np.interp(pos, row_positions, frame_times):g}"
+                    if 0 <= pos <= row_positions[-1]
                     else ""
                 )
             )

--- a/src/confusius/plotting/matrix.py
+++ b/src/confusius/plotting/matrix.py
@@ -1,8 +1,8 @@
 """2D matrix visualization utilities.
 
-`plot_matrix` is inspired by `nilearn.plotting.plot_matrix` (BSD-3-Clause License; see
-`NOTICE` for details). The `groups` colored-rectangle annotation has no Nilearn
-equivalent.
+Several functions (`plot_matrix`, `plot_design_matrix`, `plot_contrast_matrix`) in this
+module are inspired by `nilearn.plotting.plot_matrix` (BSD-3-Clause License; see
+`NOTICE` for details).
 """
 
 from collections.abc import Hashable
@@ -10,8 +10,10 @@ from typing import TYPE_CHECKING, Any, Literal, Mapping, Sequence
 
 import numpy as np
 import numpy.typing as npt
+import pandas as pd
 import xarray as xr
 
+from confusius.glm._utils import resolve_contrast_vector
 from confusius.plotting._utils import (
     _auto_fg_color,
     _get_distinct_colors,
@@ -662,6 +664,361 @@ def plot_matrix(
             label=cbar_label,
             label_fontsize=label_fontsize,
         )
+
+    if title:
+        ax.set_title(title, color=text_color, fontsize=title_fontsize)
+
+    return figure, ax
+
+
+def plot_contrast_matrix(
+    contrast_def: "str | npt.NDArray[Any]",
+    design_matrix: "pd.DataFrame | npt.NDArray[Any]",
+    *,
+    cmap: "str | Colormap | None" = "gray",
+    title: str | None = None,
+    bg_color: str = "white",
+    fg_color: str | None = None,
+    fontsize: float | None = None,
+    show_colorbar: bool = False,
+    row_height: float = 0.5,
+    column_width: float = 0.6,
+    ax: "Axes | None" = None,
+) -> tuple["Figure | SubFigure", "Axes"]:
+    """Plot a GLM contrast as a strip of weights aligned with the design regressors.
+
+    Visualizes the same `contrast_def` you would pass to
+    [`compute_contrast`][confusius.glm.first_level.FirstLevelModel.compute_contrast],
+    laid out under `design_matrix`'s regressor columns. Each contrast is drawn as one row
+    of a heatmap on a symmetric range `[-m, m]` (`m = max(|weights|)`), so positive and
+    negative weights read symmetrically.
+
+    Parameters
+    ----------
+    contrast_def : str or numpy.ndarray
+        Contrast definition. A string is parsed as an expression over the design-matrix
+        column names (e.g. `"stim_A - stim_B"`); a 1D `(n_columns,)` array is a *t*-contrast
+        (one row) and a 2D `(q, n_columns)` array an *F*-contrast (`q` rows). Arrays
+        narrower than the design are zero-padded on the right, mirroring `compute_contrast`.
+    design_matrix : (n_volumes, n_regressors) pandas.DataFrame or numpy.ndarray
+        Design matrix the contrast applies to, used for its regressor count and column
+        labels. When a DataFrame is passed, its column names label the regressors. A bare
+        array has no column names, so a string `contrast_def` cannot be resolved against it
+        and raises.
+    cmap : str or matplotlib.colors.Colormap, default: "gray"
+        Colormap for the weights.
+    title : str, optional
+        Plot title.
+    bg_color : str, default: "white"
+        Background color for the figure and axes. Any matplotlib-compatible color string
+        (e.g. `"black"`, `"white"`, `"#1a1a2e"`).
+    fg_color : str, optional
+        Color for text, labels, ticks, and spines. If not provided, derived automatically
+        from `bg_color` using the WCAG relative luminance formula (white on dark
+        backgrounds, black on light ones).
+    fontsize : float, optional
+        Base font size for text elements. Title uses `fontsize` directly; the y-axis label
+        uses `0.9 * fontsize` and the tick labels use `0.85 * fontsize`. If not provided,
+        uses the active Matplotlib defaults.
+    show_colorbar : bool, default: False
+        Whether to add a colorbar for the weights to the figure.
+    row_height : float, default: 0.5
+        Figure height contributed per contrast row, in inches, used only when `ax` is not
+        provided. The height is `1.5 + row_height * n_contrasts` (the 1.5 in base leaves
+        room for the rotated regressor labels and a colorbar taller than the strip),
+        floored at 2 inches.
+    column_width : float, default: 0.6
+        Figure width contributed per regressor, in inches, used only when `ax` is not
+        provided. The width is `column_width * n_regressors`, floored at 4 inches so a
+        few-column design does not render as a sliver.
+    ax : matplotlib.axes.Axes, optional
+        Axes to plot on. If not provided, creates a new figure and axes sized from
+        `row_height` and `column_width`.
+
+    Returns
+    -------
+    figure : matplotlib.figure.Figure or matplotlib.figure.SubFigure
+        Figure object containing the contrast plot.
+    axes : matplotlib.axes.Axes
+        Axes object with the contrast plot.
+
+    Raises
+    ------
+    ValueError
+        If `contrast_def` is a string but `design_matrix` is a bare array with no column
+        names to resolve it against.
+    """
+    import matplotlib.pyplot as plt
+
+    values, labels, _ = _design_matrix_values_and_labels(design_matrix)
+    n_columns = values.shape[1]
+    if isinstance(contrast_def, str) and labels is None:
+        raise ValueError(
+            "A string contrast_def needs a pandas.DataFrame design_matrix with named "
+            "columns to resolve against; got a bare array."
+        )
+
+    columns = labels if labels is not None else [str(i) for i in range(n_columns)]
+    contrast = np.atleast_2d(resolve_contrast_vector(contrast_def, columns))
+    n_contrasts = contrast.shape[0]
+
+    maxval = float(np.abs(contrast).max())
+    if maxval == 0.0:
+        maxval = 1.0  # All-zero contrast: keep a neutral mid-gray, avoid vmin == vmax.
+
+    text_color = fg_color if fg_color is not None else _auto_fg_color(bg_color)
+    title_fontsize, label_fontsize, tick_fontsize = _resolve_font_sizes(fontsize)
+
+    if ax is None:
+        # Floor both dims so a single-row, few-column contrast is not a sliver. The
+        # 1.5 in base leaves room for the rotated regressor labels below the strip and
+        # a colorbar taller than the (equal-aspect) strip itself.
+        width = max(4.0, column_width * n_columns)
+        height = max(2.0, 1.5 + row_height * n_contrasts)
+        figure, ax = plt.subplots(figsize=(width, height), layout="constrained")
+        figure.patch.set_facecolor(bg_color)
+    else:
+        figure = ax.figure
+    ax.set_facecolor(bg_color)
+
+    # Equal aspect keeps each weight a square cell, so the strip stays a thin band and a
+    # colorbar spanning the axes reads taller than it.
+    image = ax.imshow(
+        contrast,
+        aspect="equal",
+        interpolation="nearest",
+        cmap=cmap,
+        vmin=-maxval,
+        vmax=maxval,
+    )
+
+    ax.set_xticks(range(n_columns))
+    ax.xaxis.tick_top()  # Regressor names above the strip.
+    if labels is not None:
+        ax.set_xticklabels(
+            labels,
+            rotation=45,
+            ha="left",
+            rotation_mode="anchor",
+            fontsize=tick_fontsize,
+            color=text_color,
+        )
+    # A single-row t-contrast needs no row axis; label the rows only for F-contrasts.
+    if n_contrasts > 1:
+        ax.set_yticks(range(n_contrasts))
+        ax.set_yticklabels(
+            [str(i) for i in range(n_contrasts)],
+            fontsize=tick_fontsize,
+            color=text_color,
+        )
+        ax.set_ylabel("Contrast", color=text_color, fontsize=label_fontsize)
+    else:
+        ax.set_yticks([])
+    ax.tick_params(colors=text_color)
+    for spine in ax.spines.values():
+        spine.set_color(text_color)
+
+    if show_colorbar:
+        # Let the colorbar steal space from `ax` via figure.colorbar rather than
+        # mpl_toolkits' make_axes_locatable: the latter fights layout="constrained"
+        # and lands the colorbar on top of the strip. A lower-than-default aspect
+        # widens the bar a little.
+        cbar = figure.colorbar(image, ax=ax, aspect=12)
+        _style_colorbar(
+            cbar,
+            text_color,
+            tick_fontsize,
+            bg_color=bg_color,
+            label=None,
+            label_fontsize=label_fontsize,
+        )
+
+    if title:
+        ax.set_title(title, color=text_color, fontsize=title_fontsize)
+
+    return figure, ax
+
+
+def _design_matrix_values_and_labels(
+    design_matrix: "pd.DataFrame | npt.NDArray[Any]",
+) -> tuple[npt.NDArray[Any], list[str] | None, npt.NDArray[Any] | None]:
+    """Extract the plottable array, regressor labels, and frame times from a design matrix.
+
+    Parameters
+    ----------
+    design_matrix : pandas.DataFrame or numpy.ndarray
+        Design matrix with volumes along the rows and regressors along the columns.
+
+    Returns
+    -------
+    values : (n_volumes, n_regressors) numpy.ndarray
+        Design matrix values.
+    labels : list[str] or None
+        Regressor names when `design_matrix` is a DataFrame, otherwise None.
+    frame_times : (n_volumes,) numpy.ndarray or None
+        Row index values (the per-volume acquisition times, in seconds) when
+        `design_matrix` is a DataFrame with a meaningful index, as produced by
+        [`make_first_level_design_matrix`][confusius.glm.make_first_level_design_matrix].
+        A DataFrame carrying only a trivial `pandas.RangeIndex`, or a bare array, yields
+        None.
+
+    Raises
+    ------
+    ValueError
+        If `design_matrix` is not 2D.
+    """
+    if isinstance(design_matrix, pd.DataFrame):
+        values = design_matrix.to_numpy()
+        labels = [str(column) for column in design_matrix.columns]
+        frame_times = (
+            None
+            if isinstance(design_matrix.index, pd.RangeIndex)
+            else design_matrix.index.to_numpy()
+        )
+    else:
+        values = np.asarray(design_matrix)
+        labels = None
+        frame_times = None
+    if values.ndim != 2:
+        raise ValueError(
+            f"Expected a 2D design matrix, got array of shape {values.shape}."
+        )
+    return values, labels, frame_times
+
+
+def plot_design_matrix(
+    design_matrix: "pd.DataFrame | npt.NDArray[Any]",
+    *,
+    cmap: "str | Colormap | None" = None,
+    title: str | None = None,
+    index_yaxis: bool = False,
+    yaxis_label: str | None = None,
+    bg_color: str = "white",
+    fg_color: str | None = None,
+    fontsize: float | None = None,
+    height: float = 5.0,
+    column_width: float = 0.6,
+    ax: "Axes | None" = None,
+) -> tuple["Figure | SubFigure", "Axes"]:
+    """Plot a first-level GLM design matrix as a heatmap.
+
+    Renders each regressor (column) against acquisition time (row). Values are shown on a
+    norm centered at zero, so positive and negative regressor weights read symmetrically.
+    When `ax` is not provided, the figure width scales with the number of regressors so
+    wide designs stay legible.
+
+    Parameters
+    ----------
+    design_matrix : (n_volumes, n_regressors) pandas.DataFrame or numpy.ndarray
+        Design matrix to plot, e.g. an entry of the `design_matrices_` attribute of a
+        fitted [`FirstLevelModel`][confusius.glm.first_level.FirstLevelModel]. Volumes run
+        along the rows (top to bottom) and regressors along the columns. When a DataFrame
+        is passed, its column names label the regressors and its index (the per-volume
+        acquisition times, in seconds) labels the y-axis (see `index_yaxis`).
+    cmap : str or matplotlib.colors.Colormap, optional
+        Colormap for the design matrix. If not provided, the active Matplotlib default is
+        used.
+    title : str, optional
+        Plot title.
+    index_yaxis : bool, default: False
+        Whether to label the y-axis with the design matrix's index (the per-volume
+        acquisition times, in seconds), titled "Time (s)". When False, the y-axis instead
+        shows the integer volume index titled "Volume". A bare array, or a DataFrame with a
+        trivial `pandas.RangeIndex`, has no meaningful index and always uses the volume
+        index regardless of this flag.
+    yaxis_label : str, optional
+        Override for the y-axis label. If not provided, the label is "Time (s)" when
+        `index_yaxis` selects the acquisition-time index and "Volume" otherwise.
+    bg_color : str, default: "white"
+        Background color for the figure and axes. Any matplotlib-compatible color string
+        (e.g. `"black"`, `"white"`, `"#1a1a2e"`).
+    fg_color : str, optional
+        Color for text, labels, ticks, and spines. If not provided, derived automatically
+        from `bg_color` using the WCAG relative luminance formula (white on dark
+        backgrounds, black on light ones).
+    fontsize : float, optional
+        Base font size for text elements. Title uses `fontsize` directly; the y-axis label
+        uses `0.9 * fontsize` and the regressor tick labels use `0.85 * fontsize`. If not
+        provided, uses the active Matplotlib defaults.
+    height : float, default: 5.0
+        Figure height in inches, used only when `ax` is not provided.
+    column_width : float, default: 0.6
+        Figure width contributed per regressor, in inches, used only when `ax` is not
+        provided. The width is `column_width * n_regressors`, floored at 4 inches so a
+        few-column design does not render as a sliver.
+    ax : matplotlib.axes.Axes, optional
+        Axes to plot on. If not provided, creates a new figure and axes sized from
+        `height` and `column_width`.
+
+    Returns
+    -------
+    figure : matplotlib.figure.Figure or matplotlib.figure.SubFigure
+        Figure object containing the design matrix plot.
+    axes : matplotlib.axes.Axes
+        Axes object with the design matrix plot.
+    """
+    import matplotlib.pyplot as plt
+    from matplotlib.colors import CenteredNorm
+
+    values, labels, frame_times = _design_matrix_values_and_labels(design_matrix)
+    n_columns = values.shape[1]
+
+    text_color = fg_color if fg_color is not None else _auto_fg_color(bg_color)
+    title_fontsize, label_fontsize, tick_fontsize = _resolve_font_sizes(fontsize)
+
+    if ax is None:
+        # Floor the width so a few-regressor design does not render as a sliver.
+        width = max(4.0, column_width * n_columns)
+        figure, ax = plt.subplots(figsize=(width, height), layout="constrained")
+        figure.patch.set_facecolor(bg_color)
+    else:
+        figure = ax.figure
+    ax.set_facecolor(bg_color)
+
+    ax.imshow(
+        values,
+        aspect="auto",
+        interpolation="nearest",
+        cmap=cmap,
+        norm=CenteredNorm(),
+    )
+
+    ax.set_xticks(range(n_columns))
+    ax.xaxis.tick_top()  # Regressor names above the matrix.
+    if labels is not None:
+        ax.set_xticklabels(
+            labels,
+            rotation=45,
+            ha="left",
+            rotation_mode="anchor",
+            fontsize=tick_fontsize,
+            color=text_color,
+        )
+    if index_yaxis and frame_times is not None:
+        # Rows are drawn at integer positions 0..n-1; relabel the auto-placed y ticks
+        # with the corresponding acquisition time rather than the raw volume index.
+        from matplotlib.ticker import FuncFormatter
+
+        default_ylabel = "Time (s)"
+        ax.yaxis.set_major_formatter(
+            FuncFormatter(
+                lambda pos, _: (
+                    f"{frame_times[round(pos)]:g}"
+                    if 0 <= round(pos) < len(frame_times)
+                    else ""
+                )
+            )
+        )
+    else:
+        default_ylabel = "Volume"
+    ax.set_ylabel(
+        yaxis_label if yaxis_label is not None else default_ylabel,
+        color=text_color,
+        fontsize=label_fontsize,
+    )
+    ax.tick_params(colors=text_color)
+    for spine in ax.spines.values():
+        spine.set_color(text_color)
 
     if title:
         ax.set_title(title, color=text_color, fontsize=title_fontsize)

--- a/src/confusius/plotting/matrix.py
+++ b/src/confusius/plotting/matrix.py
@@ -671,6 +671,26 @@ def plot_matrix(
     return figure, ax
 
 
+def _clear_matrix_plot_axes(ax: "Axes") -> None:
+    """Clear an Axes and remove any colorbar attached by this module.
+
+    Parameters
+    ----------
+    ax : matplotlib.axes.Axes
+        Axes to clear.
+
+    Returns
+    -------
+    None
+        The Axes is cleared in place.
+    """
+    colorbar = getattr(ax, "_confusius_matrix_colorbar", None)
+    if colorbar is not None:
+        colorbar.remove()
+        delattr(ax, "_confusius_matrix_colorbar")
+    ax.clear()
+
+
 def plot_contrast_matrix(
     contrast_def: "str | npt.NDArray[Any]",
     design_matrix: "pd.DataFrame | npt.NDArray[Any]",
@@ -732,7 +752,7 @@ def plot_contrast_matrix(
         provided. The width is `column_width * n_regressors`, floored at 4 inches.
     ax : matplotlib.axes.Axes, optional
         Axes to plot on. If not provided, creates a new figure and axes sized from
-        `row_height` and `column_width`.
+        `row_height` and `column_width`. If provided, the Axes is cleared before plotting.
 
     Returns
     -------
@@ -778,7 +798,7 @@ def plot_contrast_matrix(
         figure.patch.set_facecolor(bg_color)
     else:
         figure = ax.figure
-        ax.clear()
+        _clear_matrix_plot_axes(ax)
     ax.set_facecolor(bg_color)
 
     # Equal aspect keeps each weight a square cell, so the strip stays a thin band and a
@@ -824,6 +844,7 @@ def plot_contrast_matrix(
         # and lands the colorbar on top of the strip. A lower-than-default aspect
         # widens the bar a little.
         cbar = figure.colorbar(image, ax=ax, aspect=12)
+        ax.__dict__["_confusius_matrix_colorbar"] = cbar
         _style_colorbar(
             cbar,
             text_color,
@@ -947,7 +968,7 @@ def plot_design_matrix(
         provided. The width is `column_width * n_regressors`, floored at 4 inches.
     ax : matplotlib.axes.Axes, optional
         Axes to plot on. If not provided, creates a new figure and axes sized from
-        `height` and `column_width`.
+        `height` and `column_width`. If provided, the Axes is cleared before plotting.
 
     Returns
     -------
@@ -972,7 +993,7 @@ def plot_design_matrix(
         figure.patch.set_facecolor(bg_color)
     else:
         figure = ax.figure
-        ax.clear()
+        _clear_matrix_plot_axes(ax)
     ax.set_facecolor(bg_color)
 
     ax.imshow(

--- a/src/confusius/plotting/matrix.py
+++ b/src/confusius/plotting/matrix.py
@@ -778,6 +778,7 @@ def plot_contrast_matrix(
         figure.patch.set_facecolor(bg_color)
     else:
         figure = ax.figure
+        ax.clear()
     ax.set_facecolor(bg_color)
 
     # Equal aspect keeps each weight a square cell, so the strip stays a thin band and a
@@ -971,6 +972,7 @@ def plot_design_matrix(
         figure.patch.set_facecolor(bg_color)
     else:
         figure = ax.figure
+        ax.clear()
     ax.set_facecolor(bg_color)
 
     ax.imshow(

--- a/tests/unit/test_plotting/test_matrix.py
+++ b/tests/unit/test_plotting/test_matrix.py
@@ -4,10 +4,26 @@ See conftest.py for the matplotlib_pyplot fixture setup.
 """
 
 import numpy as np
+import pandas as pd
 import pytest
 import xarray as xr
 
-from confusius.plotting import plot_matrix
+from confusius.plotting import plot_contrast_matrix, plot_design_matrix, plot_matrix
+
+
+def _design_matrix(
+    n_columns: int = 4,
+    n_volumes: int = 20,
+    names: list[str] | None = None,
+    volume_times: np.ndarray | None = None,
+) -> pd.DataFrame:
+    columns = names if names is not None else [f"reg_{i}" for i in range(n_columns)]
+    rng = np.random.default_rng(0)
+    return pd.DataFrame(
+        rng.standard_normal((n_volumes, len(columns))),
+        columns=columns,
+        index=volume_times,
+    )
 
 
 def _correlation_matrix(size: int = 6) -> np.ndarray:
@@ -365,3 +381,108 @@ class TestPlotMatrixVisualRegression:
             show_colorbar=False,
         )
         return fig
+
+
+class TestPlotDesignMatrix:
+    """Behaviour of plot_design_matrix."""
+
+    def test_non_2d_input_raises(self, matplotlib_pyplot):
+        """A design matrix that is not 2D raises ValueError."""
+        with pytest.raises(ValueError, match="2D design matrix"):
+            plot_design_matrix(np.zeros(5))
+
+    def test_dataframe_columns_become_xticklabels(self, matplotlib_pyplot):
+        """A DataFrame's column names label the regressor ticks, in order."""
+        names = ["active", "drift", "constant"]
+        _, ax = plot_design_matrix(_design_matrix(names=names))
+        assert [t.get_text() for t in ax.get_xticklabels()] == names
+
+    def test_ndarray_input_gets_one_tick_per_column(self, matplotlib_pyplot):
+        """A bare array (no column names) still gets one x-tick per regressor."""
+        _, ax = plot_design_matrix(np.zeros((20, 5)))
+        assert ax.get_xticks().size == 5
+
+    def test_width_scales_with_column_count(self, matplotlib_pyplot):
+        """The auto-sized figure width grows with the number of regressors."""
+        narrow, _ = plot_design_matrix(_design_matrix(n_columns=12), column_width=1.0)
+        # 12 regressors * 1.0 in each == 12 in.
+        assert narrow.get_figwidth() == pytest.approx(12.0)
+
+    def test_width_floored_for_few_columns(self, matplotlib_pyplot):
+        """A few-regressor design is floored at 4 inches, not a sliver."""
+        fig, _ = plot_design_matrix(_design_matrix(n_columns=2), column_width=1.0)
+        assert fig.get_figwidth() == pytest.approx(4.0)
+
+    def test_time_index_labels_y_axis_with_seconds(self, matplotlib_pyplot):
+        """index_yaxis=True relabels the y-axis with the DataFrame's acquisition times."""
+        times = np.arange(20) * 2.0  # 2 s TR.
+        _, ax = plot_design_matrix(_design_matrix(volume_times=times), index_yaxis=True)
+        assert ax.get_ylabel() == "Time (s)"
+        # Row position 3 maps to its acquisition time (3 * 2 s), not the raw index.
+        assert ax.yaxis.get_major_formatter()(3, None) == "6"
+
+    def test_rangeindex_falls_back_to_volume_index(self, matplotlib_pyplot):
+        """A trivial RangeIndex has no time index, so index_yaxis=True still shows volumes."""
+        _, ax = plot_design_matrix(_design_matrix(), index_yaxis=True)
+        assert ax.get_ylabel() == "Volume"
+
+    def test_index_yaxis_false_forces_volume_axis(self, matplotlib_pyplot):
+        """index_yaxis=False shows the volume index even when a time index exists."""
+        times = np.arange(20) * 2.0
+        _, ax = plot_design_matrix(
+            _design_matrix(volume_times=times), index_yaxis=False
+        )
+        assert ax.get_ylabel() == "Volume"
+
+    def test_yaxis_label_overrides_default(self, matplotlib_pyplot):
+        """yaxis_label replaces the automatic "Time (s)"/"Volume" label."""
+        times = np.arange(20) * 2.0
+        _, ax = plot_design_matrix(
+            _design_matrix(volume_times=times), index_yaxis=True, yaxis_label="Frame"
+        )
+        assert ax.get_ylabel() == "Frame"
+
+
+class TestPlotContrastMatrix:
+    """Behaviour of plot_contrast_matrix."""
+
+    def test_string_expression_resolves_against_columns(self, matplotlib_pyplot):
+        """A string contrast resolves to weights over the DataFrame's columns."""
+        design = _design_matrix(names=["stim_A", "stim_B", "drift", "constant"])
+        _, ax = plot_contrast_matrix("stim_A - stim_B", design)
+        np.testing.assert_array_equal(ax.images[0].get_array(), [[1.0, -1.0, 0.0, 0.0]])
+        assert [t.get_text() for t in ax.get_xticklabels()] == list(design.columns)
+
+    def test_gray_cmap_with_symmetric_range_around_zero(self, matplotlib_pyplot):
+        """Weights use a gray cmap on a symmetric [-max|w|, max|w|] range."""
+        _, ax = plot_contrast_matrix(np.array([2.0, -1.0, 0.0, 0.0]), _design_matrix())
+        image = ax.images[0]
+        assert image.cmap.name == "gray"
+        assert image.norm.vmin == pytest.approx(-2.0)
+        assert image.norm.vmax == pytest.approx(2.0)
+
+    def test_f_contrast_matrix_gets_one_row_each(self, matplotlib_pyplot):
+        """A 2D F-contrast draws one heatmap row per contrast, with a row axis."""
+        f_contrast = np.array([[1.0, -1.0, 0.0, 0.0], [0.0, 0.0, 1.0, -1.0]])
+        _, ax = plot_contrast_matrix(f_contrast, _design_matrix())
+        assert ax.images[0].get_array().shape == (2, 4)
+        assert ax.get_yticks().size == 2
+
+    def test_short_vector_is_zero_padded_to_design_width(self, matplotlib_pyplot):
+        """A contrast narrower than the design is zero-padded on the right."""
+        _, ax = plot_contrast_matrix(np.array([1.0, -1.0]), _design_matrix(n_columns=4))
+        np.testing.assert_array_equal(ax.images[0].get_array(), [[1.0, -1.0, 0.0, 0.0]])
+
+    def test_string_contrast_with_bare_array_raises(self, matplotlib_pyplot):
+        """A string contrast needs named columns; a bare array design raises."""
+        with pytest.raises(ValueError, match="named columns"):
+            plot_contrast_matrix("a - b", np.zeros((20, 4)))
+
+    def test_colorbar_sits_beside_the_strip(self, matplotlib_pyplot):
+        """show_colorbar places the colorbar next to the strip, not on top of it."""
+        fig, ax = plot_contrast_matrix(
+            np.array([1.0, -1.0, 0.0, 0.0]), _design_matrix(), show_colorbar=True
+        )
+        cbar_ax = next(axis for axis in fig.axes if axis is not ax)
+        fig.canvas.draw()  # constrained layout finalizes positions only on draw.
+        assert cbar_ax.get_position().x0 >= ax.get_position().x1

--- a/tests/unit/test_plotting/test_matrix.py
+++ b/tests/unit/test_plotting/test_matrix.py
@@ -421,8 +421,9 @@ class TestPlotDesignMatrix:
         times = np.arange(20) * 2.0  # 2 s TR.
         _, ax = plot_design_matrix(_design_matrix(volume_times=times), index_yaxis=True)
         assert ax.get_ylabel() == "Time (s)"
-        # Row position 3 maps to its acquisition time (3 * 2 s), not the raw index.
+        # Row positions map to acquisition time, including auto-placed half-row ticks.
         assert ax.yaxis.get_major_formatter()(3, None) == "6"
+        assert ax.yaxis.get_major_formatter()(2.5, None) == "5"
 
     def test_rangeindex_falls_back_to_volume_index(self, matplotlib_pyplot):
         """A trivial RangeIndex has no time index, so index_yaxis=True still shows volumes."""

--- a/tests/unit/test_plotting/test_matrix.py
+++ b/tests/unit/test_plotting/test_matrix.py
@@ -445,6 +445,16 @@ class TestPlotDesignMatrix:
         )
         assert ax.get_ylabel() == "Frame"
 
+    def test_reuses_provided_axes_and_sets_title(self, matplotlib_pyplot):
+        """Draws on a caller-provided Axes and sets the title on it."""
+        fig, ax = matplotlib_pyplot.subplots()
+        returned_fig, returned_ax = plot_design_matrix(
+            _design_matrix(), title="design", ax=ax
+        )
+        assert returned_ax is ax
+        assert returned_fig is fig
+        assert ax.get_title() == "design"
+
 
 class TestPlotContrastMatrix:
     """Behaviour of plot_contrast_matrix."""
@@ -491,3 +501,20 @@ class TestPlotContrastMatrix:
         cbar_ax = next(axis for axis in fig.axes if axis is not ax)
         fig.canvas.draw()  # constrained layout finalizes positions only on draw.
         assert cbar_ax.get_position().x0 >= ax.get_position().x1
+
+    def test_reuses_provided_axes_and_sets_title(self, matplotlib_pyplot):
+        """Draws on a caller-provided Axes and sets the title on it."""
+        fig, ax = matplotlib_pyplot.subplots()
+        returned_fig, returned_ax = plot_contrast_matrix(
+            np.array([1.0, -1.0, 0.0, 0.0]), _design_matrix(), title="A vs B", ax=ax
+        )
+        assert returned_ax is ax
+        assert returned_fig is fig
+        assert ax.get_title() == "A vs B"
+
+    def test_all_zero_contrast_uses_symmetric_unit_range(self, matplotlib_pyplot):
+        """An all-zero contrast falls back to a symmetric [-1, 1] range, not vmin==vmax."""
+        _, ax = plot_contrast_matrix(np.zeros(4), _design_matrix())
+        image = ax.images[0]
+        assert image.norm.vmin == pytest.approx(-1.0)
+        assert image.norm.vmax == pytest.approx(1.0)

--- a/tests/unit/test_plotting/test_matrix.py
+++ b/tests/unit/test_plotting/test_matrix.py
@@ -8,6 +8,7 @@ import pandas as pd
 import pytest
 import xarray as xr
 from matplotlib.figure import Figure
+from matplotlib.ticker import ScalarFormatter
 
 from confusius.plotting import plot_contrast_matrix, plot_design_matrix, plot_matrix
 
@@ -456,6 +457,19 @@ class TestPlotDesignMatrix:
         assert returned_fig is fig
         assert ax.get_title() == "design"
 
+    def test_reused_axes_do_not_keep_stale_ticks(self, matplotlib_pyplot):
+        """A second plot on the same Axes resets labels and formatters."""
+        fig, ax = matplotlib_pyplot.subplots()
+        times = np.arange(20) * 2.0
+        plot_design_matrix(_design_matrix(volume_times=times), index_yaxis=True, ax=ax)
+
+        plot_design_matrix(np.zeros((20, 2)), ax=ax)
+        fig.canvas.draw()
+
+        assert isinstance(ax.yaxis.get_major_formatter(), ScalarFormatter)
+        assert [t.get_text() for t in ax.get_xticklabels()] == ["0", "1"]
+        assert len(ax.images) == 1
+
 
 class TestPlotContrastMatrix:
     """Behaviour of plot_contrast_matrix."""
@@ -512,6 +526,17 @@ class TestPlotContrastMatrix:
         assert returned_ax is ax
         assert returned_fig is fig
         assert ax.get_title() == "A vs B"
+
+    def test_reused_axes_do_not_keep_stale_ticks(self, matplotlib_pyplot):
+        """A second contrast plot on the same Axes resets labels and images."""
+        fig, ax = matplotlib_pyplot.subplots()
+        plot_contrast_matrix(np.array([1.0, 0.0, 0.0]), _design_matrix(n_columns=3), ax=ax)
+
+        plot_contrast_matrix(np.array([1.0, 0.0]), np.zeros((20, 2)), ax=ax)
+        fig.canvas.draw()
+
+        assert [t.get_text() for t in ax.get_xticklabels()] == ["0", "1"]
+        assert len(ax.images) == 1
 
     def test_all_zero_contrast_uses_symmetric_unit_range(self, matplotlib_pyplot):
         """An all-zero contrast falls back to a symmetric [-1, 1] range, not vmin==vmax."""

--- a/tests/unit/test_plotting/test_matrix.py
+++ b/tests/unit/test_plotting/test_matrix.py
@@ -528,15 +528,21 @@ class TestPlotContrastMatrix:
         assert ax.get_title() == "A vs B"
 
     def test_reused_axes_do_not_keep_stale_ticks(self, matplotlib_pyplot):
-        """A second contrast plot on the same Axes resets labels and images."""
+        """A second contrast plot on the same Axes resets labels, images, and colorbar."""
         fig, ax = matplotlib_pyplot.subplots()
-        plot_contrast_matrix(np.array([1.0, 0.0, 0.0]), _design_matrix(n_columns=3), ax=ax)
+        plot_contrast_matrix(
+            np.array([1.0, 0.0, 0.0]),
+            _design_matrix(n_columns=3),
+            ax=ax,
+            show_colorbar=True,
+        )
 
         plot_contrast_matrix(np.array([1.0, 0.0]), np.zeros((20, 2)), ax=ax)
         fig.canvas.draw()
 
         assert [t.get_text() for t in ax.get_xticklabels()] == ["0", "1"]
         assert len(ax.images) == 1
+        assert fig.axes == [ax]
 
     def test_all_zero_contrast_uses_symmetric_unit_range(self, matplotlib_pyplot):
         """An all-zero contrast falls back to a symmetric [-1, 1] range, not vmin==vmax."""

--- a/tests/unit/test_plotting/test_matrix.py
+++ b/tests/unit/test_plotting/test_matrix.py
@@ -7,6 +7,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
+from matplotlib.figure import Figure
 
 from confusius.plotting import plot_contrast_matrix, plot_design_matrix, plot_matrix
 
@@ -405,12 +406,14 @@ class TestPlotDesignMatrix:
     def test_width_scales_with_column_count(self, matplotlib_pyplot):
         """The auto-sized figure width grows with the number of regressors."""
         narrow, _ = plot_design_matrix(_design_matrix(n_columns=12), column_width=1.0)
+        assert isinstance(narrow, Figure)
         # 12 regressors * 1.0 in each == 12 in.
         assert narrow.get_figwidth() == pytest.approx(12.0)
 
     def test_width_floored_for_few_columns(self, matplotlib_pyplot):
         """A few-regressor design is floored at 4 inches, not a sliver."""
         fig, _ = plot_design_matrix(_design_matrix(n_columns=2), column_width=1.0)
+        assert isinstance(fig, Figure)
         assert fig.get_figwidth() == pytest.approx(4.0)
 
     def test_time_index_labels_y_axis_with_seconds(self, matplotlib_pyplot):
@@ -465,7 +468,9 @@ class TestPlotContrastMatrix:
         """A 2D F-contrast draws one heatmap row per contrast, with a row axis."""
         f_contrast = np.array([[1.0, -1.0, 0.0, 0.0], [0.0, 0.0, 1.0, -1.0]])
         _, ax = plot_contrast_matrix(f_contrast, _design_matrix())
-        assert ax.images[0].get_array().shape == (2, 4)
+        array = ax.images[0].get_array()
+        assert array is not None
+        assert array.shape == (2, 4)
         assert ax.get_yticks().size == 2
 
     def test_short_vector_is_zero_padded_to_design_width(self, matplotlib_pyplot):


### PR DESCRIPTION
Closes #330.

- Add `plot_design_matrix` to `confusius.plotting`: renders a first-level GLM design matrix as a heatmap with regressor names along the top at 45° on a zero-centered norm, with an optional acquisition-time y-axis (`index_yaxis`, read from the DataFrame index) and a customizable `yaxis_label`, falling back to the integer volume index otherwise.
- Add `plot_contrast_matrix` to `confusius.plotting`: visualizes a GLM contrast — a string expression or a numeric vector/matrix, the same `contrast_def` accepted by `FirstLevelModel.compute_contrast` — as a gray weight strip aligned with the design regressors on a symmetric range, with an optional colorbar.
- Reuse the existing `resolve_contrast_vector` helper from `confusius.glm` so `plot_contrast_matrix` accepts exactly the same contrast definitions as the model, including string-expression parsing and zero-padding, rather than duplicating that logic.
- Add unit tests covering both helpers and changelog entries under `0.6.0.dev0`.