### PR TITLE
fix(docs): fix latest docs alias

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -305,13 +305,13 @@ jobs:
           git -C /tmp/confusius-docs config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Deploy dev docs
-        if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+        if: github.ref == 'refs/heads/main'
         working-directory: /tmp/confusius-docs
-        run: uv run --project ${{ github.workspace }} mike deploy --config-file ${{ github.workspace }}/zensical.toml --branch main --push --update-aliases dev latest
+        run: uv run --project ${{ github.workspace }} mike deploy --config-file ${{ github.workspace }}/zensical.toml --branch main --push --update-aliases dev
 
       - name: Deploy release docs
         if: startsWith(github.ref, 'refs/tags/v')
         working-directory: /tmp/confusius-docs
         run: |
           VERSION="${GITHUB_REF#refs/tags/v}"
-          uv run --project ${{ github.workspace }} mike deploy --config-file ${{ github.workspace }}/zensical.toml --branch main --push "$VERSION"
+          uv run --project ${{ github.workspace }} mike deploy --config-file ${{ github.workspace }}/zensical.toml --branch main --push --update-aliases "$VERSION" latest


### PR DESCRIPTION
Closes #389.

- keep main docs at /dev
- move /latest alias to release tag deploys
- avoid treating manual dispatch as a dev deploy on tag refs

For the already-published 0.6.1 docs, do a one-time mike alias update after merge; rerunning the old tag workflow would use the old workflow file.

Checks: pre-commit hooks on commit.
