### PR TITLE
fix(napari): guard scale/translate against non-numeric coordinates

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -167,6 +167,10 @@ Current development version for the next ConfUSIus release.
   input has it, instead of collapsing to a single pose; the explicit-`mask`
   path no longer rejects a `pose`-carrying mask either
   ([#278](https://github.com/confusius-tools/confusius/pull/278)).
+- `plot_napari` and the napari plugin no longer crash on a non-spatial dimension
+  with string coordinates (e.g. a recording-id stack dim); such a dimension now
+  falls back to scale 1/origin 0 like any other missing world geometry
+  ([#409](https://github.com/confusius-tools/confusius/pull/409)).
 
 ## 0.6.1
 

--- a/src/confusius/_napari/_registration/_panel.py
+++ b/src/confusius/_napari/_registration/_panel.py
@@ -1439,7 +1439,7 @@ class RegistrationPanel(QWidget):
         world_origins = source.fusi.origin
         origins = {d: world_origins[voxel_to_world_name.get(d, d)] for d in dims}
         # Display each voxel dim by its linked world coordinate name (matching the
-        # convention in `get_napari_scale_translate_units`), not the raw k/j/i name.
+        # convention in `get_napari_layer_geometry`), not the raw k/j/i name.
         axis_labels = tuple(voxel_to_world_name.get(d, d) for d in dims)
         units = tuple(
             source.coords[world_name].attrs.get("units")

--- a/src/confusius/_utils/napari.py
+++ b/src/confusius/_utils/napari.py
@@ -70,7 +70,7 @@ def build_direct_label_colormap(data: xr.DataArray) -> DirectLabelColormap | Non
     return DirectLabelColormap(color_dict=color_dict, background_value=0)
 
 
-def get_napari_scale_translate_units(
+def get_napari_layer_geometry(
     data: xr.DataArray,
 ) -> tuple[
     list[float], list[float], list[str], list[str | None], list[str], dict[str, float]
@@ -87,7 +87,7 @@ def get_napari_scale_translate_units(
     Parameters
     ----------
     data : xarray.DataArray
-        DataArray to compute napari layer geometry for.
+        VoxelData array to compute napari layer geometry for.
 
     Returns
     -------
@@ -121,35 +121,22 @@ def get_napari_scale_translate_units(
     axis_labels: list[str] = []
     units: list[str | None] = []
     for dim in all_dims:
-        # `coord_name` is the true linked world coordinate (z/y/x) for a native
-        # voxel dim (k/j/i); for any other dim it's just that dim's own name, and
-        # `coord` -- if present -- isn't necessarily a world coordinate at all (e.g.
-        # a `stack` dim's coordinate may hold non-numeric recording IDs).
         coord_name = world_dim.get(dim, dim)
         coord = data.coords.get(coord_name)
-        if (
+        # `origin` (`.fusi.origin`) always has an entry for every dim -- spatial
+        # dims via the voxel-to-world index, others defaulting to 0.0 -- so it's a
+        # safe fallback translate whenever `coord` isn't itself 1-D numeric world
+        # geometry for `dim`.
+        is_world_coord = (
             coord is not None
             and coord.dims == (dim,)
             and np.issubdtype(coord.dtype, np.number)
-        ):
-            values = np.asarray(coord.values, dtype=float)
-            scale.append(spacing[dim])
-            translate.append(np.float64(values[0]).item())
-            axis_labels.append(coord_name)
-        else:
-            scale.append(spacing[dim])
-            translate.append(
-                origin[coord_name]
-                if coord_name in origin
-                else (
-                    np.float64(
-                        np.asarray(data.coords[dim].values, dtype=float)[0]
-                    ).item()
-                    if dim in data.coords
-                    else 0.0
-                )
-            )
-            axis_labels.append(coord_name if coord_name in data.coords else dim)
+        )
+        scale.append(spacing[dim])
+        translate.append(
+            np.float64(coord.values[0]).item() if is_world_coord else origin[coord_name]
+        )
+        axis_labels.append(coord_name if coord_name in data.coords else dim)
         units.append(
             data.coords[coord_name].attrs.get("units")
             if coord_name in data.coords
@@ -199,7 +186,7 @@ def convert_dataarray_to_layer_data(
     )
 
     scale, translate, axis_labels, all_units, non_uniform, spacing = (
-        get_napari_scale_translate_units(da)
+        get_napari_layer_geometry(da)
     )
     for dim in non_uniform:
         show_warning(

--- a/src/confusius/_utils/napari.py
+++ b/src/confusius/_utils/napari.py
@@ -119,19 +119,28 @@ def get_napari_scale_translate_units(
     scale: list[float] = []
     translate: list[float] = []
     axis_labels: list[str] = []
+    units: list[str | None] = []
     for dim in all_dims:
-        world_name = world_dim.get(dim, dim)
-        world_coord = data.coords.get(world_name)
-        if world_coord is not None and world_coord.dims == (dim,):
-            values = np.asarray(world_coord.values, dtype=float)
+        # `coord_name` is the true linked world coordinate (z/y/x) for a native
+        # voxel dim (k/j/i); for any other dim it's just that dim's own name, and
+        # `coord` -- if present -- isn't necessarily a world coordinate at all (e.g.
+        # a `stack` dim's coordinate may hold non-numeric recording IDs).
+        coord_name = world_dim.get(dim, dim)
+        coord = data.coords.get(coord_name)
+        if (
+            coord is not None
+            and coord.dims == (dim,)
+            and np.issubdtype(coord.dtype, np.number)
+        ):
+            values = np.asarray(coord.values, dtype=float)
             scale.append(spacing[dim])
             translate.append(np.float64(values[0]).item())
-            axis_labels.append(world_name)
+            axis_labels.append(coord_name)
         else:
             scale.append(spacing[dim])
             translate.append(
-                origin[world_name]
-                if world_name in origin
+                origin[coord_name]
+                if coord_name in origin
                 else (
                     np.float64(
                         np.asarray(data.coords[dim].values, dtype=float)[0]
@@ -140,18 +149,12 @@ def get_napari_scale_translate_units(
                     else 0.0
                 )
             )
-            axis_labels.append(world_name if world_name in data.coords else dim)
-    units: list[str | None] = []
-    for dim in all_dims:
-        world_name = world_dim.get(dim, dim)
-        # world_name only ever differs from dim for k/j/i, and .fusi.spacing above
-        # already requires a real VoxelToWorldIndex covering every present voxel
-        # dim -- so a voxel dim's world coordinate is never missing while the dim
-        # itself has one; the two checks can't diverge.
-        if world_name in data.coords:
-            units.append(data.coords[world_name].attrs.get("units"))
-        else:
-            units.append(None)
+            axis_labels.append(coord_name if coord_name in data.coords else dim)
+        units.append(
+            data.coords[coord_name].attrs.get("units")
+            if coord_name in data.coords
+            else None
+        )
     return scale, translate, axis_labels, units, non_uniform, spacing
 
 

--- a/src/confusius/plotting/napari.py
+++ b/src/confusius/plotting/napari.py
@@ -24,7 +24,7 @@ from confusius._utils.geometry import (
 from confusius._utils.napari import (
     build_direct_label_colormap,
     build_roi_labels_features,
-    get_napari_scale_translate_units,
+    get_napari_layer_geometry,
 )
 from confusius._utils.plotting import resample_to_axis_aligned_world_grid
 from confusius._utils.stack import find_stack_level
@@ -182,7 +182,7 @@ def plot_napari(
         )
 
     scale, coord_translates, axis_labels, all_units, non_uniform, spacing = (
-        get_napari_scale_translate_units(data)
+        get_napari_layer_geometry(data)
     )
     for dim in non_uniform:
         warnings.warn(
@@ -351,7 +351,7 @@ def draw_napari_labels(
     time_dim = TIME_DIM if TIME_DIM in all_dims else None
     spatial_dims = [dim for dim in all_dims if dim != time_dim]
     spatial_indices = [all_dims.index(dim) for dim in spatial_dims]
-    scale, translate, axis_labels, all_units, _, _ = get_napari_scale_translate_units(
+    scale, translate, axis_labels, all_units, _, _ = get_napari_layer_geometry(
         display_data
     )
 

--- a/tests/unit/test_plotting/test_napari.py
+++ b/tests/unit/test_plotting/test_napari.py
@@ -140,6 +140,20 @@ class TestPlotNapari:
         assert layer.translate[0] == pytest.approx(0.0)
         viewer.close()
 
+    def test_string_coordinate_dim_falls_back_to_scale_1(
+        self, sample_voxeldata_3d, make_napari_viewer
+    ):
+        """A dim with non-numeric (e.g. string) coordinates uses scale=1.0."""
+        da = sample_voxeldata_3d.expand_dims(session=["cp230328a"])
+        viewer = make_napari_viewer()
+        _, layer = plot_napari(
+            da, viewer=viewer, show_colorbar=False, show_scale_bar=False
+        )
+
+        assert layer.scale[0] == pytest.approx(1.0)
+        assert layer.translate[0] == pytest.approx(0.0)
+        viewer.close()
+
     def test_dim_order_reorders_4d_display_axes(
         self, sample_voxeldata_3dt, make_napari_viewer
     ):


### PR DESCRIPTION
## Summary
- `get_napari_scale_translate_units` blindly cast any same-named 1-D coordinate to float, crashing `plot_napari`/the CLI on a non-spatial dim with string coordinates (e.g. a recording-id `stack` dim).
- Guard with a numeric-dtype check; falls back to the existing `scale=1`/origin-default path, which already handles non-numeric coordinates safely.
- Merged the separate `units` loop into the main loop (removes a duplicate `world_name` computation).

Fixes #408.