### PR TITLE
feat(registration): add intensity_scaling to register_volume/register_volumewise

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -113,12 +113,14 @@ Current development version for the next ConfUSIus release.
   random sampling), with optional deterministic seeding via `metric_sampling_seed`,
   to speed up large affine or B-spline registrations
   ([#396](https://github.com/confusius-tools/confusius/issues/396)).
-- [`register_volume`][confusius.registration.register_volume] and
-  [`register_volumewise`][confusius.registration.register_volumewise] gained an
-  `intensity_scaling` argument (`"none"` by default) to rescale the images passed
-  to the registration optimizer without affecting the returned/resampled data:
+- [`register_volume`][confusius.registration.register_volume] gained
+  `fixed_intensity_scaling`/`moving_intensity_scaling` and
+  [`register_volumewise`][confusius.registration.register_volumewise] gained
+  `intensity_scaling` (all `"none"` by default) to rescale the images passed to
+  the registration optimizer without affecting the returned/resampled data:
   `"db"`, `"sqrt"` (an alias for `0.5`), or any positive float exponent for power
-  scaling.
+  scaling. **[Napari plugin]** The Registration panel exposes the same selectors
+  ([#405](https://github.com/confusius-tools/confusius/pull/405)).
 - `VoxelToWorldIndex`/`create_voxeldata`/`attach_voxel_to_world_index` now
   support pose-dependent voxel-to-world geometry: a `(npose, 4, 4)` affine
   stack, one per pose, instead of one affine shared by every pose. New

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -113,6 +113,12 @@ Current development version for the next ConfUSIus release.
   random sampling), with optional deterministic seeding via `metric_sampling_seed`,
   to speed up large affine or B-spline registrations
   ([#396](https://github.com/confusius-tools/confusius/issues/396)).
+- [`register_volume`][confusius.registration.register_volume] and
+  [`register_volumewise`][confusius.registration.register_volumewise] gained an
+  `intensity_scaling` argument (`"none"` by default) to rescale the images passed
+  to the registration optimizer without affecting the returned/resampled data:
+  `"db"`, `"sqrt"` (an alias for `0.5`), or any positive float exponent for power
+  scaling.
 - `VoxelToWorldIndex`/`create_voxeldata`/`attach_voxel_to_world_index` now
   support pose-dependent voxel-to-world geometry: a `(npose, 4, 4)` affine
   stack, one per pose, instead of one affine shared by every pose. New

--- a/docs/gui/plugin.md
+++ b/docs/gui/plugin.md
@@ -336,7 +336,7 @@ large-scale and local deformation at once.
 | **Transform** | Chooses the motion model being optimized. | Start with `translation` or `rigid` for simple alignment; use `affine` for global scale/shear differences; use `bspline` only after a good global initialization. |
 | **Mesh size** | Sets the B-spline control-grid density. | Increase it only when `bspline` needs to capture finer local mismatches; too fine a grid can lead to unrealistic warping. |
 | **Metric** | Chooses the similarity criterion (`correlation` or `mattes_mi`). | `correlation` is a good default for power Doppler data; `mattes_mi` is more robust when intensity distributions differ. |
-| **Scale** | Applies optional intensity scaling before registration. | Useful for power Doppler data where large vessels are typically overbright compared to finer structures. |
+| **Fixed / Moving intensity scaling** | Applies optional intensity scaling (`decibel`, `square root`, or `none`) to the fixed and moving layers, only for the optimizer; result layers keep their original intensities. | Useful for power Doppler data where large vessels are typically overbright compared to finer structures. Set them differently when the two layers are already on different scales (e.g. a dB atlas and linear power Doppler). |
 | **Initialization** | Sets the starting transform before optimization. | Use `center_geometry` or `center_moments` for coarse setup; reuse a saved/manual affine transform when you already have a good approximate alignment. |
 | **Learning rate** | Sets the optimizer step size. | Leave **Auto** enabled to let SimpleITK estimate it each iteration, or untick it to use a fixed value (default `0.01`). |
 | **Iterations** | Maximum number of optimizer steps. | Increase it when alignment is still improving near the end of a run. |
@@ -380,7 +380,7 @@ Use **Within-scan** for motion correction inside a single time series.
 | **Reference volume** | Chooses the volume index used as the motion-correction target. | Pick a representative, sharp frame with little motion. |
 | **Transform** | Chooses the volume-wise motion model. | `rigid` is the safest starting point; `affine` is available when motion is more complex. |
 | **Metric** | Chooses the volume-to-reference similarity criterion. | `correlation` is usually a good default for within-recording motion correction. |
-| **Scale** | Applies optional preprocessing before registration. | Useful when an intensity transform makes anatomy more stable across time for the optimizer. |
+| **Intensity scaling** | Applies optional intensity scaling (`decibel`, `square root`, or `none`) to the reference and every frame, only for the optimizer. | Useful when an intensity transform makes anatomy more stable across time for the optimizer. |
 | **Initialization** | Sets the initial volume-wise centering transform. | Most runs can use no initialization. |
 | **Learning rate** | Sets the optimizer step size for each frame. | Within-scan uses a fixed value here; the default is `0.01`. Reduce it if updates look unstable; increase it if frames are already close and convergence is too slow. |
 | **Iterations** | Maximum optimizer steps per frame. | Increase it for harder motion or more flexible transforms. |

--- a/src/confusius/_napari/_registration/_panel.py
+++ b/src/confusius/_napari/_registration/_panel.py
@@ -75,7 +75,6 @@ from confusius._napari._registration._panel_transforms import (
 )
 from confusius._napari._registration._panel_utils import (
     ScientificDoubleSpinBox,
-    _apply_registration_scale,
     _get_source_dataarray,
     _is_registration_source_layer,
     _parse_comma_separated_ints,
@@ -98,7 +97,7 @@ if TYPE_CHECKING:
     from napari.layers import Image, Layer
 
 
-ScaleMode = Literal["off", "dB", "sqrt"]
+ScaleMode = Literal["none", "db", "sqrt"]
 """Allowed registration intensity-scaling modes used by the panel."""
 
 MetricName = Literal["correlation", "mattes_mi"]
@@ -664,16 +663,16 @@ class RegistrationPanel(QWidget):
         self._scale_combo.setSizePolicy(
             QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed
         )
-        self._scale_combo.addItem("decibel", "dB")
+        self._scale_combo.addItem("decibel", "db")
         self._scale_combo.addItem("square root", "sqrt")
-        self._scale_combo.addItem("none", "off")
+        self._scale_combo.addItem("none", "none")
         self._scale_combo.setToolTip(
-            "Optional intensity preprocessing applied before registration and used for registration preview layers."
+            "Intensity scaling used only by the registration optimizer; result layers keep original intensities."
         )
         params_layout.addRow(
             self._make_form_label(
-                "Scale",
-                tooltip="Optional intensity preprocessing applied before registration and used for registration preview layers.",
+                "Intensity scaling",
+                tooltip="Intensity scaling used only by the registration optimizer; result layers keep original intensities.",
             ),
             self._scale_combo,
         )
@@ -1667,8 +1666,6 @@ class RegistrationPanel(QWidget):
 
             moving = _prepare_between_scan_data(moving)
             fixed = _prepare_between_scan_data(fixed)
-            moving = _apply_registration_scale(moving, scale_mode)
-            fixed = _apply_registration_scale(fixed, scale_mode)
 
             initial_transform: npt.NDArray[np.floating] | None = None
             try:
@@ -1742,7 +1739,6 @@ class RegistrationPanel(QWidget):
                         )
                     ),
                     initial_transform=initial_transform,
-                    scale_mode=volume_payload["scale"],
                 )
             except Exception:  # noqa: BLE001
                 return
@@ -1768,6 +1764,7 @@ class RegistrationPanel(QWidget):
                 shrink_factors=volume_payload["shrink_factors"] or (6, 2, 1),
                 smoothing_sigmas=volume_payload["smoothing_sigmas"] or (6, 2, 1),
                 fill_value=volume_payload["fill_value"],
+                intensity_scaling=volume_payload["scale"],
                 sitk_threads=volume_payload["sitk_threads"],
                 show_progress=True,
                 progress_plotter=progress_plotter,
@@ -1819,8 +1816,6 @@ class RegistrationPanel(QWidget):
                 "reference_time": self._reference_time_spin.value(),
                 "n_jobs": self._n_jobs_spin.value(),
             }
-            moving = _apply_registration_scale(moving, volumewise_payload["scale"])
-
             progress_reporter = setup_volumewise_progress(
                 self,
                 moving_layer=cast("Image", moving_layer),
@@ -1830,7 +1825,6 @@ class RegistrationPanel(QWidget):
                         volumewise_payload["moving_layer_name"]
                     )
                 ),
-                scale_mode=volumewise_payload["scale"],
             )
 
             worker = thread_worker(register_volumewise)(
@@ -1844,6 +1838,7 @@ class RegistrationPanel(QWidget):
                 use_multi_resolution=volumewise_payload["use_multi_resolution"],
                 resample_interpolation=volumewise_payload["resample_interpolation"],
                 number_of_histogram_bins=volumewise_payload["number_of_histogram_bins"],
+                intensity_scaling=volumewise_payload["scale"],
                 convergence_minimum_value=volumewise_payload[
                     "convergence_minimum_value"
                 ],

--- a/src/confusius/_napari/_registration/_panel.py
+++ b/src/confusius/_napari/_registration/_panel.py
@@ -137,6 +137,7 @@ class ModeParameters(TypedDict):
     transform: str
     metric: MetricName
     scale: ScaleMode
+    fixed_scale: ScaleMode
     initialization: InitializationSelection
     learning_rate_auto: bool
     learning_rate_value: float
@@ -186,6 +187,7 @@ class VolumeRegistrationRunPayload(RegistrationRunPayloadBase):
 
     operation: Literal["register_volume"]
     transform: VolumeTransformType
+    fixed_scale: ScaleMode
     mesh_size: tuple[int, int, int]
     fixed_layer_name: str
     fixed_mask_layer_name: str | None
@@ -299,6 +301,31 @@ class RegistrationPanel(QWidget):
         self._setup_ui()
         self.viewer.layers.events.inserted.connect(self._refresh_layers)
         self.viewer.layers.events.removed.connect(self._refresh_layers)
+
+    def _make_scale_combo(self, tooltip: str) -> QComboBox:
+        """Return an intensity-scaling selector (decibel / square root / none).
+
+        Parameters
+        ----------
+        tooltip : str
+            Tooltip shown when hovering the combo box.
+
+        Returns
+        -------
+        QComboBox
+            Configured selector whose item data is the `ScaleMode` value.
+        """
+        combo = QComboBox()
+        combo.setMinimumContentsLength(10)
+        combo.setSizeAdjustPolicy(
+            QComboBox.SizeAdjustPolicy.AdjustToMinimumContentsLengthWithIcon
+        )
+        combo.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        combo.addItem("decibel", "db")
+        combo.addItem("square root", "sqrt")
+        combo.addItem("none", "none")
+        combo.setToolTip(tooltip)
+        return combo
 
     def _make_form_label(self, text: str, *, tooltip: str | None = None) -> QLabel:
         """Return a form label with an optional tooltip.
@@ -655,27 +682,23 @@ class RegistrationPanel(QWidget):
             self._metric_combo,
         )
 
-        self._scale_combo = QComboBox()
-        self._scale_combo.setMinimumContentsLength(10)
-        self._scale_combo.setSizeAdjustPolicy(
-            QComboBox.SizeAdjustPolicy.AdjustToMinimumContentsLengthWithIcon
+        self._fixed_scale_combo = self._make_scale_combo(
+            "Intensity scaling applied to the fixed layer, only by the registration optimizer; result layers keep original intensities."
         )
-        self._scale_combo.setSizePolicy(
-            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed
+        self._fixed_scale_label = self._make_form_label(
+            "Fixed intensity scaling", tooltip=self._fixed_scale_combo.toolTip()
         )
-        self._scale_combo.addItem("decibel", "db")
-        self._scale_combo.addItem("square root", "sqrt")
-        self._scale_combo.addItem("none", "none")
-        self._scale_combo.setToolTip(
-            "Intensity scaling used only by the registration optimizer; result layers keep original intensities."
+        params_layout.addRow(self._fixed_scale_label, self._fixed_scale_combo)
+
+        # Labelled "Moving intensity scaling" between scans and "Intensity scaling"
+        # within-scan, where it applies to the reference and every frame.
+        self._scale_combo = self._make_scale_combo(
+            "Intensity scaling applied to the moving layer (within-scan: to the reference and every frame), only by the registration optimizer; result layers keep original intensities."
         )
-        params_layout.addRow(
-            self._make_form_label(
-                "Intensity scaling",
-                tooltip="Intensity scaling used only by the registration optimizer; result layers keep original intensities.",
-            ),
-            self._scale_combo,
+        self._scale_label = self._make_form_label(
+            "Moving intensity scaling", tooltip=self._scale_combo.toolTip()
         )
+        params_layout.addRow(self._scale_label, self._scale_combo)
 
         self._initialization_combo = QComboBox()
         self._initialization_combo.setSizeAdjustPolicy(
@@ -1519,6 +1542,11 @@ class RegistrationPanel(QWidget):
         self._fixed_mask_row.setVisible(not is_volumewise)
         self._moving_mask_label.setVisible(not is_volumewise)
         self._moving_mask_row.setVisible(not is_volumewise)
+        self._fixed_scale_label.setVisible(not is_volumewise)
+        self._fixed_scale_combo.setVisible(not is_volumewise)
+        self._scale_label.setText(
+            "Intensity scaling" if is_volumewise else "Moving intensity scaling"
+        )
         self._reference_time_label.setVisible(is_volumewise)
         self._reference_time_spin.setVisible(is_volumewise)
         self._n_jobs_row.setVisible(is_volumewise)
@@ -1690,6 +1718,7 @@ class RegistrationPanel(QWidget):
                 "transform": transform,
                 "metric": metric,
                 "scale": scale_mode,
+                "fixed_scale": self._current_scale_mode(fixed=True),
                 "learning_rate": learning_rate,
                 "number_of_iterations": self._iterations_spin.value(),
                 "use_multi_resolution": use_multi_res,
@@ -1764,7 +1793,8 @@ class RegistrationPanel(QWidget):
                 shrink_factors=volume_payload["shrink_factors"] or (6, 2, 1),
                 smoothing_sigmas=volume_payload["smoothing_sigmas"] or (6, 2, 1),
                 fill_value=volume_payload["fill_value"],
-                intensity_scaling=volume_payload["scale"],
+                fixed_intensity_scaling=volume_payload["fixed_scale"],
+                moving_intensity_scaling=volume_payload["scale"],
                 sitk_threads=volume_payload["sitk_threads"],
                 show_progress=True,
                 progress_plotter=progress_plotter,

--- a/src/confusius/_napari/_registration/_panel_parameters.py
+++ b/src/confusius/_napari/_registration/_panel_parameters.py
@@ -32,6 +32,7 @@ def get_default_registration_parameters(
         "transform": "rigid",
         "metric": "correlation",
         "scale": "db",
+        "fixed_scale": "db",
         "initialization": "center_geometry",
         "learning_rate_auto": not is_volumewise,
         "learning_rate_value": 0.01,
@@ -73,6 +74,7 @@ def get_registration_parameters(panel: RegistrationPanel) -> ModeParameters:
         "transform": panel._transform_combo.currentText() or "rigid",
         "metric": panel._current_metric(),
         "scale": panel._current_scale_mode(),
+        "fixed_scale": panel._current_scale_mode(fixed=True),
         "initialization": panel._initialization_combo.currentData(),
         "learning_rate_auto": panel._learning_rate_auto_check.isChecked(),
         "learning_rate_value": panel._learning_rate_edit.value(),
@@ -134,10 +136,13 @@ def set_registration_parameters(
     panel._transform_combo.blockSignals(False)
 
     panel._metric_combo.setCurrentText(params["metric"])
-    scale_mode = params["scale"]
-    scale_index = panel._scale_combo.findData(scale_mode)
-    if scale_index >= 0:
-        panel._scale_combo.setCurrentIndex(scale_index)
+    for combo, scale_mode in (
+        (panel._scale_combo, params["scale"]),
+        (panel._fixed_scale_combo, params["fixed_scale"]),
+    ):
+        scale_index = combo.findData(scale_mode)
+        if scale_index >= 0:
+            combo.setCurrentIndex(scale_index)
     initialization_data = params.get("initialization")
     for i in range(panel._initialization_combo.count()):
         if panel._initialization_combo.itemData(i) == initialization_data:

--- a/src/confusius/_napari/_registration/_panel_parameters.py
+++ b/src/confusius/_napari/_registration/_panel_parameters.py
@@ -31,7 +31,7 @@ def get_default_registration_parameters(
     return {
         "transform": "rigid",
         "metric": "correlation",
-        "scale": "dB",
+        "scale": "db",
         "initialization": "center_geometry",
         "learning_rate_auto": not is_volumewise,
         "learning_rate_value": 0.01,

--- a/src/confusius/_napari/_registration/_panel_progress.py
+++ b/src/confusius/_napari/_registration/_panel_progress.py
@@ -13,7 +13,6 @@ from qtpy.QtWidgets import QDockWidget, QWidget
 from confusius._dims import TIME_DIM
 from confusius._napari._qt import find_main_window
 from confusius._napari._registration._panel_utils import (
-    _gamma_needs_reset,
     _get_image_display_kwargs_from_layer,
     _preserve_view,
 )
@@ -45,7 +44,6 @@ def setup_volumewise_progress(
     moving_layer: Image,
     moving: xr.DataArray,
     layer_name: str,
-    scale_mode: str,
 ) -> NapariRegistrationProgressReporter:
     """Create volumewise preview layers and a progress reporter.
 
@@ -59,8 +57,6 @@ def setup_volumewise_progress(
         Moving data used to seed the preview layer.
     layer_name : str
         Name for the live output layer.
-    scale_mode : str
-        Registration scaling mode used to decide preview gamma handling.
 
     Returns
     -------
@@ -72,9 +68,6 @@ def setup_volumewise_progress(
 
     moving_display_kwargs = _get_image_display_kwargs_from_layer(moving_layer)
     moving_display_kwargs["colormap"] = "red"
-    if _gamma_needs_reset(scale_mode):
-        moving_display_kwargs["gamma"] = 1.0
-
     display_kwargs = dict(moving_display_kwargs)
     display_kwargs["colormap"] = "cyan"
     display_kwargs["blending"] = "additive"
@@ -252,7 +245,6 @@ def create_volume_progress_plotter(
     fixed: xr.DataArray,
     layer_name: str,
     initial_transform: npt.NDArray[np.floating] | None = None,
-    scale_mode: str,
 ) -> Callable[..., RegistrationProgress]:
     """Create between-scan preview layers and a progress-plotter factory.
 
@@ -272,8 +264,6 @@ def create_volume_progress_plotter(
         Name for the live registered preview layer.
     initial_transform : numpy.ndarray, optional
         Initial affine used to seed the preview before optimization starts.
-    scale_mode : str
-        Registration scaling mode used to decide preview gamma handling.
 
     Returns
     -------
@@ -293,10 +283,6 @@ def create_volume_progress_plotter(
     moving_display_kwargs = _get_image_display_kwargs_from_layer(moving_layer)
     moving_display_kwargs["colormap"] = "cyan"
     moving_display_kwargs["blending"] = "additive"
-    if _gamma_needs_reset(scale_mode):
-        fixed_display_kwargs["gamma"] = 1.0
-        moving_display_kwargs["gamma"] = 1.0
-
     display_kwargs = dict(moving_display_kwargs)
     display_kwargs["colormap"] = "cyan"
     display_kwargs["blending"] = "additive"

--- a/src/confusius/_napari/_registration/_panel_results.py
+++ b/src/confusius/_napari/_registration/_panel_results.py
@@ -12,7 +12,6 @@ from napari.utils.notifications import show_info
 from confusius._napari._registration._panel_progress import teardown_volumewise_progress
 from confusius._napari._registration._panel_transforms import refresh_transform_controls
 from confusius._napari._registration._panel_utils import (
-    _gamma_needs_reset,
     _get_image_display_kwargs_from_layer,
     _get_source_dataarray,
     _prepare_between_scan_data,
@@ -119,8 +118,6 @@ def finalize_registration_layer(
         if source_layer is not None
         else {}
     )
-    if _gamma_needs_reset(payload.get("scale", "off")):
-        display_kwargs["gamma"] = 1.0
     if payload["operation"] == "register_volume":
         display_kwargs["colormap"] = "cyan"
         display_kwargs["blending"] = "additive"

--- a/src/confusius/_napari/_registration/_panel_selection.py
+++ b/src/confusius/_napari/_registration/_panel_selection.py
@@ -141,13 +141,15 @@ def selected_layer(panel: RegistrationPanel, combo: QComboBox) -> Layer | None:
     return get_layer_by_name(panel, name)
 
 
-def current_scale_mode(panel: RegistrationPanel) -> ScaleMode:
-    """Return the validated registration scale mode from the combo box.
+def current_scale_mode(panel: RegistrationPanel, *, fixed: bool = False) -> ScaleMode:
+    """Return the validated registration scale mode from a combo box.
 
     Parameters
     ----------
     panel : RegistrationPanel
         Registration panel whose scale selector should be read.
+    fixed : bool, default: False
+        Whether to read the fixed-layer selector instead of the moving one.
 
     Returns
     -------
@@ -159,7 +161,8 @@ def current_scale_mode(panel: RegistrationPanel) -> ScaleMode:
     ValueError
         If the combo box contains an unexpected value.
     """
-    value = panel._scale_combo.currentData()
+    combo = panel._fixed_scale_combo if fixed else panel._scale_combo
+    value = combo.currentData()
     if value in {"none", "db", "sqrt"}:
         return value
     raise ValueError(f"Unknown registration intensity scaling: {value!r}.")

--- a/src/confusius/_napari/_registration/_panel_selection.py
+++ b/src/confusius/_napari/_registration/_panel_selection.py
@@ -151,8 +151,8 @@ def current_scale_mode(panel: RegistrationPanel) -> ScaleMode:
 
     Returns
     -------
-    {"off", "dB", "sqrt"}
-        Selected registration scale mode.
+    {"none", "db", "sqrt"}
+        Selected registration intensity scaling mode.
 
     Raises
     ------
@@ -160,9 +160,9 @@ def current_scale_mode(panel: RegistrationPanel) -> ScaleMode:
         If the combo box contains an unexpected value.
     """
     value = panel._scale_combo.currentData()
-    if value in {"off", "dB", "sqrt"}:
+    if value in {"none", "db", "sqrt"}:
         return value
-    raise ValueError(f"Unknown registration scale mode: {value!r}.")
+    raise ValueError(f"Unknown registration intensity scaling: {value!r}.")
 
 
 def current_metric(panel: RegistrationPanel) -> MetricName:

--- a/src/confusius/_napari/_registration/_panel_utils.py
+++ b/src/confusius/_napari/_registration/_panel_utils.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 import xarray as xr
@@ -14,7 +14,6 @@ from qtpy.QtWidgets import QDoubleSpinBox, QSizePolicy, QWidget
 
 from confusius._dims import TIME_DIM, VOXEL_DIMS, WORLD_DIMS
 from confusius._utils.geometry import attach_voxel_to_world_index
-from confusius.xarray.scale import db_scale, power_scale
 
 if TYPE_CHECKING:
     import napari
@@ -282,37 +281,6 @@ def _prepare_between_scan_data(data: xr.DataArray) -> xr.DataArray:
     return averaged
 
 
-def _apply_registration_scale(
-    data: xr.DataArray, scale_mode: Literal["off", "dB", "sqrt"]
-) -> xr.DataArray:
-    """Apply optional intensity preprocessing for registration.
-
-    Parameters
-    ----------
-    data : xarray.DataArray
-        Input data.
-    scale_mode : {"off", "dB", "sqrt"}
-        Intensity scaling mode used before registration.
-
-    Returns
-    -------
-    xarray.DataArray
-        Preprocessed data.
-
-    Raises
-    ------
-    ValueError
-        If `scale_mode` is not recognized.
-    """
-    if scale_mode == "off":
-        return data
-    if scale_mode == "dB":
-        return db_scale(data)
-    if scale_mode == "sqrt":
-        return power_scale(data, exponent=0.5)
-    raise ValueError(f"Unknown registration scale mode: {scale_mode}.")
-
-
 def _get_image_display_kwargs_from_layer(layer: Layer) -> dict[str, Any]:
     """Return image-display kwargs copied from an existing napari layer.
 
@@ -331,26 +299,6 @@ def _get_image_display_kwargs_from_layer(layer: Layer) -> dict[str, Any]:
         if hasattr(layer, attr):
             kwargs[attr] = getattr(layer, attr)
     return kwargs
-
-
-def _gamma_needs_reset(scale_mode: str) -> bool:
-    """Return whether registration preview/result gamma should be reset.
-
-    When using intensity scaling, the gamma of the preview and result layers is forced
-    to 1.0 to avoid double scaling. When scaling is off, the original layer gamma is
-    preserved.
-
-    Parameters
-    ----------
-    scale_mode : str
-        Registration intensity scaling mode.
-
-    Returns
-    -------
-    bool
-        Whether preview/result layers should force `gamma=1.0`.
-    """
-    return scale_mode != "off"
 
 
 def _parse_comma_separated_ints(text: str, expected_len: int = 3) -> tuple[int, ...]:

--- a/src/confusius/registration/_utils.py
+++ b/src/confusius/registration/_utils.py
@@ -7,7 +7,7 @@ from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from copy import deepcopy
 from types import FrameType
-from typing import TYPE_CHECKING, TypeGuard
+from typing import TYPE_CHECKING, Literal, TypeGuard
 
 import numpy as np
 import xarray as xr
@@ -180,6 +180,37 @@ def initialize_single_slice_rigid_transform(
 
 SignalHandler = Callable[[int, FrameType | None], object]
 """Python-level SIGINT handler callable."""
+
+
+def validate_intensity_scaling(
+    intensity_scaling: Literal["none", "db", "sqrt"] | float, name: str
+) -> None:
+    """Validate an intensity-scaling argument for the registration optimizer.
+
+    Parameters
+    ----------
+    intensity_scaling : {"none", "db", "sqrt"} or float
+        Scaling mode or positive power-scaling exponent to check.
+    name : str
+        Argument name used in the error message.
+
+    Raises
+    ------
+    ValueError
+        If `intensity_scaling` is neither a known mode nor a positive finite float.
+    """
+    valid_modes = {"none", "db", "sqrt"}
+    is_valid_exponent = (
+        isinstance(intensity_scaling, (int, float))
+        and not isinstance(intensity_scaling, bool)
+        and np.isfinite(intensity_scaling)
+        and intensity_scaling > 0
+    )
+    if intensity_scaling not in valid_modes and not is_valid_exponent:
+        raise ValueError(
+            f"Invalid {name} {intensity_scaling!r}. Expected one of "
+            f"{sorted(valid_modes)} or a positive finite exponent."
+        )
 
 
 def _is_python_signal_handler(handler: object) -> TypeGuard[SignalHandler]:

--- a/src/confusius/registration/volume.py
+++ b/src/confusius/registration/volume.py
@@ -266,17 +266,14 @@ def _apply_intensity_scaling(
     data : xarray.DataArray
         Input VoxelData array.
     intensity_scaling : {"none", "db", "sqrt"} or float
-        Scaling mode to apply. Floats apply power scaling with that exponent.
+        Scaling mode to apply. Assumed already validated by
+        `_validate_register_volume_inputs`. Floats apply power scaling with that
+        exponent.
 
     Returns
     -------
     xarray.DataArray
         Scaled data for optimization, or `data` unchanged.
-
-    Raises
-    ------
-    ValueError
-        If `intensity_scaling` is not recognized.
     """
     if intensity_scaling == "none":
         return data
@@ -286,11 +283,7 @@ def _apply_intensity_scaling(
         return db_scale(data)
     if intensity_scaling == "sqrt":
         return power_scale(data, exponent=0.5)
-    if isinstance(intensity_scaling, (int, float)) and not isinstance(
-        intensity_scaling, bool
-    ):
-        return power_scale(data, exponent=float(intensity_scaling))
-    raise ValueError(f"Unknown intensity_scaling: {intensity_scaling!r}.")
+    return power_scale(data, exponent=float(intensity_scaling))
 
 
 def _translate_registration_runtime_error(

--- a/src/confusius/registration/volume.py
+++ b/src/confusius/registration/volume.py
@@ -34,6 +34,7 @@ def _validate_register_volume_inputs(
     moving_mask: xr.DataArray | None,
     transform_type: Literal["translation", "rigid", "affine", "bspline"],
     metric: Literal["correlation", "mattes_mi"],
+    intensity_scaling: Literal["none", "db", "sqrt"] | float,
     number_of_histogram_bins: int,
     metric_sampling_percentage: float | None,
     metric_sampling_seed: int | None,
@@ -63,6 +64,8 @@ def _validate_register_volume_inputs(
         Transform model name.
     metric : {"correlation", "mattes_mi"}
         Similarity metric name.
+    intensity_scaling : {"none", "db", "sqrt"} or float
+        Intensity transform applied before optimization.
     number_of_histogram_bins : int
         Number of histogram bins for Mattes mutual information.
     metric_sampling_percentage : float, optional
@@ -144,6 +147,20 @@ def _validate_register_volume_inputs(
     if metric not in valid_metrics:
         raise ValueError(
             f"Invalid metric {metric!r}. Expected one of {sorted(valid_metrics)}."
+        )
+
+    valid_intensity_scalings = {"none", "db", "sqrt"}
+    if isinstance(intensity_scaling, bool) or not (
+        intensity_scaling in valid_intensity_scalings
+        or (
+            isinstance(intensity_scaling, (int, float))
+            and np.isfinite(intensity_scaling)
+            and intensity_scaling > 0
+        )
+    ):
+        raise ValueError(
+            f"Invalid intensity_scaling {intensity_scaling!r}. Expected one of "
+            f"{sorted(valid_intensity_scalings)} or a positive finite exponent."
         )
 
     valid_initializations = {"center_geometry", "center_moments"}
@@ -239,6 +256,43 @@ def _validate_register_volume_inputs(
     return moving, fixed, fixed_mask, moving_mask
 
 
+def _apply_intensity_scaling(
+    data: xr.DataArray, intensity_scaling: Literal["none", "db", "sqrt"] | float
+) -> xr.DataArray:
+    """Apply optional intensity scaling for optimizer inputs.
+
+    Parameters
+    ----------
+    data : xarray.DataArray
+        Input VoxelData array.
+    intensity_scaling : {"none", "db", "sqrt"} or float
+        Scaling mode to apply. Floats apply power scaling with that exponent.
+
+    Returns
+    -------
+    xarray.DataArray
+        Scaled data for optimization, or `data` unchanged.
+
+    Raises
+    ------
+    ValueError
+        If `intensity_scaling` is not recognized.
+    """
+    if intensity_scaling == "none":
+        return data
+    from confusius.xarray.scale import db_scale, power_scale
+
+    if intensity_scaling == "db":
+        return db_scale(data)
+    if intensity_scaling == "sqrt":
+        return power_scale(data, exponent=0.5)
+    if isinstance(intensity_scaling, (int, float)) and not isinstance(
+        intensity_scaling, bool
+    ):
+        return power_scale(data, exponent=float(intensity_scaling))
+    raise ValueError(f"Unknown intensity_scaling: {intensity_scaling!r}.")
+
+
 def _translate_registration_runtime_error(
     exc: RuntimeError,
     *,
@@ -298,6 +352,7 @@ def register_volume(  # numpydoc ignore=GL08,PR01,RT01
     moving_mask: xr.DataArray | None = ...,
     transform_type: Literal["translation", "rigid", "affine"],
     metric: Literal["correlation", "mattes_mi"] = ...,
+    intensity_scaling: Literal["none", "db", "sqrt"] | float = ...,
     number_of_histogram_bins: int = ...,
     metric_sampling_percentage: float | None = ...,
     metric_sampling_seed: int | None = ...,
@@ -335,6 +390,7 @@ def register_volume(  # numpydoc ignore=GL08,PR01,RT01
     moving_mask: xr.DataArray | None = ...,
     transform_type: Literal["bspline"],
     metric: Literal["correlation", "mattes_mi"] = ...,
+    intensity_scaling: Literal["none", "db", "sqrt"] | float = ...,
     number_of_histogram_bins: int = ...,
     metric_sampling_percentage: float | None = ...,
     metric_sampling_seed: int | None = ...,
@@ -371,6 +427,7 @@ def register_volume(  # numpydoc ignore=GL08,PR01,RT01
     fixed_mask: xr.DataArray | None = ...,
     moving_mask: xr.DataArray | None = ...,
     metric: Literal["correlation", "mattes_mi"] = ...,
+    intensity_scaling: Literal["none", "db", "sqrt"] | float = ...,
     number_of_histogram_bins: int = ...,
     metric_sampling_percentage: float | None = ...,
     metric_sampling_seed: int | None = ...,
@@ -407,6 +464,7 @@ def register_volume(
     moving_mask: xr.DataArray | None = None,
     transform_type: Literal["translation", "rigid", "affine", "bspline"] = "rigid",
     metric: Literal["correlation", "mattes_mi"] = "correlation",
+    intensity_scaling: Literal["none", "db", "sqrt"] | float = "none",
     number_of_histogram_bins: int = 50,
     metric_sampling_percentage: float | None = None,
     metric_sampling_seed: int | None = None,
@@ -470,6 +528,10 @@ def register_volume(
         appropriate for same-modality registration. `"mattes_mi"` (Mattes
         mutual information) is better suited for multi-modal registration or
         when the intensity relationship between images is non-linear.
+    intensity_scaling : {"none", "db", "sqrt"} or float, default: "none"
+        Intensity transform applied only to the images used by the registration
+        optimizer. Floats apply power scaling with that exponent; `"sqrt"` is an alias
+        for `0.5`. Returned/resampled data keeps the original input intensities.
     number_of_histogram_bins : int, default: 50
         Number of histogram bins used by Mattes mutual information. Only
         relevant when using `"mattes_mi"` metric.
@@ -615,7 +677,7 @@ def register_volume(
     ValueError
         If `moving` or `fixed` contains NaN values.
     ValueError
-        If `transform_type`, `metric`, `initialization`, or
+        If `transform_type`, `metric`, `intensity_scaling`, `initialization`, or
         `resample_interpolation` is not a recognised value.
     ValueError
         If `learning_rate` is not a positive finite float or `"auto"`.
@@ -645,6 +707,7 @@ def register_volume(
         moving_mask=moving_mask,
         transform_type=transform_type,
         metric=metric,
+        intensity_scaling=intensity_scaling,
         number_of_histogram_bins=number_of_histogram_bins,
         metric_sampling_percentage=metric_sampling_percentage,
         metric_sampling_seed=metric_sampling_seed,
@@ -659,14 +722,18 @@ def register_volume(
 
     fixed_sitk = voxeldata_to_sitk_image(fixed)
     moving_sitk = voxeldata_to_sitk_image(moving)
+    fixed_optimizer = _apply_intensity_scaling(fixed, intensity_scaling)
+    moving_optimizer = _apply_intensity_scaling(moving, intensity_scaling)
+    fixed_optimizer_sitk = voxeldata_to_sitk_image(fixed_optimizer)
+    moving_optimizer_sitk = voxeldata_to_sitk_image(moving_optimizer)
 
     # SimpleITK's multi-resolution pyramid and interpolation fail when any spatial
     # dimension is smaller than 4 voxels (common for single-slice fUSI recordings with
     # a 1-voxel depth). We thus expand thin dimensions before registration; the
     # originals are kept as the resample source/reference so the output grid is never
     # affected.
-    fixed_reg = expand_thin_dims(fixed_sitk)
-    moving_reg = expand_thin_dims(moving_sitk)
+    fixed_reg = expand_thin_dims(fixed_optimizer_sitk)
+    moving_reg = expand_thin_dims(moving_optimizer_sitk)
 
     # CenteredTransformInitializer (and the registration method) require both images to
     # have the same pixel type. Cast moving to fixed's type when they differ.

--- a/src/confusius/registration/volume.py
+++ b/src/confusius/registration/volume.py
@@ -12,6 +12,7 @@ from confusius.registration._utils import (
     expand_thin_dims,
     replace_affines_attr,
     set_sitk_thread_count,
+    validate_intensity_scaling,
     voxeldata_to_sitk_image,
 )
 from confusius.registration.affines import (
@@ -34,7 +35,8 @@ def _validate_register_volume_inputs(
     moving_mask: xr.DataArray | None,
     transform_type: Literal["translation", "rigid", "affine", "bspline"],
     metric: Literal["correlation", "mattes_mi"],
-    intensity_scaling: Literal["none", "db", "sqrt"] | float,
+    fixed_intensity_scaling: Literal["none", "db", "sqrt"] | float,
+    moving_intensity_scaling: Literal["none", "db", "sqrt"] | float,
     number_of_histogram_bins: int,
     metric_sampling_percentage: float | None,
     metric_sampling_seed: int | None,
@@ -64,8 +66,10 @@ def _validate_register_volume_inputs(
         Transform model name.
     metric : {"correlation", "mattes_mi"}
         Similarity metric name.
-    intensity_scaling : {"none", "db", "sqrt"} or float
-        Intensity transform applied before optimization.
+    fixed_intensity_scaling : {"none", "db", "sqrt"} or float
+        Intensity transform applied to `fixed` before optimization.
+    moving_intensity_scaling : {"none", "db", "sqrt"} or float
+        Intensity transform applied to `moving` before optimization.
     number_of_histogram_bins : int
         Number of histogram bins for Mattes mutual information.
     metric_sampling_percentage : float, optional
@@ -149,19 +153,8 @@ def _validate_register_volume_inputs(
             f"Invalid metric {metric!r}. Expected one of {sorted(valid_metrics)}."
         )
 
-    valid_intensity_scalings = {"none", "db", "sqrt"}
-    if isinstance(intensity_scaling, bool) or not (
-        intensity_scaling in valid_intensity_scalings
-        or (
-            isinstance(intensity_scaling, (int, float))
-            and np.isfinite(intensity_scaling)
-            and intensity_scaling > 0
-        )
-    ):
-        raise ValueError(
-            f"Invalid intensity_scaling {intensity_scaling!r}. Expected one of "
-            f"{sorted(valid_intensity_scalings)} or a positive finite exponent."
-        )
+    validate_intensity_scaling(fixed_intensity_scaling, "fixed_intensity_scaling")
+    validate_intensity_scaling(moving_intensity_scaling, "moving_intensity_scaling")
 
     valid_initializations = {"center_geometry", "center_moments"}
     if (
@@ -267,7 +260,7 @@ def _apply_intensity_scaling(
         Input VoxelData array.
     intensity_scaling : {"none", "db", "sqrt"} or float
         Scaling mode to apply. Assumed already validated by
-        `_validate_register_volume_inputs`. Floats apply power scaling with that
+        `validate_intensity_scaling`. Floats apply power scaling with that
         exponent.
 
     Returns
@@ -345,7 +338,8 @@ def register_volume(  # numpydoc ignore=GL08,PR01,RT01
     moving_mask: xr.DataArray | None = ...,
     transform_type: Literal["translation", "rigid", "affine"],
     metric: Literal["correlation", "mattes_mi"] = ...,
-    intensity_scaling: Literal["none", "db", "sqrt"] | float = ...,
+    fixed_intensity_scaling: Literal["none", "db", "sqrt"] | float = ...,
+    moving_intensity_scaling: Literal["none", "db", "sqrt"] | float = ...,
     number_of_histogram_bins: int = ...,
     metric_sampling_percentage: float | None = ...,
     metric_sampling_seed: int | None = ...,
@@ -383,7 +377,8 @@ def register_volume(  # numpydoc ignore=GL08,PR01,RT01
     moving_mask: xr.DataArray | None = ...,
     transform_type: Literal["bspline"],
     metric: Literal["correlation", "mattes_mi"] = ...,
-    intensity_scaling: Literal["none", "db", "sqrt"] | float = ...,
+    fixed_intensity_scaling: Literal["none", "db", "sqrt"] | float = ...,
+    moving_intensity_scaling: Literal["none", "db", "sqrt"] | float = ...,
     number_of_histogram_bins: int = ...,
     metric_sampling_percentage: float | None = ...,
     metric_sampling_seed: int | None = ...,
@@ -420,7 +415,8 @@ def register_volume(  # numpydoc ignore=GL08,PR01,RT01
     fixed_mask: xr.DataArray | None = ...,
     moving_mask: xr.DataArray | None = ...,
     metric: Literal["correlation", "mattes_mi"] = ...,
-    intensity_scaling: Literal["none", "db", "sqrt"] | float = ...,
+    fixed_intensity_scaling: Literal["none", "db", "sqrt"] | float = ...,
+    moving_intensity_scaling: Literal["none", "db", "sqrt"] | float = ...,
     number_of_histogram_bins: int = ...,
     metric_sampling_percentage: float | None = ...,
     metric_sampling_seed: int | None = ...,
@@ -457,7 +453,8 @@ def register_volume(
     moving_mask: xr.DataArray | None = None,
     transform_type: Literal["translation", "rigid", "affine", "bspline"] = "rigid",
     metric: Literal["correlation", "mattes_mi"] = "correlation",
-    intensity_scaling: Literal["none", "db", "sqrt"] | float = "none",
+    fixed_intensity_scaling: Literal["none", "db", "sqrt"] | float = "none",
+    moving_intensity_scaling: Literal["none", "db", "sqrt"] | float = "none",
     number_of_histogram_bins: int = 50,
     metric_sampling_percentage: float | None = None,
     metric_sampling_seed: int | None = None,
@@ -521,10 +518,13 @@ def register_volume(
         appropriate for same-modality registration. `"mattes_mi"` (Mattes
         mutual information) is better suited for multi-modal registration or
         when the intensity relationship between images is non-linear.
-    intensity_scaling : {"none", "db", "sqrt"} or float, default: "none"
-        Intensity transform applied only to the images used by the registration
-        optimizer. Floats apply power scaling with that exponent; `"sqrt"` is an alias
-        for `0.5`. Returned/resampled data keeps the original input intensities.
+    fixed_intensity_scaling : {"none", "db", "sqrt"} or float, default: "none"
+        Intensity transform applied to `fixed` only for the registration optimizer.
+        Floats apply power scaling with that exponent; `"sqrt"` is an alias for `0.5`.
+    moving_intensity_scaling : {"none", "db", "sqrt"} or float, default: "none"
+        Intensity transform applied to `moving` only for the registration optimizer,
+        with the same options as `fixed_intensity_scaling`. Returned/resampled data
+        keeps the original input intensities.
     number_of_histogram_bins : int, default: 50
         Number of histogram bins used by Mattes mutual information. Only
         relevant when using `"mattes_mi"` metric.
@@ -670,8 +670,9 @@ def register_volume(
     ValueError
         If `moving` or `fixed` contains NaN values.
     ValueError
-        If `transform_type`, `metric`, `intensity_scaling`, `initialization`, or
-        `resample_interpolation` is not a recognised value.
+        If `transform_type`, `metric`, `fixed_intensity_scaling`,
+        `moving_intensity_scaling`, `initialization`, or `resample_interpolation`
+        is not a recognised value.
     ValueError
         If `learning_rate` is not a positive finite float or `"auto"`.
     ValueError
@@ -700,7 +701,8 @@ def register_volume(
         moving_mask=moving_mask,
         transform_type=transform_type,
         metric=metric,
-        intensity_scaling=intensity_scaling,
+        fixed_intensity_scaling=fixed_intensity_scaling,
+        moving_intensity_scaling=moving_intensity_scaling,
         number_of_histogram_bins=number_of_histogram_bins,
         metric_sampling_percentage=metric_sampling_percentage,
         metric_sampling_seed=metric_sampling_seed,
@@ -715,10 +717,12 @@ def register_volume(
 
     fixed_sitk = voxeldata_to_sitk_image(fixed)
     moving_sitk = voxeldata_to_sitk_image(moving)
-    fixed_optimizer = _apply_intensity_scaling(fixed, intensity_scaling)
-    moving_optimizer = _apply_intensity_scaling(moving, intensity_scaling)
-    fixed_optimizer_sitk = voxeldata_to_sitk_image(fixed_optimizer)
-    moving_optimizer_sitk = voxeldata_to_sitk_image(moving_optimizer)
+    fixed_optimizer_sitk = voxeldata_to_sitk_image(
+        _apply_intensity_scaling(fixed, fixed_intensity_scaling)
+    )
+    moving_optimizer_sitk = voxeldata_to_sitk_image(
+        _apply_intensity_scaling(moving, moving_intensity_scaling)
+    )
 
     # SimpleITK's multi-resolution pyramid and interpolation fail when any spatial
     # dimension is smaller than 4 voxels (common for single-slice fUSI recordings with

--- a/src/confusius/registration/volumewise.py
+++ b/src/confusius/registration/volumewise.py
@@ -9,6 +9,7 @@ import numpy.typing as npt
 import xarray as xr
 
 from confusius._utils.io import is_h5py_backed
+from confusius.registration._utils import validate_intensity_scaling
 from confusius.registration.diagnostics import RegistrationDiagnostics
 from confusius.registration.motion import create_motion_dataframe
 from confusius.registration.volume import register_volume
@@ -68,10 +69,10 @@ def register_volumewise(
         mutual information) is better suited for multi-modal registration or
         when the intensity relationship between images is non-linear.
     intensity_scaling : {"none", "db", "sqrt"} or float, default: "none"
-        Intensity transform applied only to the images used by the registration
-        optimizer. Floats apply power scaling with that exponent; `"sqrt"` is an
-        alias for `0.5`. Returned/resampled data keeps the original input
-        intensities.
+        Intensity transform applied to the reference volume and to every frame, only
+        for the registration optimizer. Floats apply power scaling with that
+        exponent; `"sqrt"` is an alias for `0.5`. Returned/resampled data keeps the
+        original input intensities.
     number_of_histogram_bins : int, default: 50
         Number of histogram bins used by Mattes mutual information. Only
         relevant when `metric="mattes_mi"`.
@@ -186,19 +187,7 @@ def register_volumewise(
     if "time" not in data.dims:
         raise ValueError("Time dimension 'time' not found in data")
 
-    valid_intensity_scalings = {"none", "db", "sqrt"}
-    if isinstance(intensity_scaling, bool) or not (
-        intensity_scaling in valid_intensity_scalings
-        or (
-            isinstance(intensity_scaling, (int, float))
-            and np.isfinite(intensity_scaling)
-            and intensity_scaling > 0
-        )
-    ):
-        raise ValueError(
-            f"Invalid intensity_scaling {intensity_scaling!r}. Expected one of "
-            f"{sorted(valid_intensity_scalings)} or a positive finite exponent."
-        )
+    validate_intensity_scaling(intensity_scaling, "intensity_scaling")
 
     if n_jobs != 1 and is_h5py_backed(data):
         raise TypeError(
@@ -261,7 +250,10 @@ def register_volumewise(
             ref_da,
             transform_type=transform,
             metric=metric,
-            intensity_scaling=intensity_scaling,
+            # The reference is a frame of the same recording, so one scaling
+            # applies to both sides.
+            fixed_intensity_scaling=intensity_scaling,
+            moving_intensity_scaling=intensity_scaling,
             number_of_histogram_bins=number_of_histogram_bins,
             learning_rate=learning_rate,
             number_of_iterations=number_of_iterations,

--- a/src/confusius/registration/volumewise.py
+++ b/src/confusius/registration/volumewise.py
@@ -27,6 +27,7 @@ def register_volumewise(
     n_jobs: int = -1,
     transform: Literal["translation", "rigid", "affine"] = "rigid",
     metric: Literal["correlation", "mattes_mi"] = "correlation",
+    intensity_scaling: Literal["none", "db", "sqrt"] | float = "none",
     number_of_histogram_bins: int = 50,
     learning_rate: float | Literal["auto"] = 0.01,
     number_of_iterations: int = 100,
@@ -66,6 +67,11 @@ def register_volumewise(
         appropriate for same-modality registration. `"mattes_mi"` (Mattes
         mutual information) is better suited for multi-modal registration or
         when the intensity relationship between images is non-linear.
+    intensity_scaling : {"none", "db", "sqrt"} or float, default: "none"
+        Intensity transform applied only to the images used by the registration
+        optimizer. Floats apply power scaling with that exponent; `"sqrt"` is an
+        alias for `0.5`. Returned/resampled data keeps the original input
+        intensities.
     number_of_histogram_bins : int, default: 50
         Number of histogram bins used by Mattes mutual information. Only
         relevant when `metric="mattes_mi"`.
@@ -180,6 +186,20 @@ def register_volumewise(
     if "time" not in data.dims:
         raise ValueError("Time dimension 'time' not found in data")
 
+    valid_intensity_scalings = {"none", "db", "sqrt"}
+    if isinstance(intensity_scaling, bool) or not (
+        intensity_scaling in valid_intensity_scalings
+        or (
+            isinstance(intensity_scaling, (int, float))
+            and np.isfinite(intensity_scaling)
+            and intensity_scaling > 0
+        )
+    ):
+        raise ValueError(
+            f"Invalid intensity_scaling {intensity_scaling!r}. Expected one of "
+            f"{sorted(valid_intensity_scalings)} or a positive finite exponent."
+        )
+
     if n_jobs != 1 and is_h5py_backed(data):
         raise TypeError(
             "Data is backed by an h5py dataset, which cannot be serialized for "
@@ -188,9 +208,8 @@ def register_volumewise(
             "for serial processing."
         )
 
-    data_moved = data.transpose("time", ...)
     data_moved = ensure_voxeldata(
-        data_moved,
+        data,
         require_time=True,
         allow_pose=False,
         allow_extra_dims=False,
@@ -242,6 +261,7 @@ def register_volumewise(
             ref_da,
             transform_type=transform,
             metric=metric,
+            intensity_scaling=intensity_scaling,
             number_of_histogram_bins=number_of_histogram_bins,
             learning_rate=learning_rate,
             number_of_iterations=number_of_iterations,

--- a/tests/unit/test_napari/test_registration_panel.py
+++ b/tests/unit/test_napari/test_registration_panel.py
@@ -309,9 +309,15 @@ class TestOperationMode:
 
         assert registration_panel._transform_combo.currentText() == "rigid"
 
-    def test_scale_preprocessing_resets_gamma_for_previews(
+    def test_preview_layers_preserve_source_gamma(
         self, real_viewer, real_registration_panel
     ):
+        """Preview layers keep the source layers' gamma.
+
+        Intensity scaling is applied only to the registration optimizer's inputs
+        (inside `register_volume`/`register_volumewise`); preview layers always show
+        the original, unscaled data, so their gamma is never reset.
+        """
         moving_data = create_voxeldata(
             np.ones((4, 6), dtype=np.float32), dims=("j", "i"), spacing=(1.0, 0.2, 0.1)
         )
@@ -332,21 +338,6 @@ class TestOperationMode:
             moving=moving_data,
             fixed=fixed,
             layer_name="Registered (rigid)",
-            scale_mode="sqrt",
-        )
-        assert real_viewer.layers["Fixed"].gamma == pytest.approx(1.0)
-        assert real_viewer.layers["Moving"].gamma == pytest.approx(1.0)
-        assert real_viewer.layers["Registered (rigid)"].gamma == pytest.approx(1.0)
-
-        teardown_volume_progress(real_registration_panel)
-        create_volume_progress_plotter(
-            real_registration_panel,
-            moving_layer=moving,
-            fixed_layer=fixed_layer,
-            moving=moving_data,
-            fixed=fixed,
-            layer_name="Registered (rigid)",
-            scale_mode="off",
         )
         assert real_viewer.layers["Fixed"].gamma == pytest.approx(0.6)
         assert real_viewer.layers["Moving"].gamma == pytest.approx(0.4)
@@ -385,7 +376,6 @@ class TestOperationMode:
             moving=moving_data,
             fixed=fixed,
             layer_name="Registered (rigid)",
-            scale_mode="off",
         )
 
         after = (
@@ -1268,7 +1258,6 @@ class TestVolumewiseProgress:
             moving_layer=moving_layer,
             moving=moving,
             layer_name="Motion corrected",
-            scale_mode="off",
         )
 
         assert registration_panel._volumewise_progress_layer is not None
@@ -1407,7 +1396,6 @@ class TestFinishedCallbacks:
             moving=moving_data,
             fixed=fixed,
             layer_name="Registered (rigid)",
-            scale_mode="off",
         )
         assert {"Fixed", "Moving", "Registered (rigid)"}.issubset(
             {layer.name for layer in real_viewer.layers}
@@ -1475,7 +1463,6 @@ class TestFinishedCallbacks:
             fixed=fixed,
             layer_name="Registered (rigid)",
             initial_transform=initial_transform,
-            scale_mode="off",
         )
 
         expected = resample_like(moving_data, fixed, initial_transform)
@@ -1517,7 +1504,6 @@ class TestFinishedCallbacks:
             moving=moving_data,
             fixed=fixed,
             layer_name="Registered (rigid)",
-            scale_mode="off",
         )
 
         next_arr = np.full((1, 4, 6), 0.5, dtype=np.float32)
@@ -1555,7 +1541,6 @@ class TestFinishedCallbacks:
             moving_layer=moving_layer,
             moving=moving,
             layer_name="Motion corrected",
-            scale_mode="off",
         )
 
         registered = moving.copy(data=np.ones((3, 1, 4, 6), dtype=np.float32))

--- a/tests/unit/test_napari/test_registration_panel.py
+++ b/tests/unit/test_napari/test_registration_panel.py
@@ -255,6 +255,7 @@ class TestOperationMode:
         registration_panel._learning_rate_auto_check.setChecked(True)
         registration_panel._learning_rate_edit.setValue(0.42)
         registration_panel._scale_combo.setCurrentText("none")
+        registration_panel._fixed_scale_combo.setCurrentText("square root")
         registration_panel._time_series_radio.setChecked(True)
 
         assert registration_panel._learning_rate_auto_check.isHidden()
@@ -262,6 +263,20 @@ class TestOperationMode:
         assert registration_panel._learning_rate_edit.value() == pytest.approx(0.23)
         assert registration_panel._n_jobs_spin.value() == 3
         assert registration_panel._scale_combo.currentText() == "square root"
+
+        registration_panel._single_volume_radio.setChecked(True)
+
+        assert registration_panel._scale_combo.currentText() == "none"
+        assert registration_panel._fixed_scale_combo.currentText() == "square root"
+
+    def test_fixed_scale_combo_only_between_scans(self, registration_panel):
+        assert not registration_panel._fixed_scale_combo.isHidden()
+        assert registration_panel._scale_label.text() == "Moving intensity scaling"
+
+        registration_panel._time_series_radio.setChecked(True)
+
+        assert registration_panel._fixed_scale_combo.isHidden()
+        assert registration_panel._scale_label.text() == "Intensity scaling"
 
     def test_advanced_group_is_collapsed_by_default(self, registration_panel):
         assert not registration_panel._advanced_toggle.isChecked()
@@ -297,6 +312,7 @@ class TestOperationMode:
     def test_default_parameter_values(self, registration_panel):
         assert registration_panel._transform_combo.currentText() == "rigid"
         assert registration_panel._scale_combo.currentText() == "decibel"
+        assert registration_panel._fixed_scale_combo.currentText() == "decibel"
         assert registration_panel._learning_rate_edit.minimum() == pytest.approx(1e-10)
         assert registration_panel._learning_rate_edit.value() == pytest.approx(0.01)
         assert registration_panel._convergence_min_edit.minimum() == pytest.approx(
@@ -548,6 +564,7 @@ class TestRunRegistration:
         registration_panel._moving_combo.setCurrentText("moving")
         registration_panel._fixed_combo.setCurrentText("fixed")
         registration_panel._scale_combo.setCurrentText("square root")
+        registration_panel._fixed_scale_combo.setCurrentText("none")
         for i in range(registration_panel._initialization_combo.count()):
             if registration_panel._initialization_combo.itemData(i) == (
                 "layer",
@@ -594,8 +611,11 @@ class TestRunRegistration:
         kwargs = cast("dict[str, Any]", captured["kwargs"])
         args = cast("tuple[Any, ...]", captured["args"])
         np.testing.assert_array_equal(kwargs["initialization"], affine)
-        np.testing.assert_allclose(args[0].values, np.sqrt(moving.values))
-        np.testing.assert_allclose(args[1].values, np.sqrt(fixed.values))
+        assert kwargs["moving_intensity_scaling"] == "sqrt"
+        assert kwargs["fixed_intensity_scaling"] == "none"
+        # Scaling happens inside register_volume; the panel passes raw data.
+        np.testing.assert_array_equal(args[0].values, moving.values)
+        np.testing.assert_array_equal(args[1].values, fixed.values)
         assert registration_panel._worker is not None
 
     def test_between_scan_run_uses_selected_manual_napari_transform(

--- a/tests/unit/test_registration/test_volume.py
+++ b/tests/unit/test_registration/test_volume.py
@@ -286,6 +286,18 @@ class TestRegisterVolumeValidation:
         assert calls["strategy"] == sitk.ImageRegistrationMethod().RANDOM
         assert calls["percentage"] == expected_args
 
+    @pytest.mark.parametrize("intensity_scaling", ["gamma", 0.0, -1.0, float("nan")])
+    def test_invalid_intensity_scaling_raises(
+        self, sample_voxeldata_2d_registration, intensity_scaling
+    ):
+        """An unknown mode or non-positive exponent raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid intensity_scaling"):
+            register_volume(
+                sample_voxeldata_2d_registration,
+                sample_voxeldata_2d_registration,
+                intensity_scaling=intensity_scaling,
+            )
+
     def test_shape_mismatch_no_error(self, sample_voxeldata_2d_registration):
         """Different shapes do not raise an error."""
         moving = sample_voxeldata_2d_registration.isel(j=slice(16), i=slice(16))
@@ -570,6 +582,84 @@ class TestRegisterVolumeOutput:
         )
         assert type(result.xindexes["x"]).__name__ == "VoxelToWorldIndex"
         assert result.coords["i"].dims == fixed.coords["i"].dims
+
+
+class TestRegisterVolumeIntensityScaling:
+    """intensity_scaling applies power scaling to the optimizer inputs only."""
+
+    @pytest.mark.parametrize(
+        ("intensity_scaling", "expected_exponent"),
+        [("sqrt", 0.5), (2.0, 2.0), (0.3, 0.3)],
+    )
+    def test_scales_optimizer_inputs_with_exponent(
+        self,
+        sample_voxeldata_2d_registration,
+        monkeypatch,
+        intensity_scaling,
+        expected_exponent,
+    ):
+        """Float/sqrt intensity_scaling calls power_scale with the right exponent."""
+        import confusius.xarray.scale as scale_module
+
+        calls: list[float] = []
+        original_power_scale = scale_module.power_scale
+
+        def spy_power_scale(data, exponent=0.5):
+            calls.append(exponent)
+            return original_power_scale(data, exponent=exponent)
+
+        monkeypatch.setattr(scale_module, "power_scale", spy_power_scale)
+
+        register_volume(
+            sample_voxeldata_2d_registration,
+            sample_voxeldata_2d_registration,
+            transform_type="translation",
+            intensity_scaling=intensity_scaling,
+            number_of_iterations=1,
+            resample=False,
+        )
+
+        assert calls == [expected_exponent, expected_exponent]
+
+    def test_none_does_not_scale_optimizer_inputs(
+        self, sample_voxeldata_2d_registration, monkeypatch
+    ):
+        """intensity_scaling='none' does not call power_scale or db_scale."""
+        import confusius.xarray.scale as scale_module
+
+        calls: list[str] = []
+        monkeypatch.setattr(
+            scale_module,
+            "power_scale",
+            lambda *a, **k: calls.append("power_scale") or a[0],
+        )
+        monkeypatch.setattr(
+            scale_module, "db_scale", lambda *a, **k: calls.append("db_scale") or a[0]
+        )
+
+        register_volume(
+            sample_voxeldata_2d_registration,
+            sample_voxeldata_2d_registration,
+            transform_type="translation",
+            intensity_scaling="none",
+            number_of_iterations=1,
+            resample=False,
+        )
+
+        assert calls == []
+
+    def test_output_intensities_are_unscaled(self, sample_voxeldata_2d_registration):
+        """Registered output keeps original intensities regardless of intensity_scaling."""
+        result, _, _ = register_volume(
+            sample_voxeldata_2d_registration,
+            sample_voxeldata_2d_registration,
+            transform_type="translation",
+            intensity_scaling=2.0,
+            number_of_iterations=1,
+        )
+        assert (
+            result.values.max() <= sample_voxeldata_2d_registration.values.max() + 1e-5
+        )
 
 
 class TestRegisterVolumeMask:

--- a/tests/unit/test_registration/test_volume.py
+++ b/tests/unit/test_registration/test_volume.py
@@ -621,6 +621,35 @@ class TestRegisterVolumeIntensityScaling:
 
         assert calls == [expected_exponent, expected_exponent]
 
+    def test_db_calls_db_scale(self, sample_voxeldata_2d_registration, monkeypatch):
+        """intensity_scaling='db' calls db_scale, not power_scale."""
+        import confusius.xarray.scale as scale_module
+
+        calls: list[str] = []
+        original_db_scale = scale_module.db_scale
+
+        def spy_db_scale(data, *args, **kwargs):
+            calls.append("db_scale")
+            return original_db_scale(data, *args, **kwargs)
+
+        monkeypatch.setattr(scale_module, "db_scale", spy_db_scale)
+        monkeypatch.setattr(
+            scale_module,
+            "power_scale",
+            lambda *a, **k: calls.append("power_scale") or a[0],
+        )
+
+        register_volume(
+            sample_voxeldata_2d_registration,
+            sample_voxeldata_2d_registration,
+            transform_type="translation",
+            intensity_scaling="db",
+            number_of_iterations=1,
+            resample=False,
+        )
+
+        assert calls == ["db_scale", "db_scale"]
+
     def test_none_does_not_scale_optimizer_inputs(
         self, sample_voxeldata_2d_registration, monkeypatch
     ):

--- a/tests/unit/test_registration/test_volume.py
+++ b/tests/unit/test_registration/test_volume.py
@@ -286,16 +286,19 @@ class TestRegisterVolumeValidation:
         assert calls["strategy"] == sitk.ImageRegistrationMethod().RANDOM
         assert calls["percentage"] == expected_args
 
+    @pytest.mark.parametrize(
+        "name", ["fixed_intensity_scaling", "moving_intensity_scaling"]
+    )
     @pytest.mark.parametrize("intensity_scaling", ["gamma", 0.0, -1.0, float("nan")])
     def test_invalid_intensity_scaling_raises(
-        self, sample_voxeldata_2d_registration, intensity_scaling
+        self, sample_voxeldata_2d_registration, name, intensity_scaling
     ):
         """An unknown mode or non-positive exponent raises ValueError."""
-        with pytest.raises(ValueError, match="Invalid intensity_scaling"):
+        with pytest.raises(ValueError, match=f"Invalid {name}"):
             register_volume(
                 sample_voxeldata_2d_registration,
                 sample_voxeldata_2d_registration,
-                intensity_scaling=intensity_scaling,
+                **{name: intensity_scaling},
             )
 
     def test_shape_mismatch_no_error(self, sample_voxeldata_2d_registration):
@@ -585,7 +588,7 @@ class TestRegisterVolumeOutput:
 
 
 class TestRegisterVolumeIntensityScaling:
-    """intensity_scaling applies power scaling to the optimizer inputs only."""
+    """Intensity scaling applies power scaling to the optimizer inputs only."""
 
     @pytest.mark.parametrize(
         ("intensity_scaling", "expected_exponent"),
@@ -614,15 +617,46 @@ class TestRegisterVolumeIntensityScaling:
             sample_voxeldata_2d_registration,
             sample_voxeldata_2d_registration,
             transform_type="translation",
-            intensity_scaling=intensity_scaling,
+            fixed_intensity_scaling=intensity_scaling,
+            moving_intensity_scaling=intensity_scaling,
             number_of_iterations=1,
             resample=False,
         )
 
         assert calls == [expected_exponent, expected_exponent]
 
+    def test_fixed_and_moving_are_scaled_independently(
+        self, sample_voxeldata_2d_registration, monkeypatch
+    ):
+        """Fixed and moving optimizer inputs get their own scaling."""
+        import confusius.xarray.scale as scale_module
+
+        calls: list[tuple[str, float | None]] = []
+        monkeypatch.setattr(
+            scale_module,
+            "db_scale",
+            lambda data, *a, **k: calls.append(("db_scale", None)) or data,
+        )
+        monkeypatch.setattr(
+            scale_module,
+            "power_scale",
+            lambda data, exponent: calls.append(("power_scale", exponent)) or data,
+        )
+
+        register_volume(
+            sample_voxeldata_2d_registration,
+            sample_voxeldata_2d_registration,
+            transform_type="translation",
+            fixed_intensity_scaling="db",
+            moving_intensity_scaling="sqrt",
+            number_of_iterations=1,
+            resample=False,
+        )
+
+        assert calls == [("db_scale", None), ("power_scale", 0.5)]
+
     def test_db_calls_db_scale(self, sample_voxeldata_2d_registration, monkeypatch):
-        """intensity_scaling='db' calls db_scale, not power_scale."""
+        """'db' calls db_scale, not power_scale."""
         import confusius.xarray.scale as scale_module
 
         calls: list[str] = []
@@ -643,7 +677,8 @@ class TestRegisterVolumeIntensityScaling:
             sample_voxeldata_2d_registration,
             sample_voxeldata_2d_registration,
             transform_type="translation",
-            intensity_scaling="db",
+            fixed_intensity_scaling="db",
+            moving_intensity_scaling="db",
             number_of_iterations=1,
             resample=False,
         )
@@ -653,7 +688,7 @@ class TestRegisterVolumeIntensityScaling:
     def test_none_does_not_scale_optimizer_inputs(
         self, sample_voxeldata_2d_registration, monkeypatch
     ):
-        """intensity_scaling='none' does not call power_scale or db_scale."""
+        """'none' does not call power_scale or db_scale."""
         import confusius.xarray.scale as scale_module
 
         calls: list[str] = []
@@ -670,7 +705,8 @@ class TestRegisterVolumeIntensityScaling:
             sample_voxeldata_2d_registration,
             sample_voxeldata_2d_registration,
             transform_type="translation",
-            intensity_scaling="none",
+            fixed_intensity_scaling="none",
+            moving_intensity_scaling="none",
             number_of_iterations=1,
             resample=False,
         )
@@ -678,12 +714,13 @@ class TestRegisterVolumeIntensityScaling:
         assert calls == []
 
     def test_output_intensities_are_unscaled(self, sample_voxeldata_2d_registration):
-        """Registered output keeps original intensities regardless of intensity_scaling."""
+        """Registered output keeps original intensities regardless of scaling."""
         result, _, _ = register_volume(
             sample_voxeldata_2d_registration,
             sample_voxeldata_2d_registration,
             transform_type="translation",
-            intensity_scaling=2.0,
+            fixed_intensity_scaling=2.0,
+            moving_intensity_scaling=2.0,
             number_of_iterations=1,
         )
         assert (

--- a/tests/unit/test_registration/test_volumewise.py
+++ b/tests/unit/test_registration/test_volumewise.py
@@ -52,16 +52,24 @@ class TestRegisterVolumewise:
     def test_float_intensity_scaling_is_forwarded_to_register_volume(
         self, sample_voxeldata_2dt_registration, monkeypatch
     ):
-        """A positive float intensity_scaling is passed through to register_volume."""
+        """intensity_scaling is forwarded as both fixed and moving scaling."""
         import confusius.registration.volumewise as volumewise_module
 
-        calls: list[float | str] = []
+        calls: list[tuple[float | str, float | str]] = []
         original_register_volume = volumewise_module.register_volume
 
-        def spy_register_volume(*args, intensity_scaling="none", **kwargs):
-            calls.append(intensity_scaling)
+        def spy_register_volume(
+            *args,
+            fixed_intensity_scaling="none",
+            moving_intensity_scaling="none",
+            **kwargs,
+        ):
+            calls.append((fixed_intensity_scaling, moving_intensity_scaling))
             return original_register_volume(
-                *args, intensity_scaling=intensity_scaling, **kwargs
+                *args,
+                fixed_intensity_scaling=fixed_intensity_scaling,
+                moving_intensity_scaling=moving_intensity_scaling,
+                **kwargs,
             )
 
         monkeypatch.setattr(volumewise_module, "register_volume", spy_register_volume)
@@ -73,7 +81,7 @@ class TestRegisterVolumewise:
             intensity_scaling=2.0,
         )
 
-        assert calls and all(exponent == 2.0 for exponent in calls)
+        assert calls and all(scaling == (2.0, 2.0) for scaling in calls)
 
     def test_h5py_backed_raises_with_parallel_jobs(self, scan_2d):
         """h5py-backed DataArray (from a .scan file) raises TypeError when n_jobs != 1."""

--- a/tests/unit/test_registration/test_volumewise.py
+++ b/tests/unit/test_registration/test_volumewise.py
@@ -39,6 +39,42 @@ class TestRegisterVolumewise:
         with pytest.raises(ValueError, match="Time dimension 'time' not found"):
             register_volumewise(data)
 
+    @pytest.mark.parametrize("intensity_scaling", ["gamma", 0.0, -1.0])
+    def test_invalid_intensity_scaling_raises(
+        self, sample_voxeldata_2dt_registration, intensity_scaling
+    ):
+        """An unknown mode or non-positive exponent raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid intensity_scaling"):
+            register_volumewise(
+                sample_voxeldata_2dt_registration, intensity_scaling=intensity_scaling
+            )
+
+    def test_float_intensity_scaling_is_forwarded_to_register_volume(
+        self, sample_voxeldata_2dt_registration, monkeypatch
+    ):
+        """A positive float intensity_scaling is passed through to register_volume."""
+        import confusius.registration.volumewise as volumewise_module
+
+        calls: list[float | str] = []
+        original_register_volume = volumewise_module.register_volume
+
+        def spy_register_volume(*args, intensity_scaling="none", **kwargs):
+            calls.append(intensity_scaling)
+            return original_register_volume(
+                *args, intensity_scaling=intensity_scaling, **kwargs
+            )
+
+        monkeypatch.setattr(volumewise_module, "register_volume", spy_register_volume)
+
+        register_volumewise(
+            sample_voxeldata_2dt_registration,
+            n_jobs=1,
+            transform="translation",
+            intensity_scaling=2.0,
+        )
+
+        assert calls and all(exponent == 2.0 for exponent in calls)
+
     def test_h5py_backed_raises_with_parallel_jobs(self, scan_2d):
         """h5py-backed DataArray (from a .scan file) raises TypeError when n_jobs != 1."""
         with pytest.raises(TypeError, match="h5py dataset"):


### PR DESCRIPTION
## Summary
- Add `intensity_scaling` (`"none"`/`"db"`/`"sqrt"`/any positive float exponent) to `register_volume` and `register_volumewise`, rescaling only the optimizer's inputs; returned/resampled data keeps original intensities.
- Wire the napari registration panel's existing scale selector to the new argument instead of pre-scaling layers itself.