### PR TITLE
fix(io): support 4DscanCustom SCAN v1

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -153,6 +153,8 @@ Current development version for the next ConfUSIus release.
 
 ### :bug: Fixes
 
+- `load_scan` now opens Iconeus SCAN v1 files marked as `4DscanCustom`
+  ([#406](https://github.com/confusius-tools/confusius/pull/406)).
 - `save_nifti` now always writes both a qform and sform (previously sform was
   silently dropped when no secondary affine had been explicitly recorded)
   ([#278](https://github.com/confusius-tools/confusius/pull/278)).

--- a/src/confusius/io/scan.py
+++ b/src/confusius/io/scan.py
@@ -450,13 +450,13 @@ def load_scan(
 
         - v1 `2Dscan` → `(time, k, j, i)`.
         - v1 `3Dscan` → `(pose, k, j, i)`.
-        - v1 `4Dscan` → `(time, pose, k, j, i)`.
+        - v1 `4Dscan`/`4DscanCustom` → `(time, pose, k, j, i)`.
         - v2 single-pose → `(time, k, j, i)`.
         - v2 multi-pose is currently unsupported (see Raises).
 
         World coordinates `z`, `y`, `x` are in millimeters. The `time` coordinate is in
-        seconds. For v1 `4Dscan`, `time` is pose-dependent (`(time, pose)`-shaped),
-        holding each pose's own acquisition timestamps directly.
+        seconds. For v1 `4Dscan`/`4DscanCustom`, `time` is pose-dependent
+        (`(time, pose)`-shaped), holding each pose's own acquisition timestamps directly.
 
     Raises
     ------
@@ -464,8 +464,9 @@ def load_scan(
         If `path` does not exist or is not a file, if the file is neither an
         HDF5-based SCAN (v1) nor a binary SCAN v2 file, if a v2 file's experimental
         `probe_to_lab` affine cannot be built, if a v1 `acquisitionMode` is not one
-        of `"2Dscan"`, `"3Dscan"`, or `"4Dscan"`, or if a v2 file has multiple poses
-        (currently unsupported -- how v2 encodes per-pose geometry isn't known yet).
+        of `"2Dscan"`, `"3Dscan"`, `"4Dscan"`, or `"4DscanCustom"`, or if a v2 file has
+        multiple poses (currently unsupported -- how v2 encodes per-pose geometry isn't
+        known yet).
 
     Notes
     -----
@@ -577,7 +578,7 @@ def _load_scan_v1(
     ------
     ValueError
         If the `acquisitionMode` stored in the file is not one of `"2Dscan"`,
-        `"3Dscan"`, or `"4Dscan"`.
+        `"3Dscan"`, `"4Dscan"`, or `"4DscanCustom"`.
     """
     h5 = h5py.File(path, "r")
 
@@ -618,7 +619,7 @@ def _load_scan_v1(
             data_array = _load_2dscan(h5, raw_lazy, attrs, voxel_to_world)
         elif mode == "3Dscan":
             data_array = _load_3dscan(raw_lazy, attrs, npose, voxel_to_world)
-        elif mode == "4Dscan":
+        elif mode in {"4Dscan", "4DscanCustom"}:
             data_array = _load_4dscan(
                 h5,
                 raw_lazy,
@@ -630,7 +631,7 @@ def _load_scan_v1(
         else:
             raise ValueError(
                 f"Unknown acquisitionMode: {mode!r}. Expected one of '2Dscan',"
-                " '3Dscan', '4Dscan'."
+                " '3Dscan', '4Dscan', '4DscanCustom'."
             )
 
         data_array.name = attrs["iconeus_scan"] or path.stem

--- a/tests/unit/test_io/test_scan.py
+++ b/tests/unit/test_io/test_scan.py
@@ -501,6 +501,35 @@ class TestLoadScan4D:
         """iconeus_scan_mode attr equals '4Dscan'."""
         assert scan_4d.attrs["iconeus_scan_mode"] == "4Dscan"
 
+    def test_4dscan_custom_loads_as_4d(self, tmp_path: Path) -> None:
+        """4DscanCustom follows the same layout as 4Dscan."""
+        path = tmp_path / "test_4dscan_custom.scan"
+        time_flat = _end_referenced_times(_T * _NPOSE, _POSE_DURATION).reshape(
+            _T * _NPOSE, 1
+        )
+        data = _RNG.random((_T, _NPOSE, 1, _SIZE_Z, _SIZE_Y, _SIZE_X), dtype=np.float64)
+        with h5py.File(path, "w") as f:
+            f.create_dataset("/Data", data=data)
+            _write_scan_metadata(
+                f,
+                mode="4DscanCustom",
+                size_x=_SIZE_X,
+                size_y=_SIZE_Y,
+                size_z=_SIZE_Z,
+                npose=_NPOSE,
+                nscan_repeat=_T,
+                nblock_repeat=None,
+                voxels_to_probe=_VOXELS_TO_PROBE,
+                probe_to_lab=_PROBE_TO_LAB_MULTI,
+                time_data=time_flat,
+            )
+
+        scan_4d = load_scan(path)
+
+        assert scan_4d.dims == ("time", "pose", "k", "j", "i")
+        assert scan_4d.shape == (_T, _NPOSE, _SIZE_Y, _SIZE_Z, _SIZE_X)
+        assert scan_4d.attrs["iconeus_scan_mode"] == "4DscanCustom"
+
     def test_multiblock_repeats_are_merged_into_time(
         self, scan_4d_multiblock_path: Path, scan_4d_multiblock: xr.DataArray
     ) -> None:


### PR DESCRIPTION
Fixes #403.

- Treat SCAN v1 `4DscanCustom` as the existing 4D layout.
- Keep `iconeus_scan_mode` unchanged for downstream inspection.
- Add a regression test.