### PR TITLE
fix(plotting): exclude non-finite values from composite normalization

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -40,6 +40,13 @@ Current development version for the next ConfUSIus release.
   `beamforming_sound_velocity` arguments
   ([#322](https://github.com/confusius-tools/confusius/pull/322)).
 
+### :bug: Fixes
+
+- `plot_composite` no longer produces a blank/NaN composite when either input has
+  been scaled with `.fusi.scale.db()`; the `-inf` values `db_scale` assigns to
+  zero-valued voxels are now excluded from the normalization bounds
+  ([#370](https://github.com/confusius-tools/confusius/pull/370)).
+
 ## 0.6.1
 
 Released 2026-08-07.

--- a/src/confusius/_utils/plotting.py
+++ b/src/confusius/_utils/plotting.py
@@ -16,12 +16,23 @@ def scale_min_max(arr: NDArray[np.floating]) -> NDArray[np.floating]:
     -------
     numpy.ndarray
         Float array with the same shape as `arr`, rescaled to `[0, 1]`. Returns an
-        all-zero array when `arr` is flat (`arr.min() == arr.max()`).
+        all-zero array when `arr` is flat (`arr.min() == arr.max()`). Non-finite values
+        (e.g. `-inf` from [`db_scale`][confusius.xarray.scale.db_scale] on zero-valued
+        voxels) are excluded when computing the scaling bounds and clipped to `0`/`1`
+        in the output, instead of propagating as `nan`.
+
+    Raises
+    ------
+    ValueError
+        If `arr` contains no finite values.
     """
-    lo, hi = arr.min(), arr.max()
+    finite = arr[np.isfinite(arr)]
+    if finite.size == 0:
+        raise ValueError("Cannot scale an array with no finite values.")
+    lo, hi = finite.min(), finite.max()
     if hi == lo:
         return np.zeros_like(arr, dtype=float)
-    return (arr - lo) / (hi - lo)
+    return np.clip((arr - lo) / (hi - lo), 0.0, 1.0)
 
 
 def blend_red_cyan(

--- a/src/confusius/_utils/plotting.py
+++ b/src/confusius/_utils/plotting.py
@@ -16,10 +16,11 @@ def scale_min_max(arr: NDArray[np.floating]) -> NDArray[np.floating]:
     -------
     numpy.ndarray
         Float array with the same shape as `arr`, rescaled to `[0, 1]`. Returns an
-        all-zero array when `arr` is flat (`arr.min() == arr.max()`). Non-finite values
-        (e.g. `-inf` from [`db_scale`][confusius.xarray.scale.db_scale] on zero-valued
-        voxels) are excluded when computing the scaling bounds and clipped to `0`/`1`
-        in the output, instead of propagating as `nan`.
+        all-zero array when `arr` is flat (`arr.min() == arr.max()`). `-inf`/`inf` values
+        (e.g. from [`db_scale`][confusius.xarray.scale.db_scale] on zero-valued voxels)
+        are excluded when computing the scaling bounds and clipped to `0`/`1` in the
+        output. `nan` elements are likewise excluded from the bounds but remain `nan`
+        in the output, since there is no position on the `[0, 1]` scale to clip them to.
 
     Raises
     ------

--- a/src/confusius/plotting/image.py
+++ b/src/confusius/plotting/image.py
@@ -1303,14 +1303,20 @@ class VolumePlotter:
         elif normalize_strategy == "shared":
             arr1 = data1.values.astype(float)
             arr2 = data2.values.astype(float)
-            lo = float(min(arr1.min(), arr2.min()))
-            hi = float(max(arr1.max(), arr2.max()))
+            finite = np.concatenate([arr1[np.isfinite(arr1)], arr2[np.isfinite(arr2)]])
+            if finite.size == 0:
+                raise ValueError(
+                    "Cannot normalize data1/data2 with 'shared' strategy: no finite "
+                    "values found in either array."
+                )
+            lo = float(finite.min())
+            hi = float(finite.max())
             if hi == lo:
                 arr1 = np.zeros_like(arr1)
                 arr2 = np.zeros_like(arr2)
             else:
-                arr1 = (arr1 - lo) / (hi - lo)
-                arr2 = (arr2 - lo) / (hi - lo)
+                arr1 = np.clip((arr1 - lo) / (hi - lo), 0.0, 1.0)
+                arr2 = np.clip((arr2 - lo) / (hi - lo), 0.0, 1.0)
             data1 = data1.copy(data=arr1)
             data2 = data2.copy(data=arr2)
 

--- a/tests/unit/test_plotting/test_image_composite.py
+++ b/tests/unit/test_plotting/test_image_composite.py
@@ -284,6 +284,16 @@ class TestAddCompositeNormalize:
         assert red_max == pytest.approx(0.25, abs=1e-6)
         assert cyan_max == pytest.approx(1.0, abs=1e-6)
 
+    def test_shared_raises_when_no_finite_values(
+        self, sample_3d_volume, matplotlib_pyplot
+    ):
+        data1 = sample_3d_volume.copy(data=np.full(sample_3d_volume.shape, -np.inf))
+        data2 = sample_3d_volume.copy(data=np.full(sample_3d_volume.shape, np.nan))
+        with pytest.raises(ValueError, match="no finite"):
+            VolumePlotter(slice_mode="z").add_composite(
+                data1, data2, resample=False, normalize_strategy="shared"
+            )
+
     @pytest.mark.parametrize(
         "normalize_strategy", ["per_volume", "per_slice", "shared"]
     )

--- a/tests/unit/test_plotting/test_image_composite.py
+++ b/tests/unit/test_plotting/test_image_composite.py
@@ -284,6 +284,31 @@ class TestAddCompositeNormalize:
         assert red_max == pytest.approx(0.25, abs=1e-6)
         assert cyan_max == pytest.approx(1.0, abs=1e-6)
 
+    @pytest.mark.parametrize(
+        "normalize_strategy", ["per_volume", "per_slice", "shared"]
+    )
+    def test_neg_inf_background_does_not_propagate_nan(
+        self, sample_3d_volume, matplotlib_pyplot, normalize_strategy
+    ):
+        # db_scale maps zero/negative voxels to -inf (background in power-Doppler
+        # data). All three normalisation strategies must exclude -inf from the
+        # min/max bounds instead of letting it turn every pixel into nan.
+        base1 = sample_3d_volume.copy()
+        base1.values[0, 0, 0] = 0.0
+        base2 = _shifted_volume(sample_3d_volume)
+        base2.values[0, 0, 0] = 0.0
+        data1 = base1.fusi.scale.db()
+        data2 = base2.fusi.scale.db()
+
+        plotter = VolumePlotter(slice_mode="z").add_composite(
+            data1, data2, resample=False, normalize_strategy=normalize_strategy
+        )
+        for ax in _axes(plotter).ravel():
+            rgb = ax.collections[0].get_array()
+            assert np.isfinite(rgb).all()
+            assert rgb.min() >= 0.0
+            assert rgb.max() <= 1.0
+
 
 class TestAddCompositeValidation:
     """Validation guards on add_composite inputs."""

--- a/tests/unit/test_utils/test_plotting.py
+++ b/tests/unit/test_utils/test_plotting.py
@@ -1,0 +1,23 @@
+"""Tests for confusius._utils.plotting."""
+
+import numpy as np
+import pytest
+
+from confusius._utils.plotting import scale_min_max
+
+
+def test_scale_min_max_ignores_inf_but_preserves_nan():
+    arr = np.array([-np.inf, 0.0, 5.0, 10.0, np.nan])
+    result = scale_min_max(arr)
+
+    # -inf/inf are excluded from the bounds and clipped into [0, 1]; nan is
+    # excluded from the bounds too but has no position on the scale to clip to.
+    assert result[0] == 0.0
+    np.testing.assert_allclose(result[1:4], [0.0, 0.5, 1.0])
+    assert np.isnan(result[4])
+
+
+def test_scale_min_max_raises_on_no_finite_values():
+    arr = np.array([-np.inf, np.inf, np.nan])
+    with pytest.raises(ValueError, match="no finite values"):
+        scale_min_max(arr)


### PR DESCRIPTION
## Summary
- `db_scale` maps zero/negative voxels to `-inf`, which `scale_min_max` and the `"shared"` branch of `add_composite` fed straight into `min()`/`max()`, turning every normalized pixel into `nan` and silently blanking `plot_composite` output.
- Both now exclude non-finite values from the normalization bounds and clip output to `[0, 1]`.

Fixes #369