### PR TITLE
fix(nifti): keep the primary header form recoverable after apply

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -148,6 +148,11 @@ Current development version for the next ConfUSIus release.
 
 ### :bug: Fixes
 
+- `load_nifti` now stores an identity `world_to_qform`/`world_to_sform` entry for
+  the coordinate-defining form, so applying another affine (e.g.
+  `.fusi.affine.apply("world_to_sform")`) keeps that form recoverable and
+  `save_nifti` writes it back to the header
+  ([#399](https://github.com/confusius-tools/confusius/pull/399)).
 - `save_nifti` now always writes both a qform and sform (previously sform was
   silently dropped when no secondary affine had been explicitly recorded)
   ([#278](https://github.com/confusius-tools/confusius/pull/278)).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -148,11 +148,6 @@ Current development version for the next ConfUSIus release.
 
 ### :bug: Fixes
 
-- `load_nifti` now stores an identity `world_to_qform`/`world_to_sform` entry for
-  the coordinate-defining form, so applying another affine (e.g.
-  `.fusi.affine.apply("world_to_sform")`) keeps that form recoverable and
-  `save_nifti` writes it back to the header
-  ([#399](https://github.com/confusius-tools/confusius/pull/399)).
 - `save_nifti` now always writes both a qform and sform (previously sform was
   silently dropped when no secondary affine had been explicitly recorded)
   ([#278](https://github.com/confusius-tools/confusius/pull/278)).

--- a/docs/user-guide/voxeldata.md
+++ b/docs/user-guide/voxeldata.md
@@ -384,10 +384,10 @@ pose.
 
 Several loaders populate `.attrs["affines"]` automatically:
 
-- **NIfTI**: The world space is whichever affine (`sform` or `qform`) was selected—it
-  never appears in `.attrs["affines"]` itself. When the other one is also valid, it is
-  stored as `"world_to_sform"` or `"world_to_qform"` accordingly, so the world space can
-  be switched between the two. [`save_nifti`][confusius.io.save_nifti] can write any
+- **NIfTI**: The world space is whichever affine (`sform` or `qform`) was selected; its
+  own entry (`"world_to_sform"` or `"world_to_qform"`) is the identity. When the other
+  one is also valid, it is stored under the other key, so the world space can be
+  switched between the two. [`save_nifti`][confusius.io.save_nifti] can write any
   named affine in `.attrs["affines"]` back to the header via its `qform=`/`sform=`
   arguments, defaulting to `"world_to_qform"`/`"world_to_sform"` when not specified.
 - **Iconeus SCAN**: [`load_scan`][confusius.io.load_scan] stores a
@@ -438,7 +438,8 @@ Applying `world_to_qform` absorbs the rotation into the DataArray's voxel-to-wor
 affine, and the derived `z`/`y` coordinates change accordingly. The `qform` space
 becomes the new world space, and `"world_to_qform"` is dropped from the result:
 applying a stored affine by its own key re-anchors the world space to exactly that
-space, so the entry would carry no information any more.
+space, so the entry would carry no information any more. The `sform` entry, identity
+before, now holds the inverse rotation, so the `sform` space stays recoverable.
 
 ```pycon
 >>> da_q = da.fusi.affine.apply("world_to_qform")
@@ -448,7 +449,10 @@ array([-0.5, -1.5, -2.5, -3.5, -0.5, -1.5, -2.5, -3.5, -0.5, -1.5, -2.5,
 >>> da_q.coords["y"].values.flatten()
 array([-1., -1., -1., -1.,  0.,  0.,  0.,  0.,  1.,  1.,  1.,  1.])
 >>> da_q.attrs["affines"]
-{}
+{'world_to_sform': array([[ 0.,  1.,  0.,  0.],
+       [-1.,  0.,  0.,  0.],
+       [ 0.,  0.,  1.,  0.],
+       [ 0.,  0.,  0.,  1.]])}
 ```
 
 See [Affine Transforms](xarray.md#affine-transforms) in Working with Xarray for

--- a/src/confusius/_napari/_registration/_transform_payloads.py
+++ b/src/confusius/_napari/_registration/_transform_payloads.py
@@ -336,7 +336,8 @@ def _normalize_loaded_bspline_transform(transform: xr.DataArray) -> xr.DataArray
     affines = normalized.attrs.get("affines")
     if isinstance(affines, dict):
         normalized_affines = dict(affines)
-        normalized_affines.pop("world_to_qform", None)
+        for nifti_key in ("world_to_qform", "world_to_sform"):
+            normalized_affines.pop(nifti_key, None)
         if normalized_affines:
             normalized.attrs["affines"] = normalized_affines
         else:

--- a/src/confusius/io/nifti.py
+++ b/src/confusius/io/nifti.py
@@ -476,21 +476,21 @@ def _resolve_spatial_geometry_from_nifti(
     # exactly equivalent to evaluating the affine at voxel-index 0 along that
     # axis (index 0 zeroes out that column's contribution).
     #
-    # The primary form has no named `attrs["affines"]` entry: it is not a
-    # separately tracked relationship, it *is* the array's own world frame,
-    # so on save it always mirrors the current `voxel_to_world` (see
-    # `_build_selected_nifti_affine`'s `affine_key=None` fallback). Only the
-    # secondary form is a genuinely distinct, named relationship, so only it
-    # gets one: secondary = world_to_<secondary> @ primary, so
+    # The primary form *is* the array's world frame, so its entry is identity.
+    # Storing it (rather than omitting it) is what lets `apply_affine` keep track
+    # of it: applying another affine re-expresses this identity into the
+    # relationship between the new world frame and the original primary form, so
+    # `save_nifti` can still write that form back to the header (#397). The
+    # secondary form is a genuinely distinct relationship:
+    # secondary = world_to_<secondary> @ primary, so
     # world_to_<secondary> = secondary @ inv(primary).
     voxel_to_world = primary_affine[[2, 1, 0, 3]][:, [2, 1, 0, 3]]
+    extra_attrs["affines"] = {f"world_to_{primary_prefix}": np.eye(4)}
     if secondary_affine is not None:
         world_to_secondary = secondary_affine @ np.linalg.inv(primary_affine)
-        extra_attrs["affines"] = {
-            f"world_to_{secondary_prefix}": world_to_secondary[[2, 1, 0, 3]][
-                :, [2, 1, 0, 3]
-            ]
-        }
+        extra_attrs["affines"][f"world_to_{secondary_prefix}"] = world_to_secondary[
+            [2, 1, 0, 3]
+        ][:, [2, 1, 0, 3]]
 
     return voxel_to_world, units, extra_attrs
 
@@ -1139,11 +1139,16 @@ def load_nifti(
 
     With `coordinate_affine="auto"`, affine selection follows NIfTI conventions:
 
-    - If `sform_code > 0`: sform is used as the primary affine; a
+    - If `sform_code > 0`: sform is used as the primary affine; an identity
       `"world_to_sform"` entry is written. When `qform_code > 0` as well, a
       `"world_to_qform"` entry is also stored as secondary.
-    - Else, if only `qform_code > 0`: qform is used as the primary affine; only
-      `"world_to_qform"` is written.
+    - Else, if only `qform_code > 0`: qform is used as the primary affine; only an
+      identity `"world_to_qform"` entry is written.
+
+    The primary form's identity entry is what keeps that form recoverable after
+    [`apply`][confusius.xarray.FUSIAffineAccessor.apply] re-anchors the world
+    frame elsewhere: it is re-expressed along with the other entries, so
+    [`save_nifti`][confusius.io.save_nifti] can still write the original header form.
     - If both codes are zero: a warning is emitted, coordinates are built from
       `pixdim` only (origin 0, step = voxel size), and no `"affines"` entry is
       stored in `da.attrs`.

--- a/tests/unit/test_io/test_nifti.py
+++ b/tests/unit/test_io/test_nifti.py
@@ -936,10 +936,10 @@ class TestLoadNifti:
         assert "z_qform" not in da.coords
         # Primary z coord (NIfTI col 2, size 2) should reflect qform spacing of 4.0.
         np.testing.assert_allclose(_world_coord_1d(da, "z"), [0.0, 4.0])
-        # qform is primary with no valid secondary (sform is invalid), so it has no
-        # named attrs["affines"] entry -- it's the array's own world frame, not a
-        # separately tracked relationship.
-        assert "affines" not in da.attrs
+        # qform is primary, so its entry is identity (world frame == qform frame);
+        # the invalid sform gets no entry at all.
+        np.testing.assert_array_equal(da.attrs["affines"]["world_to_qform"], np.eye(4))
+        assert "world_to_sform" not in da.attrs["affines"]
 
     def test_load_nifti_coordinate_affine_sform_forces_sform(
         self, tmp_path: Path
@@ -960,9 +960,8 @@ class TestLoadNifti:
         np.testing.assert_allclose(
             get_voxel_to_world_affine(da)[:3, :3], np.diag([4.0, 3.0, 2.0])
         )
-        # sform is primary (no named entry of its own); qform is the distinct
-        # secondary relationship, so only it gets a named affines entry.
-        assert "world_to_sform" not in da.attrs["affines"]
+        # sform is primary (identity entry); qform is the distinct secondary.
+        np.testing.assert_array_equal(da.attrs["affines"]["world_to_sform"], np.eye(4))
         assert "world_to_qform" in da.attrs["affines"]
 
     def test_load_nifti_coordinate_affine_qform_forces_qform(
@@ -984,9 +983,8 @@ class TestLoadNifti:
         np.testing.assert_allclose(
             get_voxel_to_world_affine(da)[:3, :3], np.diag([7.0, 6.0, 5.0])
         )
-        # qform is primary (no named entry of its own); sform is the distinct
-        # secondary relationship, so only it gets a named affines entry.
-        assert "world_to_qform" not in da.attrs["affines"]
+        # qform is primary (identity entry); sform is the distinct secondary.
+        np.testing.assert_array_equal(da.attrs["affines"]["world_to_qform"], np.eye(4))
         assert "world_to_sform" in da.attrs["affines"]
 
     def test_load_nifti_rotated_affine_voxel_to_world(self, tmp_path: Path) -> None:
@@ -995,8 +993,7 @@ class TestLoadNifti:
         The voxel-to-world index represents rotations exactly, so the sform's 90°
         rotation (mapping voxel x->world y, voxel y->world -x) is not dropped into
         a residual "world_to_sform" entry -- it lands directly in
-        `voxel_to_world`. Sform is primary here (with no valid qform), so it has no
-        named `attrs["affines"]` entry at all.
+        `voxel_to_world`, and the primary sform's own entry is identity.
         """
         # 90° rotation around z maps x→y, y→-x with spacing [2, 3, 4].
         spacing = np.array([2.0, 3.0, 4.0])
@@ -1023,7 +1020,7 @@ class TestLoadNifti:
         np.testing.assert_allclose(
             get_voxel_to_world_affine(da), expected_voxel_to_world
         )
-        assert "affines" not in da.attrs
+        np.testing.assert_array_equal(da.attrs["affines"]["world_to_sform"], np.eye(4))
 
     def test_load_nifti_sheared_affine_correct_spacing(self, tmp_path: Path) -> None:
         """Sheared affine uses decompose44 spacings, not (wrong) column norms."""
@@ -3088,11 +3085,9 @@ class TestRoundtrip:
         the coordinates, otherwise the saved qform carries the stale voxel size
         on that axis.
 
-        Sform (primary here) has no named `attrs["affines"]` entry of its own, so
-        after `apply_affine` moves the world frame into qform's space, sform is
-        no longer recoverable -- it mirrors the new `voxel_to_world` on save, same
-        as qform (whose own `world_to_qform` entry is now identity, re-expressed
-        by `apply_affine`).
+        Sform (primary here) starts with an identity `world_to_sform` entry, which
+        `apply_affine` re-expresses against the new qform-anchored world frame, so
+        both header forms survive the round trip.
         """
         sform = np.diag([2.0, 3.0, 4.0, 1.0])
         sform[:3, 3] = [10.0, -5.0, 2.0]
@@ -3115,7 +3110,41 @@ class TestRoundtrip:
             reloaded.header.get_qform(coded=True)[0], qform, atol=1e-4
         )
         np.testing.assert_allclose(
-            reloaded.header.get_sform(coded=True)[0], qform, atol=1e-4
+            reloaded.header.get_sform(coded=True)[0], sform, atol=1e-4
+        )
+
+    def test_roundtrip_qform_after_applying_added_sform_key(self, tmp_path):
+        """Applying a user-added `world_to_sform` by key keeps the original qform.
+
+        Regression (#397): a qform-only file gets a `world_to_sform` entry, which is
+        then applied in place. The saved header must still carry the original qform
+        (code preserved) alongside the new sform.
+        """
+        qform = np.diag([1.0, 2.0, 3.0, 1.0])
+        qform[:3, 3] = [10.0, 20.0, 30.0]
+        img = nib.Nifti1Image(np.zeros((4, 3, 2), dtype=np.float32), qform)
+        img.header.set_qform(qform, code=1)
+        img.header.set_sform(None, code=0)
+        in_path = tmp_path / "in.nii.gz"
+        img.to_filename(in_path)
+
+        da = load_nifti(in_path)
+        # Sheared world-to-sform in ConfUSIus (z, y, x) order.
+        world_to_sform = np.eye(4)
+        world_to_sform[0, 1] = 0.3
+        world_to_sform[:3, 3] = [1.0, 2.0, 3.0]
+        da.attrs["affines"]["world_to_sform"] = world_to_sform
+        da.fusi.affine.apply("world_to_sform", inplace=True)
+        out_path = tmp_path / "out.nii.gz"
+        save_nifti(da, out_path)
+        reloaded = nib.nifti1.Nifti1Image.from_filename(out_path)
+
+        saved_qform, saved_qform_code = reloaded.header.get_qform(coded=True)
+        assert saved_qform_code == 1
+        np.testing.assert_allclose(saved_qform, qform, atol=1e-4)
+        expected_sform = world_to_sform[[2, 1, 0, 3]][:, [2, 1, 0, 3]] @ qform
+        np.testing.assert_allclose(
+            reloaded.header.get_sform(coded=True)[0], expected_sform, atol=1e-4
         )
 
     def test_roundtrip_3d(self, tmp_path, sample_voxeldata_3d):


### PR DESCRIPTION
Closes #397

## Problem

Loading a qform-only NIfTI, adding `attrs["affines"]["world_to_sform"]`, applying it with `da.fusi.affine.apply("world_to_sform", inplace=True)` and saving dropped the original qform from the header: `load_nifti` stored no `affines` entry for the primary form, so after `apply` moved the world frame there was nothing left describing where it came from. Depending on shear, the saved file either disabled qform with a warning or silently wrote the sform geometry into qform under the stale `qform_code`. The symmetric case (both forms loaded, `apply("world_to_qform")`) lost the sform the same way.

## Fix

`load_nifti` now stores an identity `world_to_<primary>` entry (`world_to_qform` or `world_to_sform`, whichever defines the world frame). `apply_affine` already re-expresses every stored entry against the new frame, so the identity turns into the exact relationship between the new world frame and the original primary form, and `save_nifti` picks it up through its existing default-key lookup. No change to `apply_affine` or the save path.

The napari B-spline loader strips the new NIfTI-added `world_to_sform` entry the same way it already stripped `world_to_qform`.

## Tests

- New `test_roundtrip_qform_after_applying_added_sform_key`: the issue scenario, asserts qform matrix and code survive and sform equals the applied geometry.
- `test_roundtrip_qform_after_apply_affine_with_singleton_dim` now asserts sform survives as the original sform (previously documented as lost).
- Load tests updated for the identity entry on the primary form.
