### PR TITLE
fix(registration): default metric_sampling_percentage to None

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -109,9 +109,10 @@ Current development version for the next ConfUSIus release.
 ### :sparkles: Enhancements
 
 - [`register_volume`][confusius.registration.register_volume] now supports random
-  metric sampling via `metric_sampling_percentage`, with optional deterministic
-  seeding via `metric_sampling_seed`, to speed up large affine or B-spline
-  registrations ([#396](https://github.com/confusius-tools/confusius/issues/396)).
+  metric sampling via `metric_sampling_percentage` (`None` by default, disabling
+  random sampling), with optional deterministic seeding via `metric_sampling_seed`,
+  to speed up large affine or B-spline registrations
+  ([#396](https://github.com/confusius-tools/confusius/issues/396)).
 - `VoxelToWorldIndex`/`create_voxeldata`/`attach_voxel_to_world_index` now
   support pose-dependent voxel-to-world geometry: a `(npose, 4, 4)` affine
   stack, one per pose, instead of one affine shared by every pose. New

--- a/src/confusius/registration/volume.py
+++ b/src/confusius/registration/volume.py
@@ -35,7 +35,7 @@ def _validate_register_volume_inputs(
     transform_type: Literal["translation", "rigid", "affine", "bspline"],
     metric: Literal["correlation", "mattes_mi"],
     number_of_histogram_bins: int,
-    metric_sampling_percentage: float,
+    metric_sampling_percentage: float | None,
     metric_sampling_seed: int | None,
     learning_rate: float | Literal["auto"],
     number_of_iterations: int,
@@ -65,8 +65,9 @@ def _validate_register_volume_inputs(
         Similarity metric name.
     number_of_histogram_bins : int
         Number of histogram bins for Mattes mutual information.
-    metric_sampling_percentage : float, default: 1.0
-        Random metric sampling percentage in `(0, 1]`.
+    metric_sampling_percentage : float, optional
+        Random metric sampling percentage in `(0, 1]`. If not provided, all voxels
+        are used without random sampling.
     metric_sampling_seed : int, optional
         Random metric sampling seed.
     learning_rate : float or "auto"
@@ -195,7 +196,7 @@ def _validate_register_volume_inputs(
             f"got {number_of_histogram_bins!r}."
         )
 
-    if (
+    if metric_sampling_percentage is not None and (
         not isinstance(metric_sampling_percentage, (int, float))
         or not np.isfinite(metric_sampling_percentage)
         or not 0 < metric_sampling_percentage <= 1
@@ -205,7 +206,9 @@ def _validate_register_volume_inputs(
             f"than 1; got {metric_sampling_percentage!r}."
         )
 
-    if metric_sampling_seed is not None and metric_sampling_percentage >= 1:
+    if metric_sampling_seed is not None and (
+        metric_sampling_percentage is None or metric_sampling_percentage >= 1
+    ):
         raise ValueError(
             "metric_sampling_seed requires metric_sampling_percentage below 1."
         )
@@ -296,7 +299,7 @@ def register_volume(  # numpydoc ignore=GL08,PR01,RT01
     transform_type: Literal["translation", "rigid", "affine"],
     metric: Literal["correlation", "mattes_mi"] = ...,
     number_of_histogram_bins: int = ...,
-    metric_sampling_percentage: float = ...,
+    metric_sampling_percentage: float | None = ...,
     metric_sampling_seed: int | None = ...,
     learning_rate: float | Literal["auto"] = ...,
     number_of_iterations: int = ...,
@@ -333,7 +336,7 @@ def register_volume(  # numpydoc ignore=GL08,PR01,RT01
     transform_type: Literal["bspline"],
     metric: Literal["correlation", "mattes_mi"] = ...,
     number_of_histogram_bins: int = ...,
-    metric_sampling_percentage: float = ...,
+    metric_sampling_percentage: float | None = ...,
     metric_sampling_seed: int | None = ...,
     learning_rate: float | Literal["auto"] = ...,
     number_of_iterations: int = ...,
@@ -369,7 +372,7 @@ def register_volume(  # numpydoc ignore=GL08,PR01,RT01
     moving_mask: xr.DataArray | None = ...,
     metric: Literal["correlation", "mattes_mi"] = ...,
     number_of_histogram_bins: int = ...,
-    metric_sampling_percentage: float = ...,
+    metric_sampling_percentage: float | None = ...,
     metric_sampling_seed: int | None = ...,
     learning_rate: float | Literal["auto"] = ...,
     number_of_iterations: int = ...,
@@ -405,7 +408,7 @@ def register_volume(
     transform_type: Literal["translation", "rigid", "affine", "bspline"] = "rigid",
     metric: Literal["correlation", "mattes_mi"] = "correlation",
     number_of_histogram_bins: int = 50,
-    metric_sampling_percentage: float = 1.0,
+    metric_sampling_percentage: float | None = None,
     metric_sampling_seed: int | None = None,
     learning_rate: float | Literal["auto"] = "auto",
     number_of_iterations: int = 100,
@@ -470,9 +473,9 @@ def register_volume(
     number_of_histogram_bins : int, default: 50
         Number of histogram bins used by Mattes mutual information. Only
         relevant when using `"mattes_mi"` metric.
-    metric_sampling_percentage : float, default: 1.0
+    metric_sampling_percentage : float, optional
         Percentage of voxels randomly sampled when computing the metric, in `(0, 1]`.
-        A value of `1.0` uses all voxels without random sampling.
+        If not provided, all voxels are used without random sampling.
     metric_sampling_seed : int, optional
         Seed for random metric sampling. Only used when `metric_sampling_percentage < 1`.
         If not provided, SimpleITK's default `sitkWallClock` seed is used.
@@ -697,7 +700,7 @@ def register_volume(
             numberOfHistogramBins=number_of_histogram_bins
         )
 
-    if metric_sampling_percentage < 1:
+    if metric_sampling_percentage is not None and metric_sampling_percentage < 1:
         registration.SetMetricSamplingStrategy(registration.RANDOM)
         if metric_sampling_seed is None:
             registration.SetMetricSamplingPercentage(metric_sampling_percentage)

--- a/src/confusius/xarray/registration.py
+++ b/src/confusius/xarray/registration.py
@@ -42,7 +42,7 @@ class FUSIRegistrationAccessor:
         transform: Literal["translation", "rigid", "affine", "bspline"] = "rigid",
         metric: Literal["correlation", "mattes_mi"] = "correlation",
         number_of_histogram_bins: int = 50,
-        metric_sampling_percentage: float = 1.0,
+        metric_sampling_percentage: float | None = None,
         metric_sampling_seed: int | None = None,
         learning_rate: float | Literal["auto"] = "auto",
         number_of_iterations: int = 100,
@@ -82,9 +82,9 @@ class FUSIRegistrationAccessor:
             Similarity metric for registration.
         number_of_histogram_bins : int, default: 50
             Number of histogram bins (only used when `metric="mattes_mi"`).
-        metric_sampling_percentage : float, default: 1.0
+        metric_sampling_percentage : float, optional
             Percentage of voxels randomly sampled when computing the metric, in `(0, 1]`.
-            A value of `1.0` uses all voxels without random sampling.
+            If not provided, all voxels are used without random sampling.
         metric_sampling_seed : int, optional
             Seed for random metric sampling. Only used when
             `metric_sampling_percentage < 1`. If not provided, SimpleITK's default


### PR DESCRIPTION
Change the default because it makes more sense: 100% random sampling isn't equivalent to no sampling, since random sampling is done with replacement.