### PR TITLE
docs: unify user guide output formatting

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -90,6 +90,14 @@ Apply the same citation replacements as in `README.md`.
 Update any other release/version/date files only if they actually exist and clearly need to
 track the release version.
 
+### `docs/user-guide/installation.md`
+Replace the confusius development version with the final version. Example
+
+```
+>>> print(cf.__version__)
+0.6.0
+```
+
 ### Step 3 — Sync and verify
 
 Run:

--- a/docs/user-guide/atlas.md
+++ b/docs/user-guide/atlas.md
@@ -77,12 +77,9 @@ contain layers. [`show_tree`][confusius.atlas.AtlasAccessor.show_tree] prints th
 hierarchy, and its `nid` argument restricts the printout to one branch, which is handy
 since the full Allen tree has well over a thousand nodes:
 
-```python
-# Print just the hippocampus (HIP, id 1080) subtree.
-atlas.atlas.show_tree(nid=1080)
-```
-
-```text
+```pycon
+>>> # Print just the hippocampus (HIP, id 1080) subtree.
+>>> atlas.atlas.show_tree(nid=1080)
 HIP (1080)
 ├── CA (375)
 │   ├── CA1 (382)

--- a/docs/user-guide/beamformed-iq.md
+++ b/docs/user-guide/beamformed-iq.md
@@ -102,15 +102,11 @@ Additionally, ConfUSIus expects certain metadata attributes to be present:
     data has the required structure and attributes. See [Other Systems](io.md#other-systems)
     for details.
 
-```python
-import xarray as xr
-
-iq = cf.load("sub-01_task-rest_iq.zarr")
-
-print(iq)
-```
-
-```text
+```pycon
+>>> import xarray as xr
+>>>
+>>> iq = cf.load("sub-01_task-rest_iq.zarr")
+>>> iq
 <xarray.DataArray 'iq' (time: 50000, z: 1, y: 118, x: 52)> Size: 24GB
 dask.array<...>
 Coordinates:
@@ -540,11 +536,8 @@ function or the corresponding Xarray accessor method.
 The resulting power Doppler DataArray will be backed by a Dask array (even if the input
 wasn't Dask-backed) and rely on lazy evaluation.
 
-```python
-print(pwd)
-```
-
-```text
+```pycon
+>>> pwd
 <xarray.DataArray 'power_doppler' (time: 860, z: 1, y: 128, x: 86)> Size: 76MB
 dask.array<...>
 Coordinates:
@@ -570,12 +563,9 @@ Attributes: (11/16)
 To actually compute the power Doppler values and load them into memory, you must call
 `.compute()`:
 
-```python
-pwd = pwd.compute()
-print(pwd)
-```
-
-```text
+```pycon
+>>> pwd = pwd.compute()
+>>> pwd
 <xarray.DataArray 'power_doppler' (time: 860, z: 1, y: 128, x: 86)> Size: 76MB
 array([[[[74.26474299, 76.99585806, 84.46316397, ..., 79.11284661,
           77.6835962 , 69.19274666],
@@ -651,11 +641,8 @@ function or the corresponding Xarray accessor method.
 The resulting axial velocity DataArray will be backed by a Dask array (even if the input
 wasn't Dask-backed) and rely on lazy evaluation.
 
-```python
-print(velocity)
-```
-
-```text
+```pycon
+>>> velocity
 <xarray.DataArray (time: 1000, z: 1, y: 118, x: 52)> Size: 24MB
 dask.array<...>
 Coordinates:

--- a/docs/user-guide/datasets.md
+++ b/docs/user-guide/datasets.md
@@ -21,28 +21,28 @@ root directory, or a more specific object (e.g., a DataArray for templates or an
 The fastest way to get started is to fetch a single subject from the Nunez-Elizalde
 2022 dataset[^nunez2022] and load one of its NIfTI files:
 
-```python
-import confusius as cf
-from confusius.datasets import fetch_nunez_elizalde_2022
-
-# Download data for one mouse, one task, one brain slice (~30 MB).
-root = fetch_nunez_elizalde_2022(
-    subjects=["CR020"],
-    sessions=["20191122"],
-    tasks=["spontaneous"], 
-    acqs=["slice03"],
-)
-
-# Load a power Doppler acquisition from the returned BIDS tree.
-pwd = cf.load(
-   root 
-    / "sub-CR020"
-    / "ses-20191122"
-    / "fusi"
-    / "sub-CR020_ses-20191122_task-spontaneous_acq-slice03_pwd.nii.gz"
-)
-print(pwd.dims)
-# Output: ('time', 'z', 'y', 'x')
+```pycon
+>>> import confusius as cf
+>>> from confusius.datasets import fetch_nunez_elizalde_2022
+>>>
+>>> # Download data for one mouse, one task, one brain slice (~30 MB).
+>>> root = fetch_nunez_elizalde_2022(
+...     subjects=["CR020"],
+...     sessions=["20191122"],
+...     tasks=["spontaneous"],
+...     acqs=["slice03"],
+... )
+>>>
+>>> # Load a power Doppler acquisition from the returned BIDS tree.
+>>> pwd = cf.load(
+...    root
+...     / "sub-CR020"
+...     / "ses-20191122"
+...     / "fusi"
+...     / "sub-CR020_ses-20191122_task-spontaneous_acq-slice03_pwd.nii.gz"
+... )
+>>> pwd.dims
+('time', 'z', 'y', 'x')
 ```
 
 
@@ -58,11 +58,10 @@ ConfUSIus resolves the cache directory using the following priority chain:
 You can inspect the resolved directory at any time with
 [`get_datasets_dir`][confusius.datasets.get_datasets_dir]:
 
-```python
-from confusius.datasets import get_datasets_dir
-
-print(get_datasets_dir())
-# /home/alice/.cache/confusius
+```pycon
+>>> from confusius.datasets import get_datasets_dir
+>>> get_datasets_dir()
+PosixPath('/home/alice/.cache/confusius')
 ```
 
 Each fetcher creates its own BIDS-root subdirectory under this path (e.g.
@@ -73,13 +72,10 @@ Each fetcher creates its own BIDS-root subdirectory under this path (e.g.
 Use [`list_datasets`][confusius.datasets.list_datasets] to print a table of available
 fetchers and their full download sizes:
 
-```python
-from confusius.datasets import list_datasets
-
-list_datasets()
-```
-
-```text
+```pycon
+>>> from confusius.datasets import list_datasets
+>>>
+>>> list_datasets()
                    Available Datasets
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━┓
 ┃ Fetch function                   ┃     Size ┃ On disk ┃

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -29,10 +29,10 @@ Please find all development installation instructions on the
 To verify that ConfUSIus has been installed correctly, you may run the following code
 snippet in a Python environment:
 
-```python
-import confusius as cf
-
-print(cf.__version__)
+```pycon
+>>> import confusius as cf
+>>> print(cf.__version__)
+'0.6.0.dev0'
 ```
 
 If the installation was successful, this code will print the installed version of

--- a/docs/user-guide/io.md
+++ b/docs/user-guide/io.md
@@ -235,32 +235,16 @@ an operation requires it.
 
 Once your data is in Zarr format, load it with [`confusius.load`][confusius.load]:
 
-```python
-import confusius as cf
-
-# Load beamformed IQ data (returns the first variable as a DataArray by default).
-iq_data = cf.load("sub-01_task-awake_iq.zarr")
-
-# Or specify the variable name if there are multiple variables in the Zarr store.
-iq_data = cf.load("sub-01_task-awake_iq.zarr", variable="iq")
-
-print(iq_data)
-```
-
-!!! question "Loading a full Dataset"
-    [`confusius.load`][confusius.load] always returns a single DataArray. To load all
-    variables in a Zarr store as a Dataset, use [`xarray.open_zarr`][xarray.open_zarr]
-    directly:
-
-    ```python
-    import xarray as xr
-
-    ds = xr.open_zarr("sub-01_task-awake_iq.zarr")
-    ```
-
-This returns an DataArray lazily loaded from the Zarr store, ready for processing:
-
-```text
+```pycon
+>>> import confusius as cf
+>>>
+>>> # Load beamformed IQ data (returns the first variable as a DataArray by default).
+>>> iq_data = cf.load("sub-01_task-awake_iq.zarr")
+>>>
+>>> # Or specify the variable name if there are multiple variables in the Zarr store.
+>>> iq_data = cf.load("sub-01_task-awake_iq.zarr", variable="iq")
+>>>
+>>> iq_data
 <xarray.DataArray 'iq' (time: 1168500, z: 1, y: 118, x: 52)> Size: 57GB
 dask.array<open_dataset-iq, shape=(1168500, 1, 118, 52), dtype=complex64, chunksize=(300, 1, 118, 52), chunktype=numpy.ndarray>
 Coordinates:
@@ -278,6 +262,17 @@ Attributes:
     pulse_repetition_frequency:     15000.0
     beamforming_method:             Fourier
 ```
+
+!!! question "Loading a full Dataset"
+    [`confusius.load`][confusius.load] always returns a single DataArray. To load all
+    variables in a Zarr store as a Dataset, use [`xarray.open_zarr`][xarray.open_zarr]
+    directly:
+
+    ```python
+    import xarray as xr
+
+    ds = xr.open_zarr("sub-01_task-awake_iq.zarr")
+    ```
 
 Notice that the data remains on disk (shown by `dask.array<...>`) until you explicitly
 compute operations on it.
@@ -304,24 +299,20 @@ All spatial coordinates are in millimeters; the `time` coordinate is in seconds.
 
 === "2Dscan"
 
-    ```python
-    import confusius as cf
-
-    da = cf.load("sub-01_task-awake_pwd.source.scan")
-
-    print(da.dims)
-    # Output: ('time', 'z', 'y', 'x')
+    ```pycon
+    >>> import confusius as cf
+    >>> da = cf.load("sub-01_task-awake_pwd.source.scan")
+    >>> da.dims
+    ('time', 'z', 'y', 'x')
     ```
 
 === "3Dscan"
 
-    ```python
-    import confusius as cf
-
-    da = cf.load("sub-01_acq-anat_pwd.source.scan")
-
-    print(da.dims)
-    # Output: ('pose', 'z', 'y', 'x')
+    ```pycon
+    >>> import confusius as cf
+    >>> da = cf.load("sub-01_acq-anat_pwd.source.scan")
+    >>> da.dims
+    ('pose', 'z', 'y', 'x')
     ```
 
     The `pose` dimension indexes each probe position in the multi-pose acquisition.
@@ -330,13 +321,11 @@ All spatial coordinates are in millimeters; the `time` coordinate is in seconds.
 
 === "4Dscan"
 
-    ```python
-    import confusius as cf
-
-    da = cf.load("sub-01_task-awake_pwd.source.scan")
-
-    print(da.dims)
-    # Output: ('time', 'pose', 'z', 'y', 'x')
+    ```pycon
+    >>> import confusius as cf
+    >>> da = cf.load("sub-01_task-awake_pwd.source.scan")
+    >>> da.dims
+    ('time', 'pose', 'z', 'y', 'x')
     ```
 
     In addition to the `time` coordinate (earliest timestamp per block), a
@@ -480,13 +469,13 @@ saving, or save each pose separately if you want to retain the multi-pose struct
 
 Use [`confusius.load`][confusius.load] to load NIfTI files as lazy Xarray DataArrays:
 
-```python
-import confusius as cf
-
-# Load with automatic fUSI-BIDS sidecar metadata.
-da = cf.load("sub-01_task-awake_pwd.nii.gz")
-print(da.dims)
-# Output: ('time', 'z', 'y', 'x')
+```pycon
+>>> import confusius as cf
+>>>
+>>> # Load with automatic fUSI-BIDS sidecar metadata.
+>>> da = cf.load("sub-01_task-awake_pwd.nii.gz")
+>>> da.dims
+('time', 'z', 'y', 'x')
 ```
 
 ConfUSIus automatically loads a JSON sidecar file with the same basename (e.g.,

--- a/docs/user-guide/multipose.md
+++ b/docs/user-guide/multipose.md
@@ -53,14 +53,10 @@ elevation slices per pose—translated across multiple regularly spaced position
 
 === "3Dscan (anatomical)"
 
-    ```python
-    from confusius.io import load_scan
-
-    anat = load_scan("sub-01_acq-anat_pwd.scan")
-    print(anat)
-    ```
-
-    ```text
+    ```pycon
+    >>> from confusius.io import load_scan
+    >>> anat = load_scan("sub-01_acq-anat_pwd.scan")
+    >>> anat
     <xarray.DataArray 'scan_data' (pose: 15, z: 4, y: 72, x: 64)> Size: 2MB
     dask.array<transpose, shape=(15, 4, 72, 64), dtype=float64, chunksize=(15, 4, 72, 64), chunktype=numpy.ndarray>
     Coordinates:
@@ -79,14 +75,10 @@ elevation slices per pose—translated across multiple regularly spaced position
 
 === "4Dscan (functional)"
 
-    ```python
-    from confusius.io import load_scan
-
-    fus = load_scan("sub-01_task-awake_pwd.scan")
-    print(fus)
-    ```
-
-    ```text
+    ```pycon
+    >>> from confusius.io import load_scan
+    >>> fus = load_scan("sub-01_task-awake_pwd.scan")
+    >>> fus
     <xarray.DataArray 'scan_data' (time: 750, pose: 4, z: 4, y: 72, x: 64)> Size: 442MB
     dask.array<transpose, shape=(750, 4, 4, 72, 64), dtype=float64, chunksize=(227, 4, 4, 72, 64), chunktype=numpy.ndarray>
     Coordinates:
@@ -152,15 +144,11 @@ steps:
 
 === "3Dscan (anatomical)"
 
-    ```python
-    import confusius as cf
-
-    anat = cf.load("sub-01_acq-anat_pwd.scan")
-    volume = cf.multipose.consolidate_poses(anat)
-    print(volume)
-    ```
-
-    ```text
+    ```pycon
+    >>> import confusius as cf
+    >>> anat = cf.load("sub-01_acq-anat_pwd.scan")
+    >>> volume = cf.multipose.consolidate_poses(anat)
+    >>> volume
     <xarray.DataArray 'scan_data' (z: 60, y: 72, x: 64)> Size: 2MB
     array([...])
     Coordinates:
@@ -178,15 +166,11 @@ steps:
 
 === "4Dscan (functional)"
 
-    ```python
-    import confusius as cf
-
-    fus = cf.load("sub-01_task-awake_pwd.scan")
-    volume = cf.multipose.consolidate_poses(fus)
-    print(volume)
-    ```
-
-    ```text
+    ```pycon
+    >>> import confusius as cf
+    >>> fus = cf.load("sub-01_task-awake_pwd.scan")
+    >>> volume = cf.multipose.consolidate_poses(fus)
+    >>> volume
     <xarray.DataArray 'scan_data' (time: 750, z: 16, y: 72, x: 64)> Size: 442MB
     array([...])
     Coordinates:

--- a/docs/user-guide/spatial-conventions.md
+++ b/docs/user-guide/spatial-conventions.md
@@ -251,21 +251,24 @@ The following example uses an axis-aligned `sform`, so `physical_to_sform` is th
 identity. The `qform` is shifted by +10 along `z` and +5 along `y` relative to the
 `sform`, so `physical_to_qform` contains only a translation:
 
-```python
-da.coords["z"].values  # array([0., 1., 2.])
-da.coords["y"].values  # array([0., 1., 2., 3.])
-
-da.attrs["affines"]["physical_to_sform"]  # identity
-# array([[ 1.,  0.,  0.,  0.],
-#        [ 0.,  1.,  0.,  0.],
-#        [ 0.,  0.,  1.,  0.],
-#        [ 0.,  0.,  0.,  1.]])
-
-da.attrs["affines"]["physical_to_qform"]  # (+10, +5) shift in (z, y):
-# array([[ 1.,  0.,  0., 10.],
-#        [ 0.,  1.,  0.,  5.],
-#        [ 0.,  0.,  1.,  0.],
-#        [ 0.,  0.,  0.,  1.]])
+```pycon
+>>> da.coords["z"].values
+array([0., 1., 2.])
+>>>
+>>> da.coords["y"].values
+array([0., 1., 2., 3.])
+>>>
+>>> da.attrs["affines"]["physical_to_sform"]  # identity
+array([[1., 0., 0., 0.],
+       [0., 1., 0., 0.],
+       [0., 0., 1., 0.],
+       [0., 0., 0., 1.]])
+>>>
+>>> da.attrs["affines"]["physical_to_qform"]  # (+10, +5) shift in (z, y):
+array([[ 1.,  0.,  0., 10.],
+       [ 0.,  1.,  0.,  5.],
+       [ 0.,  0.,  1.,  0.],
+       [ 0.,  0.,  0.,  1.]])
 ```
 
 Applying `physical_to_qform` absorbs the translation into the coordinate arrays. The
@@ -287,22 +290,30 @@ coordinates.
     da_q, orientation = da.fusi.affine.apply(da.attrs["affines"]["physical_to_qform"])
     ```
 
-```python
-da_q.coords["z"].values  # array([10., 11., 12.])   <- shifted by +10
-da_q.coords["y"].values  # array([5., 6., 7., 8.])  <- shifted by +5
-
-da_q.attrs["affines"]["physical_to_sform"]  # (-10, -5) shift back to sform
-# array([[ 1.,  0.,  0., -10.],
-#        [ 0.,  1.,  0.,  -5.],
-#        [ 0.,  0.,  1.,   0.],
-#        [ 0.,  0.,  0.,   1.]])
-
-da_q.attrs["affines"]["physical_to_qform"]  # identity, the new physical frame
-# array([[ 1.,  0.,  0.,  0.],
-#        [ 0.,  1.,  0.,  0.],
-#        [ 0.,  0.,  1.,  0.],
-#        [ 0.,  0.,  0.,  1.]])
-orientation                                 # identity, nothing left over
+```pycon
+>>> da_q.coords["z"].values
+array([10., 11., 12.])
+>>>
+>>> da_q.coords["y"].values
+array([5., 6., 7., 8.])
+>>>
+>>> da_q.attrs["affines"]["physical_to_sform"]  # (-10, -5) shift back to sform
+array([[  1.,   0.,   0., -10.],
+       [  0.,   1.,   0.,  -5.],
+       [  0.,   0.,   1.,   0.],
+       [  0.,   0.,   0.,   1.]])
+>>>
+>>> da_q.attrs["affines"]["physical_to_qform"]  # identity, the new physical frame
+array([[1., 0., 0., 0.],
+       [0., 1., 0., 0.],
+       [0., 0., 1., 0.],
+       [0., 0., 0., 1.]])
+>>> 
+>>> orientation  # identity, nothing left over
+array([[1., 0., 0., 0.],
+       [0., 1., 0., 0.],
+       [0., 0., 1., 0.],
+       [0., 0., 0., 1.]])
 ```
 
 Because `orientation` is the identity, the change of physical frame is complete.
@@ -313,32 +324,34 @@ Independent one-dimensional coordinate arrays cannot represent a transform that 
 axes. For example, consider a `physical_to_qform` containing a 90° rotation in the
 `(z, y)` plane:
 
-```python
-da.attrs["affines"]["physical_to_qform"]
-# array([[ 0., -1., 0., 0.],
-#        [ 1., 0., 0., 0.],
-#        [ 0., 0., 1., 0.],
-#        [ 0., 0., 0., 1.]])
+```pycon
+>>> da.attrs["affines"]["physical_to_qform"]
+array([[ 0., -1.,  0.,  0.],
+       [ 1.,  0.,  0.,  0.],
+       [ 0.,  0.,  1.,  0.],
+       [ 0.,  0.,  0.,  1.]])
 ```
 
 After calling [`.fusi.affine.apply`][confusius.xarray.FUSIAffineAccessor.apply], the
 coordinate arrays remain unchanged because none of this rotation can be represented as
 independent changes to `z`, `y`, and `x`:
 
-```python
-da_q, orientation = da.fusi.affine.apply(da.attrs["affines"]["physical_to_qform"])
-da_q.coords["z"].values  # array([0., 1., 2.])
-da_q.coords["y"].values  # array([0., 1., 2., 3.])
+```pycon
+>>> da_q, orientation = da.fusi.affine.apply(da.attrs["affines"]["physical_to_qform"])
+>>> da_q.coords["z"].values
+array([0., 1., 2.])
+>>> da_q.coords["y"].values
+array([0., 1., 2., 3.])
 ```
 
 The unabsorbed transform is returned as orientation:
 
-```python
-orientation
-# array([[ 0., -1., 0., 0.],
-#        [ 1.,  0., 0., 0.],
-#        [ 0.,  0., 1., 0.],
-#        [ 0.,  0., 0., 1.]])
+```pycon
+>>> orientation
+array([[ 0., -1.,  0.,  0.],
+       [ 1.,  0.,  0.,  0.],
+       [ 0.,  0.,  1.,  0.],
+       [ 0.,  0.,  0.,  1.]])
 ```
 
 Because the residual is non-identity, the DataArray has not been fully re-anchored to

--- a/docs/user-guide/xarray.md
+++ b/docs/user-guide/xarray.md
@@ -47,15 +47,12 @@ Xarray has two core data structures: Dataset and DataArray.
 A **[Dataset][xarray.Dataset]** is a dictionary-like container of multiple named arrays that share
 the same coordinate system. When you open a Zarr archive, you get a Dataset:
 
-```python
-import xarray as xr
-import confusius
-
-ds = xr.open_zarr("power_doppler.zarr")
-ds
-```
-
-```
+```pycon
+>>> import xarray as xr
+>>> import confusius
+>>> 
+>>> ds = xr.open_zarr("power_doppler.zarr")
+>>> ds
 <xarray.Dataset> Size: 76MB
 Dimensions:        (time: 860, z: 1, y: 128, x: 86)
 Coordinates:
@@ -72,12 +69,9 @@ dimensions, coordinates, and attributes. You would get a DataArray if you opened
 NIfTI file through [`confusius.load`][confusius.load], or if you extract a variable from
 a Dataset:
 
-```python
-pwd = ds["power_doppler"]
-pwd
-```
-
-```
+```pycon
+>>> pwd = ds["power_doppler"]
+>>> pwd
 <xarray.DataArray 'power_doppler' (time: 860, z: 1, y: 128, x: 86)> Size: 76MB
 dask.array<open_dataset-power_doppler, shape=(860, 1, 128, 86), dtype=float64, chunksize=(215, 1, 32, 22), chunktype=numpy.ndarray>
 Coordinates:
@@ -160,23 +154,23 @@ Currently, two global helpers are available:
 - [`.fusi.spacing`][confusius.xarray.FUSIAccessor.spacing], which returns the step size
   along each dimension as a dictionary:
 
-  ```python
-  pwd.fusi.spacing
-  # {'time': 0.6, 'z': 0.4, 'y': 0.049, 'x': 0.091}
+  ```pycon
+  >>> pwd.fusi.spacing
+  {'time': 0.6, 'z': 0.4, 'y': 0.049, 'x': 0.091}
   ```
 
-    This is particularly useful for sanity-checking voxel sizes or sampling periods
-    before passing data to functions that require regular spacing (e.g., temporal
-    filters, affine registration). `None` is returned with a warning for any dimension
-    where spacing cannot be determined: non-uniform coordinates, a single coordinate
-    point without a `voxdim` attribute, or no coordinate at all.
+  This is particularly useful for sanity-checking voxel sizes or sampling periods
+  before passing data to functions that require regular spacing (e.g., temporal
+  filters, affine registration). `None` is returned with a warning for any dimension
+  where spacing cannot be determined: non-uniform coordinates, a single coordinate
+  point without a `voxdim` attribute, or no coordinate at all.
 
 - [`.fusi.origin`][confusius.xarray.FUSIAccessor.origin], which returns the coordinate
   values at the origin along each dimension as a dictionary:
 
-  ```python
-  pwd.fusi.origin
-  # {'time': 0.299, 'z': 0.0, 'y': 5.664, 'x': -3.583}
+  ```pycon
+  >>> pwd.fusi.origin
+  {'time': 0.299, 'z': 0.0, 'y': 5.664, 'x': -3.583}
   ```
 
   This is typically used for computing the affine transformation corresponding to the


### PR DESCRIPTION
Use `pycon` for user-guide examples that show Python output.