### PR TITLE
fix(io): keep NIfTI and EchoFrame loading lazy under Dask

### DIFF
--- a/src/confusius/io/echoframe.py
+++ b/src/confusius/io/echoframe.py
@@ -289,7 +289,7 @@ def _load_echoframe_dat_blocks(
 
 def load_echoframe_dat(
     dat_path: str | Path,
-    meta_path: str | Path,
+    meta_path: str | Path | None = None,
     dat_dtype: npt.DTypeLike = np.complex64,
     header_dtype: npt.DTypeLike = np.uint64,
     n_header_items: int = 5,
@@ -308,8 +308,10 @@ def load_echoframe_dat(
     ----------
     dat_path : str or pathlib.Path
         Path to the EchoFrame DAT file containing beamformed IQ data.
-    meta_path : str or pathlib.Path
-        Path to the EchoFrame sequence parameter file (MAT v7.3 / HDF5 format).
+    meta_path : str or pathlib.Path, optional
+        Path to the EchoFrame sequence parameter file (MAT v7.3 / HDF5 format). If not
+        provided, looks for `ScanParameters.mat` next to `dat_path`, matching the
+        filename EchoFrame's storage writer uses by convention.
     dat_dtype : dtype_like, default: numpy.complex64
         Data type of the beamformed IQ data in the DAT file.
     header_dtype : dtype_like, default: numpy.uint64
@@ -326,16 +328,25 @@ def load_echoframe_dat(
         remain accessible via `data.isel(time=slice(i * n, (i + 1) * n))`, where `n`
         is `data.attrs["n_volumes_per_block"]`.
 
+    Raises
+    ------
+    ValueError
+        If `meta_path` is not provided and no `ScanParameters.mat` file exists next to
+        `dat_path`.
+
     Notes
     -----
     Acquisition metadata is stored in `da.attrs`, including `n_volumes_per_block`
     (number of volumes per acquisition block).
     """
+    dat_path = check_path(dat_path, label="dat_path", type="file")
+    if meta_path is None:
+        meta_path = dat_path.parent / "ScanParameters.mat"
+
     meta = load_echoframe_metadata(meta_path)
     x, z = len(meta["lateral_coords"]), len(meta["axial_coords"])
     n_volumes_per_block = meta["n_volumes_per_block"]
 
-    dat_path = check_path(dat_path, label="dat_path", type="file")
     blocks = _load_echoframe_dat_blocks(
         dat_path, x, z, n_volumes_per_block, dat_dtype, header_dtype, n_header_items
     )

--- a/src/confusius/io/echoframe.py
+++ b/src/confusius/io/echoframe.py
@@ -101,10 +101,10 @@ def load_echoframe_metadata(meta_path: str | Path) -> EchoFrameMetadata:
         )
 
         # Spatial coordinates.
-        # recon_spec["x_axis"] is lateral (x dimension in ConfUSIus).
-        # recon_spec["z_axis"] is depth/axial (y dimension in ConfUSIus).
-        x_axis_full = np.array(recon_spec["x_axis"][:]).flatten()
-        z_axis_full = np.array(recon_spec["z_axis"][:]).flatten()
+        # recon_spec["xAxis"] is lateral (x dimension in ConfUSIus).
+        # recon_spec["zAxis"] is depth/axial (y dimension in ConfUSIus).
+        x_axis_full = np.array(recon_spec["xAxis"][:]).flatten()
+        z_axis_full = np.array(recon_spec["zAxis"][:]).flatten()
 
         if crop:
             # croppingROI is 1-indexed, convert to 0-indexed.

--- a/src/confusius/io/echoframe.py
+++ b/src/confusius/io/echoframe.py
@@ -5,9 +5,12 @@ import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypedDict
 
+import dask
+import dask.array as da
 import h5py as h5
 import numpy as np
 import numpy.typing as npt
+import xarray as xr
 import zarr
 
 if TYPE_CHECKING:
@@ -45,6 +48,8 @@ class EchoFrameMetadata(TypedDict):
         Single plane wave pulse repetition frequency in hertz.
     beamforming_method : str
         Beamforming method used (e.g. `"DAS"`).
+    n_volumes_per_block : int
+        Number of volumes per acquisition block.
     """
 
     lateral_coords: npt.NDArray[np.float64]
@@ -57,6 +62,7 @@ class EchoFrameMetadata(TypedDict):
     compound_sampling_frequency: float
     pulse_repetition_frequency: float
     beamforming_method: str
+    n_volumes_per_block: int
 
 
 def load_echoframe_metadata(meta_path: str | Path) -> EchoFrameMetadata:
@@ -136,6 +142,9 @@ def load_echoframe_metadata(meta_path: str | Path) -> EchoFrameMetadata:
         beamforming_method_bytes = np.array(recon_spec["method"][:]).flatten()
         beamforming_method = "".join(chr(int(c)) for c in beamforming_method_bytes)
 
+        # Acquisition block structure.
+        n_volumes_per_block = int(np.array(receive_spec["nRepeats"][:]).item(0))
+
     return EchoFrameMetadata(
         lateral_coords=lateral_coords,
         axial_coords=axial_coords,
@@ -147,7 +156,135 @@ def load_echoframe_metadata(meta_path: str | Path) -> EchoFrameMetadata:
         compound_sampling_frequency=compound_sampling_frequency,
         pulse_repetition_frequency=pulse_repetition_frequency,
         beamforming_method=beamforming_method,
+        n_volumes_per_block=n_volumes_per_block,
     )
+
+
+def _load_echoframe_block(
+    dat_path: str | Path,
+    block_idx: int,
+    header_size: int,
+    n_volumes_per_block: int,
+    x: int,
+    z: int,
+    dat_dtype: npt.DTypeLike,
+    padding_bytes: int,
+) -> np.ndarray:
+    """Load a single EchoFrame acquisition block from a DAT file.
+
+    Opens a fresh, block-scoped `numpy.memmap` and copies the block out of it. Used as
+    the per-chunk loader for the lazy Dask array returned by `load_echoframe_dat`; each
+    block gets its own memory map so no single memmap spanning the whole file needs to
+    be built or transferred across task boundaries.
+
+    Parameters
+    ----------
+    dat_path : str or pathlib.Path
+        Path to the EchoFrame DAT file containing beamformed IQ data.
+    block_idx : int
+        Index of the acquisition block to load.
+    header_size : int
+        Size in bytes of the DAT file header, preceding the first block.
+    n_volumes_per_block : int
+        Number of volumes per acquisition block.
+    x : int
+        Lateral dimension size.
+    z : int
+        Axial (depth) dimension size.
+    dat_dtype : dtype_like
+        Data type of the beamformed IQ data in the DAT file.
+    padding_bytes : int
+        Number of padding bytes following each block's data. `0` if blocks are
+        contiguous.
+
+    Returns
+    -------
+    (volumes, x, 1, z) numpy.ndarray
+        Beamformed IQ data for the requested block.
+    """
+    block_shape = (n_volumes_per_block, x, 1, z)
+    if padding_bytes > 0:
+        # Block has trailing padding - use a structured dtype to skip it.
+        block_dtype = np.dtype(
+            [
+                ("data", dat_dtype, block_shape),
+                ("padding", np.uint8, (padding_bytes,)),
+            ]
+        )
+        offset = header_size + block_idx * block_dtype.itemsize
+        memmap = np.memmap(
+            dat_path, dtype=block_dtype, mode="r", offset=offset, shape=(1,)
+        )
+        return np.array(memmap["data"][0])  # type: ignore
+    else:
+        itemsize = np.dtype(dat_dtype).itemsize
+        offset = header_size + block_idx * int(np.prod(block_shape)) * itemsize
+        memmap = np.memmap(
+            dat_path, dtype=dat_dtype, mode="r", offset=offset, shape=block_shape
+        )
+        return np.array(memmap)
+
+
+def _load_echoframe_dat_blocks(
+    dat_path: str | Path,
+    x: int,
+    z: int,
+    n_volumes_per_block: int,
+    dat_dtype: npt.DTypeLike,
+    header_dtype: npt.DTypeLike,
+    n_header_items: int,
+) -> da.Array:
+    """Load all EchoFrame acquisition blocks as a lazy, EchoFrame-ordered Dask array.
+
+    Parameters
+    ----------
+    dat_path : str or pathlib.Path
+        Path to the EchoFrame DAT file containing beamformed IQ data.
+    x : int
+        Lateral dimension size.
+    z : int
+        Axial (depth) dimension size.
+    n_volumes_per_block : int
+        Number of volumes per acquisition block.
+    dat_dtype : dtype_like
+        Data type of the beamformed IQ data in the DAT file.
+    header_dtype : dtype_like
+        Data type of the DAT file header.
+    n_header_items : int
+        Number of items in the DAT file header.
+
+    Returns
+    -------
+    (blocks, volumes, x, y, z) dask.array.Array
+        Lazy array containing the beamformed IQ data, where `blocks` is the number of
+        acquisition blocks, `volumes` is `n_volumes_per_block`, `x` is the lateral
+        dimension, `y` is the elevation dimension (always `1`), and `z` is the axial
+        dimension. Chunked one block per Dask chunk along the leading `blocks` axis;
+        each block is only read from disk once its chunk is computed.
+    """
+    header = np.fromfile(dat_path, dtype=header_dtype, count=n_header_items)
+    _, header_size, n_blocks, data_size, padding_bytes = (int(item) for item in header)
+
+    load = dask.delayed(_load_echoframe_block)
+    block_shape = (n_volumes_per_block, x, 1, z)
+    blocks = [
+        da.from_delayed(
+            load(
+                dat_path,
+                block_idx,
+                header_size,
+                n_volumes_per_block,
+                x,
+                z,
+                dat_dtype,
+                padding_bytes,
+            ),
+            shape=block_shape,
+            dtype=dat_dtype,
+        )
+        for block_idx in range(n_blocks)
+    ]
+    return da.stack(blocks, axis=0)
 
 
 def load_echoframe_dat(
@@ -156,15 +293,16 @@ def load_echoframe_dat(
     dat_dtype: npt.DTypeLike = np.complex64,
     header_dtype: npt.DTypeLike = np.uint64,
     n_header_items: int = 5,
-) -> np.memmap:
-    """Load an EchoFrame DAT file containing beamformed IQ data.
+) -> xr.DataArray:
+    """Load an EchoFrame DAT file as a lazy, ConfUSIus-ordered DataArray.
 
-    !!! warning "EchoFrame spatial dimensions"
-        EchoFrame stores data with `(x, y, z)` spatial ordering corresponding to
-        (lateral, elevation, axial) dimensions, which is different from the `(z, y,
-        x)` ordering used in ConfUSIus that corresponds to (elevation, axial, lateral).
-        The returned array maintains the EchoFrame ordering to avoid confusion, but
-        users should be aware of this when processing the data.
+    Beamformed IQ data is loaded as a DataArray with dimensions `(time, z, y, x)`,
+    matching ConfUSIus conventions. Coordinates (`time`, `z`, `y`, `x`) and acquisition
+    metadata (e.g. `transmit_frequency`, `beamforming_sound_velocity`) are attached
+    from the EchoFrame sequence parameter file. The `time` coordinate is computed from
+    frame indices and the compound sampling frequency; callers with acquisition
+    timestamps for each block should override it (e.g. via
+    `data.assign_coords(time=...)`).
 
     Parameters
     ----------
@@ -181,68 +319,93 @@ def load_echoframe_dat(
 
     Returns
     -------
-    (blocks, volumes, x, y, z) numpy.memmap
-        Memory-mapped array containing the beamformed IQ data, where `blocks` is the
-        number of acquisitions blocks, `volumes` is the number of volumes per block,
-        `x` is the lateral dimension, `y` is the elevation dimension, and `z` is
-        the axial dimension.
+    xarray.DataArray
+        Lazy DataArray with dimensions `(time, z, y, x)`, where `z` is a singleton
+        elevation dimension. Data is wrapped in a Dask array, chunked so that each
+        chunk corresponds to one acquisition block's volumes; individual blocks
+        remain accessible via `data.isel(time=slice(i * n, (i + 1) * n))`, where `n`
+        is `data.attrs["n_volumes_per_block"]`.
+
+    Notes
+    -----
+    Acquisition metadata is stored in `da.attrs`, including `n_volumes_per_block`
+    (number of volumes per acquisition block).
     """
+    meta = load_echoframe_metadata(meta_path)
+    x, z = len(meta["lateral_coords"]), len(meta["axial_coords"])
+    n_volumes_per_block = meta["n_volumes_per_block"]
+
     dat_path = check_path(dat_path, label="dat_path", type="file")
-    meta_path = check_path(meta_path, label="meta_path", type="file")
+    blocks = _load_echoframe_dat_blocks(
+        dat_path, x, z, n_volumes_per_block, dat_dtype, header_dtype, n_header_items
+    )
+    n_blocks, n_volumes, _, _, _ = blocks.shape
+    # EchoFrame axes are (blocks, volumes, x, y, z); transpose spatial axes to
+    # ConfUSIus (z, y, x) and merge (blocks, volumes) into a single time axis. Each
+    # Dask chunk is exactly one block, so this reshape never splits a chunk.
+    iq = blocks.transpose((0, 1, 4, 3, 2)).reshape(n_blocks * n_volumes, 1, z, x)
 
-    with h5.File(meta_path, "r") as f:
-        recon_spec = f["ReconSpec"]
-        receive_spec = f["ReceiveSpec"]
-        crop = (
-            bool(np.array(recon_spec["cropBF"][()]))
-            if "cropBF" in recon_spec
-            else False
-        )
+    n_total_volumes = n_blocks * n_volumes
+    time_values = (
+        np.arange(n_total_volumes, dtype=np.float64)
+        / meta["compound_sampling_frequency"]
+    )
+    volume_acquisition_duration = float(
+        meta["plane_wave_angles"].size / meta["pulse_repetition_frequency"]
+    )
 
-        if crop:
-            z = int(
-                np.array(recon_spec["croppingROI"][0, 1])
-                - np.array(recon_spec["croppingROI"][0, 0])
-                + 1
-            )
-            x = int(
-                np.array(recon_spec["croppingROI"][0, 3])
-                - np.array(recon_spec["croppingROI"][0, 2])
-                + 1
-            )
-        else:
-            z = int(recon_spec["nz"][0, 0])
-            x = int(recon_spec["nx"][0, 0])
-        n_volumes_per_block = np.array(receive_spec["nRepeats"][:]).item(0)
-
-    header = np.fromfile(dat_path, dtype=header_dtype, count=n_header_items)
-    _, header_size, n_blocks, data_size, padding_bytes = header
-
-    if padding_bytes > 0:
-        # File has padding between blocks - use structured dtype to skip it.
-        block_dtype = np.dtype(
-            [
-                ("data", dat_dtype, (int(n_volumes_per_block), x, 1, z)),
-                ("padding", np.uint8, (int(padding_bytes),)),
-            ]
-        )
-        memmap = np.memmap(
-            dat_path,
-            dtype=block_dtype,
-            mode="r",
-            offset=header_size,
-            shape=(int(n_blocks),),
-        )
-        return memmap["data"]  # type: ignore
-    else:
-        # No padding - direct memmap.
-        return np.memmap(
-            dat_path,
-            dtype=dat_dtype,
-            mode="r",
-            offset=header_size,
-            shape=(int(n_blocks), int(n_volumes_per_block), x, 1, z),
-        )
+    # TODO: we should compute the actual z-axis voxdim from the elevation beam width,
+    # but we're currently missing some information for that, such as the elevation
+    # aperture and elevation focus.
+    coords = {
+        "time": (
+            "time",
+            time_values,
+            {
+                "units": "s",
+                "long_name": "Time",
+                "volume_acquisition_reference": "start",
+                "volume_acquisition_duration": volume_acquisition_duration,
+            },
+        ),
+        "z": (
+            "z",
+            np.array([0.0]),
+            {"units": "mm", "long_name": "Elevation", "voxdim": 0.4},
+        ),
+        "y": (
+            "y",
+            meta["axial_coords"],
+            {
+                "units": "mm",
+                "long_name": "Depth",
+                "voxdim": float(np.diff(meta["axial_coords"]).mean()),
+            },
+        ),
+        "x": (
+            "x",
+            meta["lateral_coords"],
+            {
+                "units": "mm",
+                "long_name": "Lateral",
+                "voxdim": float(np.diff(meta["lateral_coords"]).mean()),
+            },
+        ),
+    }
+    attrs = {
+        "transmit_frequency": meta["transmit_frequency"],
+        "probe_number_of_elements": meta["probe_number_of_elements"],
+        "probe_pitch": meta["probe_pitch"],
+        "beamforming_sound_velocity": meta["beamforming_sound_velocity"],
+        "plane_wave_angles": meta["plane_wave_angles"],
+        "compound_sampling_frequency": meta["compound_sampling_frequency"],
+        "pulse_repetition_frequency": meta["pulse_repetition_frequency"],
+        "beamforming_method": meta["beamforming_method"],
+        "n_volumes_per_block": n_volumes_per_block,
+    }
+    return xr.DataArray(
+        iq, dims=("time", "z", "y", "x"), coords=coords, attrs=attrs, name="iq"
+    )
 
 
 def convert_echoframe_dat_to_zarr(
@@ -352,8 +515,7 @@ def convert_echoframe_dat_to_zarr(
     """
     from rich.progress import track
 
-    meta = load_echoframe_metadata(meta_path)
-    data = load_echoframe_dat(
+    iq_da = load_echoframe_dat(
         dat_path=dat_path,
         meta_path=meta_path,
         dat_dtype=dat_dtype,
@@ -361,7 +523,9 @@ def convert_echoframe_dat_to_zarr(
         n_header_items=n_header_items,
     )
 
-    n_blocks, n_volumes, n_x, n_y, n_z = data.shape
+    n_volumes = iq_da.attrs["n_volumes_per_block"]
+    n_total_volumes_full = iq_da.sizes["time"]
+    n_blocks = n_total_volumes_full // n_volumes
 
     total_skip = skip_first_blocks + skip_last_blocks
     if total_skip >= n_blocks:
@@ -370,8 +534,15 @@ def convert_echoframe_dat_to_zarr(
             f"skip_last_blocks={skip_last_blocks}) from {n_blocks} total blocks."
         )
 
+    iq_da = iq_da.isel(
+        time=slice(
+            skip_first_blocks * n_volumes,
+            n_total_volumes_full - skip_last_blocks * n_volumes,
+        )
+    )
     n_blocks_after_skip = n_blocks - total_skip
-    n_total_volumes = n_blocks_after_skip * n_volumes
+    n_total_volumes = iq_da.sizes["time"]
+    n_z, n_x = iq_da.sizes["y"], iq_da.sizes["x"]
 
     if volumes_per_chunk is None:
         volumes_per_chunk = n_volumes
@@ -403,7 +574,7 @@ def convert_echoframe_dat_to_zarr(
         )
     create_array_kwargs["shape"] = output_shape
     create_array_kwargs["chunks"] = chunks
-    create_array_kwargs["dtype"] = data.dtype
+    create_array_kwargs["dtype"] = iq_da.dtype
     create_array_kwargs["dimension_names"] = dim_names
 
     if shards is not None:
@@ -419,57 +590,26 @@ def convert_echoframe_dat_to_zarr(
 
         time_values = np.concatenate(
             [
-                block_start + np.arange(n_volumes) / meta["compound_sampling_frequency"]
+                block_start
+                + np.arange(n_volumes) / iq_da.attrs["compound_sampling_frequency"]
                 for block_start in block_times_array
             ]
         )
-    else:
-        skipped_volumes = skip_first_blocks * n_volumes
-        time_values = (
-            np.arange(n_total_volumes, dtype=np.float64)
-            / meta["compound_sampling_frequency"]
-            + skipped_volumes / meta["compound_sampling_frequency"]
-        )
+        iq_da = iq_da.assign_coords(time=("time", time_values))
 
     zarr_group = zarr.open_group(output_path, mode="w" if overwrite else "w-")
     zarr_iq = zarr_group.create_array("iq", **create_array_kwargs)
 
-    zarr_group.create_array("time", data=time_values, dimension_names=["time"])
-    zarr_group["time"].attrs["units"] = "s"
-    zarr_group["time"].attrs["long_name"] = "Time"
-    zarr_group["time"].attrs["volume_acquisition_reference"] = "start"
-    zarr_group["time"].attrs["volume_acquisition_duration"] = float(
-        meta["plane_wave_angles"].size / meta["pulse_repetition_frequency"]
-    )
+    for dim in ("time", "z", "y", "x"):
+        zarr_group.create_array(
+            dim, data=iq_da.coords[dim].values, dimension_names=[dim]
+        )
+        zarr_group[dim].attrs.update(iq_da.coords[dim].attrs)
 
-    # z coordinate is the stacking dimension (size 1 for 2D data).
-    z_values = np.array([0.0])
-    zarr_group.create_array("z", data=z_values, dimension_names=["z"])
-    zarr_group["z"].attrs["units"] = "mm"
-    zarr_group["z"].attrs["long_name"] = "Elevation"
-
-    zarr_group.create_array("y", data=meta["axial_coords"], dimension_names=["y"])
-    zarr_group["y"].attrs["units"] = "mm"
-    zarr_group["y"].attrs["long_name"] = "Depth"
-
-    zarr_group.create_array("x", data=meta["lateral_coords"], dimension_names=["x"])
-    zarr_group["x"].attrs["units"] = "mm"
-    zarr_group["x"].attrs["long_name"] = "Lateral"
-
-    # TODO: we should compute the actual z-axis voxdim from the elevation beam width,
-    # but we're currently missing some information for that, such as the elevation
-    # aperture and elevation focus.
-    zarr_group["z"].attrs["voxdim"] = 0.4
-    zarr_group["y"].attrs["voxdim"] = float(np.diff(meta["axial_coords"]).mean())
-    zarr_group["x"].attrs["voxdim"] = float(np.diff(meta["lateral_coords"]).mean())
-    zarr_iq.attrs["transmit_frequency"] = meta["transmit_frequency"]
-    zarr_iq.attrs["probe_number_of_elements"] = meta["probe_number_of_elements"]
-    zarr_iq.attrs["probe_pitch"] = meta["probe_pitch"]
-    zarr_iq.attrs["beamforming_sound_velocity"] = meta["beamforming_sound_velocity"]
-    zarr_iq.attrs["plane_wave_angles"] = meta["plane_wave_angles"].tolist()
-    zarr_iq.attrs["compound_sampling_frequency"] = meta["compound_sampling_frequency"]
-    zarr_iq.attrs["pulse_repetition_frequency"] = meta["pulse_repetition_frequency"]
-    zarr_iq.attrs["beamforming_method"] = meta["beamforming_method"]
+    for key, value in iq_da.attrs.items():
+        if key == "n_volumes_per_block":
+            continue
+        zarr_iq.attrs[key] = value.tolist() if isinstance(value, np.ndarray) else value
 
     first_block = skip_first_blocks
     last_block = n_blocks - skip_last_blocks
@@ -494,12 +634,10 @@ def convert_echoframe_dat_to_zarr(
         for idx, start_block in enumerate(iterable):
             end_block = min(start_block + batch_size, last_block)
 
-            batch_data = np.transpose(
-                data[start_block:end_block], axes=(0, 1, 4, 3, 2)
-            ).reshape(-1, 1, n_z, n_x)
-
             output_start = (start_block - skip_first_blocks) * n_volumes
             output_end = (end_block - skip_first_blocks) * n_volumes
+            batch_data = iq_da.data[output_start:output_end].compute()
+
             zarr_iq[output_start:output_end] = batch_data
 
             if progress is not None and task_id is not None:

--- a/src/confusius/io/nifti.py
+++ b/src/confusius/io/nifti.py
@@ -976,6 +976,37 @@ def _squeeze_synthetic_singleton_dims(
     return data_array.squeeze(dim="time", drop=True)
 
 
+def _reverse_chunk_spec(
+    chunks: int | tuple[int, ...] | str | None, ndim: int
+) -> int | tuple[int, ...] | str | None:
+    """Reverse a per-axis Dask chunk specification to match NIfTI's native axis order.
+
+    `load_nifti`'s `chunks` parameter is documented in ConfUSIus (post-transpose) axis
+    order, but the Dask array is now built directly from the NIfTI `ArrayProxy` in its
+    native (pre-transpose) axis order and transposed afterward. A tuple `chunks`
+    specification must therefore be reversed before being passed to `da.from_array` so
+    that, once transposed, it lines up with the axes the caller intended.
+
+    Parameters
+    ----------
+    chunks : int or tuple[int, ...] or str or None
+        Chunk specification as documented for `load_nifti`, in ConfUSIus axis order.
+    ndim : int
+        Number of dimensions of the array being chunked.
+
+    Returns
+    -------
+    int or tuple[int, ...] or str or None
+        `chunks` unchanged if order-independent (`int`, `str`, or `None`), or with its
+        top-level axis order reversed if given as a tuple.
+    """
+    if not isinstance(chunks, tuple):
+        return chunks
+    if len(chunks) != ndim:
+        return chunks
+    return chunks[::-1]
+
+
 def load_nifti(
     path: str | Path, chunks: int | tuple[int, ...] | str | None = "auto"
 ) -> xr.DataArray:
@@ -1059,12 +1090,25 @@ def load_nifti(
     attrs = extractor.to_attrs()
     attrs.update(_load_nifti_sidecar(path))
 
-    # We use np.asanyarray to get the memory-mapped array behind Nibabel's proxy. This
-    # will allow Dask to create a lazy array without loading the entire dataset into
-    # memory.
-    # NIfTI stores data with shape (x, y, z, time) in column-major order; transposing
-    # to row-major gives ConfUSIus order (time, z, y, x) without copying data.
-    dask_arr = da.from_array(np.asanyarray(img.dataobj).T, chunks=chunks, asarray=False)
+    # img.dataobj is a nibabel ArrayProxy, which already exposes .shape, .dtype, and
+    # numpy-style __getitem__ slicing (applying any slope/intercept scaling lazily per
+    # chunk). Passing it to da.from_array directly keeps the array lazy; converting it
+    # through np.asanyarray first would force it into a concrete numpy.memmap, which
+    # da.from_array then copies while building the graph.
+    # NIfTI stores data with shape (x, y, z, time) in column-major order. ArrayProxy has
+    # no .T, so we build the Dask array in that native order and transpose afterward
+    # (a metadata-only Dask op) to reach ConfUSIus order (time, z, y, x).
+    from nibabel.arrayproxy import ArrayProxy
+
+    proxy = img.dataobj
+    assert isinstance(proxy, ArrayProxy)
+    dask_arr = da.from_array(
+        proxy,
+        chunks=_reverse_chunk_spec(chunks, proxy.ndim),
+        asarray=False,
+        name=False,
+        meta=np.empty((), dtype=proxy.dtype),
+    ).T
 
     # NIfTI dim order is (x, y, z, time, ...); ConfUSIus order is the reverse.
     nifti_dims = _NIFTI_DIM_ORDER[: dask_arr.ndim]

--- a/tests/integration/test_io/conftest.py
+++ b/tests/integration/test_io/conftest.py
@@ -134,8 +134,8 @@ def _create_echoframe_mat_metadata(
         # 200 µs transmit-receive time -> PRF = 5000 Hz, CSF = 1000 Hz (5 angles).
         receive_spec["transmitReceiveTimeMus"] = np.array([200.0])
 
-        recon_spec["x_axis"] = np.linspace(0, x * 0.1, x)
-        recon_spec["z_axis"] = np.linspace(0, z * 0.05, z)
+        recon_spec["xAxis"] = np.linspace(0, x * 0.1, x)
+        recon_spec["zAxis"] = np.linspace(0, z * 0.05, z)
         recon_spec["c0"] = np.array([1540.0])
         recon_spec["method"] = np.array([ord(c) for c in "DAS"], dtype=np.uint8)
         probe_spec["Fc"] = np.array([15.625e6])

--- a/tests/unit/test_io/test_echoframe.py
+++ b/tests/unit/test_io/test_echoframe.py
@@ -251,6 +251,23 @@ class TestLoadEchoFrameDat:
         with pytest.raises(ValueError):
             load_echoframe_dat(dat_path, non_existent)
 
+    def test_default_meta_path_discovery(self, echoframe_dat_no_padding):
+        """`load_echoframe_dat` finds `ScanParameters.mat` next to `dat_path` by default."""
+        dat_path, meta_path = echoframe_dat_no_padding
+        assert meta_path.name == "ScanParameters.mat"
+
+        data = load_echoframe_dat(dat_path)
+
+        assert data.shape == (6, 1, 6, 4)
+
+    def test_default_meta_path_missing(self, tmp_path):
+        """`load_echoframe_dat` raises `ValueError` when no default MAT file is found."""
+        dat_path = tmp_path / "fUSi_BF.dat"
+        _create_echoframe_dat_file(dat_path, n_blocks=1, n_x=4, n_z=6, n_volumes=3)
+
+        with pytest.raises(ValueError):
+            load_echoframe_dat(dat_path)
+
     def test_different_blocks_accessible(self, echoframe_dat_no_padding):
         """`load_echoframe_dat` allows accessing different blocks with correct values."""
         dat_path, meta_path = echoframe_dat_no_padding

--- a/tests/unit/test_io/test_echoframe.py
+++ b/tests/unit/test_io/test_echoframe.py
@@ -61,8 +61,8 @@ def _create_echoframe_metadata(
         receive_spec["nRepeats"] = np.array([n_volumes], dtype=np.int32)
         receive_spec["transmitReceiveTimeMus"] = np.array([transmit_receive_time_mus])
 
-        recon_spec["x_axis"] = np.linspace(0, x * 0.1, x)
-        recon_spec["z_axis"] = np.linspace(0, z * 0.05, z)
+        recon_spec["xAxis"] = np.linspace(0, x * 0.1, x)
+        recon_spec["zAxis"] = np.linspace(0, z * 0.05, z)
         recon_spec["c0"] = np.array([1540.0])
         recon_spec["method"] = np.array([ord(c) for c in "DAS"], dtype=np.uint8)
         probe_spec["Fc"] = np.array([15.625e6])

--- a/tests/unit/test_io/test_echoframe.py
+++ b/tests/unit/test_io/test_echoframe.py
@@ -2,9 +2,11 @@
 
 from pathlib import Path
 
+import dask.array as da
 import h5py
 import numpy as np
 import pytest
+import xarray as xr
 
 from confusius.io.echoframe import load_echoframe_dat, load_echoframe_metadata
 
@@ -191,12 +193,16 @@ class TestLoadEchoFrameDat:
 
         data = load_echoframe_dat(dat_path, meta_path)
 
-        assert data.shape == (2, 3, 4, 1, 6)  # (n_blocks, n_volumes, n_x, 1, n_z)
+        assert isinstance(data, xr.DataArray)
+        assert data.dims == ("time", "z", "y", "x")
+        assert data.shape == (6, 1, 6, 4)  # (n_blocks * n_volumes, 1, n_z, n_x)
         assert data.dtype == np.complex64
 
         # Verify values match the known pattern (block_idx+1, 1).
-        assert data[0, 0, 0, 0, 0] == complex(1.0, 1.0), "Block 0 value corrupted"
-        assert data[1, 0, 0, 0, 0] == complex(2.0, 1.0), "Block 1 value corrupted"
+        block_0 = data.isel(time=0, z=0, y=0, x=0).compute().item()
+        block_1 = data.isel(time=3, z=0, y=0, x=0).compute().item()
+        assert block_0 == complex(1.0, 1.0), "Block 0 corrupted"
+        assert block_1 == complex(2.0, 1.0), "Block 1 corrupted"
 
     def test_loads_file_with_padding(self, echoframe_dat_with_padding):
         """`load_echoframe_dat` loads files with padding correctly."""
@@ -204,7 +210,7 @@ class TestLoadEchoFrameDat:
 
         data = load_echoframe_dat(dat_path, meta_path)
 
-        assert data.shape == (2, 3, 4, 1, 6)
+        assert data.shape == (6, 1, 6, 4)
         assert data.dtype == np.complex64
 
         # Verify all blocks have the expected pattern.
@@ -213,9 +219,11 @@ class TestLoadEchoFrameDat:
         expected_block_0 = complex(1.0, 1.0)
         expected_block_1 = complex(2.0, 1.0)
 
-        assert data[0, 0, 0, 0, 0] == expected_block_0, "Block 0 is corrupted"
-        assert data[1, 0, 0, 0, 0] == expected_block_1, (
-            f"Block 1 is corrupted! Got {data[1, 0, 0, 0, 0]}, expected {expected_block_1}. "
+        block_0 = data.isel(time=0, z=0, y=0, x=0).compute().item()
+        block_1 = data.isel(time=3, z=0, y=0, x=0).compute().item()
+        assert block_0 == expected_block_0, "Block 0 is corrupted"
+        assert block_1 == expected_block_1, (
+            f"Block 1 is corrupted! Got {block_1}, expected {expected_block_1}. "
             "This may indicate that padding bytes are not being skipped correctly."
         )
 
@@ -225,8 +233,8 @@ class TestLoadEchoFrameDat:
 
         data = load_echoframe_dat(dat_path, meta_path)
 
-        # With cropping ROI [1, 4, 1, 3]: z=4, x=3.
-        assert data.shape == (1, 3, 3, 1, 4)
+        # With cropping ROI [1, 4, 1, 3]: z=4, x=3; 1 block * 3 volumes = 3 in time.
+        assert data.shape == (3, 1, 4, 3)
 
     def test_missing_dat_file(self, tmp_path, echoframe_meta_file):
         """`load_echoframe_dat` raises `ValueError` for missing DAT file."""
@@ -243,30 +251,52 @@ class TestLoadEchoFrameDat:
         with pytest.raises(ValueError):
             load_echoframe_dat(dat_path, non_existent)
 
-    def test_data_accessible(self, echoframe_dat_no_padding):
-        """`load_echoframe_dat` returns accessible memmap with correct values."""
-        dat_path, meta_path = echoframe_dat_no_padding
-
-        data = load_echoframe_dat(dat_path, meta_path)
-
-        # Block 0 is filled with complex(1, 1) in the known pattern.
-        sample = data[0, 0, 0, 0, 0]
-        assert sample == complex(1.0, 1.0)
-
     def test_different_blocks_accessible(self, echoframe_dat_no_padding):
         """`load_echoframe_dat` allows accessing different blocks with correct values."""
         dat_path, meta_path = echoframe_dat_no_padding
 
         data = load_echoframe_dat(dat_path, meta_path)
+        n_volumes = data.attrs["n_volumes_per_block"]
 
-        first_block = data[0]
-        last_block = data[-1]
+        first_block = data.isel(time=slice(0, n_volumes))
+        last_block = data.isel(time=slice(-n_volumes, None))
 
-        assert first_block.shape == (3, 4, 1, 6)
-        assert last_block.shape == (3, 4, 1, 6)
+        assert first_block.shape == (3, 1, 6, 4)
+        assert last_block.shape == (3, 1, 6, 4)
         # Known pattern: block 0 → complex(1, 1), block 1 → complex(2, 1).
-        assert first_block[0, 0, 0, 0] == complex(1.0, 1.0)
-        assert last_block[0, 0, 0, 0] == complex(2.0, 1.0)
+        assert first_block.isel(time=0, z=0, y=0, x=0).compute().item() == complex(
+            1.0, 1.0
+        )
+        assert last_block.isel(time=0, z=0, y=0, x=0).compute().item() == complex(
+            2.0, 1.0
+        )
+
+    def test_lazy_dask_array(self, echoframe_dat_no_padding):
+        """`load_echoframe_dat` returns a Dask array chunked one block per chunk."""
+        dat_path, meta_path = echoframe_dat_no_padding
+
+        data = load_echoframe_dat(dat_path, meta_path)
+
+        assert isinstance(data.data, da.Array)
+        assert data.data.chunks[0] == (3, 3)  # One chunk per acquisition block.
+
+    def test_coords_and_attrs(self, echoframe_dat_no_padding):
+        """`load_echoframe_dat` attaches ConfUSIus coordinates and acquisition attrs."""
+        dat_path, meta_path = echoframe_dat_no_padding
+
+        data = load_echoframe_dat(dat_path, meta_path)
+        meta = load_echoframe_metadata(meta_path)
+
+        np.testing.assert_allclose(data.coords["x"].values, meta["lateral_coords"])
+        np.testing.assert_allclose(data.coords["y"].values, meta["axial_coords"])
+        np.testing.assert_allclose(data.coords["z"].values, [0.0])
+        np.testing.assert_allclose(
+            data.coords["time"].values,
+            np.arange(6) / meta["compound_sampling_frequency"],
+        )
+
+        assert data.attrs["transmit_frequency"] == meta["transmit_frequency"]
+        assert data.attrs["n_volumes_per_block"] == meta["n_volumes_per_block"]
 
 
 @pytest.fixture
@@ -320,6 +350,12 @@ class TestLoadEchoFrameMetadata:
         meta = load_echoframe_metadata(echoframe_meta_file_no_crop)
 
         assert meta["beamforming_method"] == "DAS"
+
+    def test_n_volumes_per_block_extracted(self, echoframe_meta_file_no_crop):
+        """`load_echoframe_metadata` extracts the number of volumes per block."""
+        meta = load_echoframe_metadata(echoframe_meta_file_no_crop)
+
+        assert meta["n_volumes_per_block"] == 3
 
     def test_cropping_applied_to_coords(self, echoframe_meta_file_crop):
         """`load_echoframe_metadata` applies the cropping ROI to spatial coordinates."""

--- a/tests/unit/test_io/test_nifti.py
+++ b/tests/unit/test_io/test_nifti.py
@@ -1006,6 +1006,45 @@ class TestLoadNifti:
 
         assert isinstance(result.data, dask_array.Array)
 
+    def test_load_nifti_does_not_materialize_array_proxy(self, tmp_path: Path) -> None:
+        """Loading never eagerly reads nibabel's ArrayProxy into memory (issue #329).
+
+        Regression test for the bug where `np.asanyarray(img.dataobj)` converted the
+        lazy `ArrayProxy` into a concrete `numpy.memmap` before wrapping it in Dask,
+        which then copied the whole array while building the graph. `ArrayProxy.__array__`
+        is exactly the method that eager conversion goes through, so it must not be
+        called until the resulting Dask array is actually computed.
+        """
+        from nibabel.arrayproxy import ArrayProxy
+
+        data = np.random.default_rng(0).random((8, 6, 4)).astype(np.float32)
+        nifti_path = tmp_path / "test_no_materialize.nii.gz"
+        nib.Nifti1Image(data, np.eye(4)).to_filename(nifti_path)
+
+        with patch.object(
+            ArrayProxy, "__array__", side_effect=AssertionError("proxy materialized")
+        ):
+            result = load_nifti(nifti_path)
+
+        np.testing.assert_allclose(result.data.compute(), data.T)
+
+    def test_load_nifti_explicit_tuple_chunks(self, tmp_path: Path) -> None:
+        """Loading with an explicit tuple `chunks` produces the requested chunk shape.
+
+        `chunks` is documented in ConfUSIus (post-transpose) axis order; internally it
+        must be reversed before being applied to the pre-transpose `ArrayProxy` so
+        the resulting per-axis chunk sizes line up correctly after transposing.
+        """
+        data = np.random.default_rng(0).random((8, 6, 4)).astype(np.float32)
+        nifti_path = tmp_path / "test_tuple_chunks.nii.gz"
+        nib.Nifti1Image(data, np.eye(4)).to_filename(nifti_path)
+
+        # ConfUSIus order is (z, y, x) = (4, 6, 8); request chunks of (2, 3, 4).
+        result = load_nifti(nifti_path, chunks=(2, 3, 4))
+
+        assert result.data.chunksize == (2, 3, 4)
+        np.testing.assert_allclose(result.data.compute(), data.T)
+
     def test_load_nifti_rejects_non_nifti_image(
         self, tmp_path: Path, monkeypatch
     ) -> None:

--- a/tests/unit/test_io/test_nifti.py
+++ b/tests/unit/test_io/test_nifti.py
@@ -1045,6 +1045,15 @@ class TestLoadNifti:
         assert result.data.chunksize == (2, 3, 4)
         np.testing.assert_allclose(result.data.compute(), data.T)
 
+    def test_load_nifti_mismatched_tuple_chunks_length(self, tmp_path: Path) -> None:
+        """A wrong-length tuple `chunks` is passed through unchanged; Dask errors."""
+        data = np.random.default_rng(0).random((8, 6, 4)).astype(np.float32)
+        nifti_path = tmp_path / "test_bad_chunks.nii.gz"
+        nib.Nifti1Image(data, np.eye(4)).to_filename(nifti_path)
+
+        with pytest.raises(ValueError, match="Chunks and shape must be"):
+            load_nifti(nifti_path, chunks=(2, 3))
+
     def test_load_nifti_rejects_non_nifti_image(
         self, tmp_path: Path, monkeypatch
     ) -> None:


### PR DESCRIPTION
## Summary
- `load_nifti` was materializing nibabel's `ArrayProxy` into a `numpy.memmap` (via `np.asanyarray`) before wrapping it in `da.from_array`, which copies the whole array while building the graph instead of staying lazy. Now passes the `ArrayProxy` straight through and transposes the resulting Dask array afterward instead.
- `load_echoframe_dat` returned a raw `numpy.memmap`; it now builds a lazy `dask.array.Array` via one `dask.delayed` task per acquisition block (Dask's documented mmap-chunking pattern) and assembles it into a ConfUSIus-ordered `(time, z, y, x)` `xarray.DataArray` with coords/attrs, matching `load_nifti`/`load_scan`. `convert_echoframe_dat_to_zarr` keeps its exact public signature but now consumes that DataArray instead of duplicating coordinate/attribute assembly and transpose/reshape logic.

Closes #329