### PR TITLE
fix(signal): z-score standardized confounds

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,12 @@ icon: lucide/history
 
 Current development version for the next ConfUSIus release.
 
+### :bug: Fixes
+
+- Confound regression now z-scores confounds when `standardize_confounds=True`, so
+  motion-confound cleaning removes fluctuations without regressing baseline-related
+  signal by default ([#351](https://github.com/confusius-tools/confusius/pull/351)).
+
 ## 0.6.0
 
 Released 2026-07-18.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,8 +10,17 @@ icon: lucide/history
 
 Current development version for the next ConfUSIus release.
 
+### :sparkles: Enhancements
+
+- `load_echoframe_dat` now returns a ConfUSIus-ordered `(time, z, y, x)` DataArray and
+  defaults `meta_path` to the sibling `ScanParameters.mat` file
+  ([#343](https://github.com/confusius-tools/confusius/pull/343)).
+
 ### :bug: Fixes
 
+- NIfTI loading now keeps nibabel data lazy under Dask, EchoFrame `.dat` loading is now
+  lazily chunked, and EchoFrame metadata reads current `xAxis`/`zAxis` fields
+  ([#343](https://github.com/confusius-tools/confusius/pull/343)).
 - Confound regression now z-scores confounds when `standardize_confounds=True`, so
   motion-confound cleaning removes fluctuations without regressing baseline-related
   signal by default ([#351](https://github.com/confusius-tools/confusius/pull/351)).

--- a/src/confusius/signal/confounds.py
+++ b/src/confusius/signal/confounds.py
@@ -73,35 +73,35 @@ def _validate_confounds(signals: xr.DataArray, confounds: xr.DataArray) -> np.nd
     return confounds_values
 
 
-def _standardize_confounds(confounds: np.ndarray) -> np.ndarray:
-    """Standardize confounds by max absolute value for numerical stability.
-
-    Following nilearn's approach: divide each confound by its maximum absolute
-    value to control the range while preserving constant terms. This improves
-    numerical stability without removing the mean (unlike z-scoring).
+def _prepare_confounds_for_regression(
+    confounds: np.ndarray,
+    standardize_confounds: bool,
+) -> np.ndarray:
+    """Prepare confounds for regression.
 
     Parameters
     ----------
     confounds : numpy.ndarray
-        Confound regressors, shape (time, n_confounds).
+        Confound regressors, shape `(time, n_confounds)`.
+    standardize_confounds : bool
+        Whether to z-score confounds. If `False`, confounds are divided by their
+        maximum absolute value without centering.
 
     Returns
     -------
     numpy.ndarray
-        Standardized confounds with values in approximately [-1, 1] range.
-        Constant columns are preserved (not zeroed out).
-
-    Notes
-    -----
-    Based on nilearn.signal.clean implementation which standardizes by max
-    absolute value to improve numerical stability while keeping constant
-    contributions intact.
+        Prepared confound regressors. Standardized constant columns are returned as
+        zeros; unstandardized columns are divided by their maximum absolute value.
     """
-    confound_max = np.max(np.abs(confounds), axis=0)
-    confound_max[confound_max == 0] = 1
-    confounds = confounds / confound_max
+    if standardize_confounds:
+        confounds = confounds - confounds.mean(axis=0)
+        confound_scale = confounds.std(axis=0, ddof=1)
+        confound_scale[confound_scale < np.finfo(np.float64).eps] = 1
+        return confounds / confound_scale
 
-    return confounds
+    confound_scale = np.max(np.abs(confounds), axis=0)
+    confound_scale[confound_scale == 0] = 1
+    return confounds / confound_scale
 
 
 def _regress_confounds_numpy(
@@ -121,7 +121,9 @@ def _regress_confounds_numpy(
     confounds : numpy.ndarray
         Confound regressors, shape (time, n_confounds).
     standardize_confounds : bool, default=True
-        Whether to standardize confounds before regression.
+        Whether to z-score confounds before regression. If `False`, confounds are
+        divided by their maximum absolute value for numerical stability without
+        centering.
 
     Returns
     -------
@@ -134,8 +136,7 @@ def _regress_confounds_numpy(
     Friston et al. (1994) for confound removal via projection onto
     the orthogonal of the signal space.
     """
-    if standardize_confounds:
-        confounds = _standardize_confounds(confounds)
+    confounds = _prepare_confounds_for_regression(confounds, standardize_confounds)
 
     qr_result = scipy.linalg.qr(confounds, mode="economic", pivoting=True)
     Q, R, _ = cast(tuple[np.ndarray, np.ndarray, np.ndarray], qr_result)
@@ -222,8 +223,9 @@ def regress_confounds(
         confound. The time dimension and coordinates must match the signals within
         the default coordinate-comparison tolerance (`rtol=1e-5`, `atol=1e-8`).
     standardize_confounds : bool, default: True
-        Whether to standardize confounds by their maximum absolute value before
-        regression. This improves numerical stability while preserving constant terms.
+        Whether to z-score confounds before regression. If `False`, confounds are
+        divided by their maximum absolute value for numerical stability without
+        centering.
 
     Returns
     -------

--- a/src/confusius/signal/core.py
+++ b/src/confusius/signal/core.py
@@ -254,8 +254,10 @@ def clean(
         signals before regression. The time dimension and coordinates must match the
         signals exactly. If not provided, no confound regression is applied.
     standardize_confounds : bool, default: True
-        Whether to standardize confounds by their maximum absolute value before
-        regression. This improves numerical stability while preserving constant terms.
+        Whether to z-score confounds before regression. If `False`, confounds are
+        divided by their maximum absolute value for numerical stability without
+        centering. When `filter_method="cosine"`, confounds are not z-scored because
+        the cosine drift matrix includes a constant column.
     ensure_finite : bool, default: False
         Whether to repair non-finite values (`NaN`, `Inf`) in `signals` and
         `confounds` before cleaning by interpolating each series along `time` and
@@ -389,8 +391,15 @@ def clean(
             confounds = censor_samples(confounds, sample_mask=sample_mask)
 
     if confounds is not None:
+        # Cosine filtering uses a constant drift regressor to match filter_cosine.
+        # Z-scoring would zero that column and stop removing the mean.
+        regress_standardized_confounds = (
+            standardize_confounds and filter_method != "cosine"
+        )
         signals = regress_confounds(
-            signals, confounds, standardize_confounds=standardize_confounds
+            signals,
+            confounds,
+            standardize_confounds=regress_standardized_confounds,
         )
 
     if standardize_method is None:

--- a/tests/unit/test_signal/test_clean.py
+++ b/tests/unit/test_signal/test_clean.py
@@ -447,7 +447,9 @@ def test_clean_cosine_filter_is_jointly_regressed_with_confounds(sample_timeseri
     )
     combined_confounds = xr.concat([confounds, cosine_confounds], dim="confound")
 
-    expected = regress_confounds(signals, combined_confounds)
+    expected = regress_confounds(
+        signals, combined_confounds, standardize_confounds=False
+    )
     result = clean(
         signals,
         detrend_order=None,
@@ -485,7 +487,9 @@ def test_clean_cosine_filter_joint_regression_with_1d_confounds(sample_timeserie
         },
     )
 
-    expected = regress_confounds(signals, combined_confounds)
+    expected = regress_confounds(
+        signals, combined_confounds, standardize_confounds=False
+    )
     result = clean(
         signals,
         detrend_order=None,

--- a/tests/unit/test_signal/test_confounds.py
+++ b/tests/unit/test_signal/test_confounds.py
@@ -63,9 +63,12 @@ def test_regress_confounds_multiple_confounds(sample_timeseries):
     # Remove confounds
     cleaned = regress_confounds(signals_with_confounds, confounds)
 
-    # Check cleaned signals have no remaining linear dependence on confounds
+    # Check cleaned signals have no remaining linear dependence on centered confounds.
+    confounds_centered = confounds.values - confounds.values.mean(axis=0)
     for j in range(signals.sizes["space"]):
-        coeffs = np.linalg.lstsq(confounds.values, cleaned.values[:, j], rcond=None)[0]
+        coeffs = np.linalg.lstsq(confounds_centered, cleaned.values[:, j], rcond=None)[
+            0
+        ]
         assert_allclose(coeffs, 0.0, atol=1e-10)
 
 
@@ -99,8 +102,8 @@ def test_regress_confounds_orthogonalization():
         assert_allclose(coeff, 0.0, atol=1e-10)
 
 
-def test_regress_confounds_normalization_preserves_constant():
-    """Test that normalization preserves constant confounds."""
+def test_regress_confounds_without_standardization_preserves_constant():
+    """Unstandardized confound regression preserves constant confounds."""
     n_time = 50
     n_voxels = 10
 
@@ -125,14 +128,36 @@ def test_regress_confounds_normalization_preserves_constant():
         coords={"time": np.arange(n_time) * 0.1},
     )
 
-    # Should work without error and remove both confounds
-    cleaned = regress_confounds(signals, confounds, standardize_confounds=True)
+    # Should work without error and remove both confounds.
+    cleaned = regress_confounds(signals, confounds, standardize_confounds=False)
 
     # Cleaned signals should be orthogonal to both confounds
     for i in range(confounds.shape[1]):
         for j in range(n_voxels):
             dot_product = np.dot(cleaned.values[:, j], confounds.values[:, i])
             assert abs(dot_product) < 1e-10
+
+
+def test_regress_confounds_standardizes_confounds_by_default():
+    """Default confound standardization removes only confound fluctuations."""
+    n_time = 20
+    time = np.arange(n_time)
+    baseline = np.array([10.0, 20.0])
+    confound = xr.DataArray(
+        100.0 + np.linspace(-1, 1, n_time),
+        dims=["time"],
+        coords={"time": time},
+    )
+    signals = xr.DataArray(
+        baseline + 2.0 * confound.values[:, np.newaxis],
+        dims=["time", "space"],
+        coords={"time": time},
+    )
+
+    cleaned = regress_confounds(signals, confound)
+
+    assert_allclose(cleaned.mean("time"), signals.mean("time"))
+    assert_allclose(cleaned.std("time"), 0.0, atol=1e-10)
 
 
 def test_regress_confounds_rank_deficient():


### PR DESCRIPTION
## Summary
- make `standardize_confounds=True` z-score confounds before regression
- keep max-absolute division for `standardize_confounds=False`
- preserve existing cosine-filter behavior with its constant drift regressor

Closes #350.
