### PR TITLE
fix(multipose): loosen consolidate_poses regularity check for small steps

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -174,9 +174,10 @@ Current development version for the next ConfUSIus release.
 - `consolidate_poses`'s regularity check no longer rejects realistic stage jitter
   on small pose steps (e.g. a 100 um step previously tolerated only ~1 um of
   jitter under a pure 1% relative tolerance). The check now combines a new `atol`
-  parameter (default: 5 um) with `rtol`, matching typical stepper-motor stage
-  repeatability at small step sizes while keeping `rtol` in control at larger
-  ones ([#363](https://github.com/confusius-tools/confusius/issues/363)).
+  parameter (default: 5 um, converted to the array's own world units) with
+  `rtol`, matching typical stepper-motor stage repeatability at small step
+  sizes while keeping `rtol` in control at larger ones
+  ([#363](https://github.com/confusius-tools/confusius/issues/363)).
 
 ## 0.6.1
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -171,6 +171,12 @@ Current development version for the next ConfUSIus release.
   with string coordinates (e.g. a recording-id stack dim); such a dimension now
   falls back to scale 1/origin 0 like any other missing world geometry
   ([#409](https://github.com/confusius-tools/confusius/pull/409)).
+- `consolidate_poses`'s regularity check no longer rejects realistic stage jitter
+  on small pose steps (e.g. a 100 um step previously tolerated only ~1 um of
+  jitter under a pure 1% relative tolerance). The check now combines a new `atol`
+  parameter (default: 5 um) with `rtol`, matching typical stepper-motor stage
+  repeatability at small step sizes while keeping `rtol` in control at larger
+  ones ([#363](https://github.com/confusius-tools/confusius/issues/363)).
 
 ## 0.6.1
 

--- a/src/confusius/_utils/geometry.py
+++ b/src/confusius/_utils/geometry.py
@@ -1386,6 +1386,53 @@ def get_voxel_to_world_units(data: xr.DataArray) -> str:
     return index.units
 
 
+_LENGTH_UNIT_TO_MM: dict[str, float] = {
+    "mm": 1.0,
+    "cm": 10.0,
+    "m": 1000.0,
+    "um": 1e-3,
+    "µm": 1e-3,
+    "nm": 1e-6,
+}
+"""Mapping from common length-unit strings to millimeters."""
+
+
+def convert_length_units(
+    values: npt.ArrayLike, from_unit: str, to_unit: str = "mm"
+) -> npt.NDArray[np.float64]:
+    """Convert length values between units.
+
+    Parameters
+    ----------
+    values : array_like
+        Length values to convert.
+    from_unit : str
+        Current unit of the values, e.g. the return of
+        [get_voxel_to_world_units][confusius._utils.geometry.get_voxel_to_world_units].
+    to_unit : str, default: "mm"
+        Target unit of the values.
+
+    Returns
+    -------
+    numpy.ndarray
+        Length values converted to `to_unit`.
+
+    Raises
+    ------
+    ValueError
+        If `from_unit` or `to_unit` is not one of `"mm"`, `"cm"`, `"m"`, `"um"`/`"µm"`,
+        `"nm"`.
+    """
+    for unit in (from_unit, to_unit):
+        if unit not in _LENGTH_UNIT_TO_MM:
+            raise ValueError(
+                f"Unrecognized length unit {unit!r}; expected one of "
+                f"{sorted(_LENGTH_UNIT_TO_MM)}."
+            )
+    values_array = np.asarray(values, dtype=np.float64)
+    return values_array * (_LENGTH_UNIT_TO_MM[from_unit] / _LENGTH_UNIT_TO_MM[to_unit])
+
+
 def restore_voxel_to_world_index(data: xr.DataArray) -> xr.DataArray:
     """Rebuild voxel-to-world geometry for a dimension restored after being fixed.
 

--- a/src/confusius/multipose/consolidate.py
+++ b/src/confusius/multipose/consolidate.py
@@ -144,6 +144,7 @@ def _detect_sweep_dim(
 def consolidate_poses(
     da: xr.DataArray,
     rtol: float = 0.01,
+    atol: float = 0.005,
 ) -> xr.DataArray:
     """Merge the `pose` dimension into the swept voxel dimension, ordered by position.
 
@@ -193,6 +194,15 @@ def consolidate_poses(
         [`stack_poses`][confusius.multipose.stack_poses].
     rtol : float, default: 0.01
         Relative tolerance for the regularity check (fraction of mean spacing).
+        Combined with `atol` as `abs(spacing - mean_spacing) <= atol + rtol *
+        abs(mean_spacing)` (`numpy.isclose` convention), so `rtol` alone dominates at
+        large step sizes.
+    atol : float, default: 0.005
+        Absolute tolerance in mm for the regularity check, combined with `rtol` as
+        described above. The default (5 um) matches typical repeatability of
+        stepper-motor-driven linear stages used for probe positioning, so it
+        dominates at small step sizes (e.g. a 100 um step) where a pure relative
+        tolerance would be unrealistically tight.
 
     Returns
     -------
@@ -216,8 +226,8 @@ def consolidate_poses(
         poses (non-translation sweep), if the swept voxel dimension cannot be
         detected (fewer than two poses, identical pose positions, or a degenerate
         voxel axis), or if the consolidated positions are not regularly spaced
-        within `rtol` -- which also rejects a sweep that steps along more than one
-        voxel axis at once, since no single voxel dimension can span it.
+        within `atol`/`rtol` -- which also rejects a sweep that steps along more than
+        one voxel axis at once, since no single voxel dimension can span it.
 
     Warns
     -----
@@ -291,11 +301,14 @@ def consolidate_poses(
 
     diffs: npt.NDArray[np.float64] = np.diff(proj_sorted)
     mean_spacing = float(np.mean(diffs))
-    if not np.allclose(diffs, mean_spacing, rtol=rtol, atol=0):
+    # A pure relative tolerance is unrealistically tight for small steps (e.g. 1% of
+    # a 100 um step is 1 um -- below real stage repeatability); combine with a small
+    # absolute tolerance so it dominates at small step sizes instead. See #363.
+    if not np.allclose(diffs, mean_spacing, rtol=rtol, atol=atol):
         raise ValueError(
             f"Consolidated {sweep_dim} positions are not regularly spaced "
             f"(spacing range: [{diffs.min():.4f}, {diffs.max():.4f}] mm, "
-            f"mean: {mean_spacing:.4f} mm, rtol={rtol})."
+            f"mean: {mean_spacing:.4f} mm, atol={atol}, rtol={rtol})."
         )
 
     pose_idx = sorted_flat // n_sweep

--- a/src/confusius/multipose/consolidate.py
+++ b/src/confusius/multipose/consolidate.py
@@ -15,6 +15,7 @@ import xarray as xr
 from confusius._dims import WORLD_DIMS
 from confusius._utils.geometry import (
     attach_voxel_to_world_index,
+    convert_length_units,
     get_voxel_to_world_affine,
     get_voxel_to_world_spatial_dims,
     get_voxel_to_world_units,
@@ -144,7 +145,7 @@ def _detect_sweep_dim(
 def consolidate_poses(
     da: xr.DataArray,
     rtol: float = 0.01,
-    atol: float = 0.005,
+    atol: float | None = None,
 ) -> xr.DataArray:
     """Merge the `pose` dimension into the swept voxel dimension, ordered by position.
 
@@ -197,12 +198,10 @@ def consolidate_poses(
         Combined with `atol` as `abs(spacing - mean_spacing) <= atol + rtol *
         abs(mean_spacing)` (`numpy.isclose` convention), so `rtol` alone dominates at
         large step sizes.
-    atol : float, default: 0.005
-        Absolute tolerance in mm for the regularity check, combined with `rtol` as
-        described above. The default (5 um) matches typical repeatability of
-        stepper-motor-driven linear stages used for probe positioning, so it
-        dominates at small step sizes (e.g. a 100 um step) where a pure relative
-        tolerance would be unrealistically tight.
+    atol : float, optional
+        Absolute tolerance for the regularity check, in `da`'s world units, combined
+        with `rtol` as described above. If not provided, defaults to 5 um converted to
+        `da`'s units.
 
     Returns
     -------
@@ -225,9 +224,11 @@ def consolidate_poses(
         pose-dependent, if the rotation block of the affine is not constant across
         poses (non-translation sweep), if the swept voxel dimension cannot be
         detected (fewer than two poses, identical pose positions, or a degenerate
-        voxel axis), or if the consolidated positions are not regularly spaced
-        within `atol`/`rtol` -- which also rejects a sweep that steps along more than
-        one voxel axis at once, since no single voxel dimension can span it.
+        voxel axis), if the consolidated positions are not regularly spaced within
+        `atol`/`rtol` -- which also rejects a sweep that steps along more than one
+        voxel axis at once, since no single voxel dimension can span it -- or if
+        `atol` is not provided and `da`'s world units aren't one of `"mm"`, `"cm"`,
+        `"m"`, `"um"`/`"µm"`, `"nm"`.
 
     Warns
     -----
@@ -238,6 +239,10 @@ def consolidate_poses(
 
     if "pose" not in da.dims:
         raise ValueError("DataArray has no 'pose' dimension.")
+
+    units = get_voxel_to_world_units(da)
+    if atol is None:
+        atol = float(convert_length_units(0.005, "mm", to_unit=units))
 
     # ensure_voxeldata above guarantees da carries a VoxelToWorldIndex, so the voxel dims
     # (and their derived world coordinates) are always available here.
@@ -307,8 +312,8 @@ def consolidate_poses(
     if not np.allclose(diffs, mean_spacing, rtol=rtol, atol=atol):
         raise ValueError(
             f"Consolidated {sweep_dim} positions are not regularly spaced "
-            f"(spacing range: [{diffs.min():.4f}, {diffs.max():.4f}] mm, "
-            f"mean: {mean_spacing:.4f} mm, atol={atol}, rtol={rtol})."
+            f"(spacing range: [{diffs.min():.4f}, {diffs.max():.4f}] {units}, "
+            f"mean: {mean_spacing:.4f} {units}, atol={atol}, rtol={rtol})."
         )
 
     pose_idx = sorted_flat // n_sweep

--- a/tests/unit/test_multipose/test_consolidate.py
+++ b/tests/unit/test_multipose/test_consolidate.py
@@ -346,6 +346,54 @@ class TestConsolidatePoses:
         with pytest.raises(ValueError, match="not regularly spaced"):
             consolidate_poses(da)
 
+    def test_small_step_jitter_within_default_tolerance(self) -> None:
+        """A few micrometers of jitter on a 100 um step passes the default tolerance.
+
+        A pure 1% relative tolerance would only allow ~1 um of jitter on a 100 um
+        step -- tighter than real stepper-motor-driven stage repeatability (see
+        #363). The default `atol` (5 um) should dominate here and absorb it.
+        """
+        npose = 3
+        # A single k voxel per pose isolates pose-to-pose spacing from intra-pose
+        # voxel spacing, so only the pose step jitter under test affects regularity.
+        data = np.random.default_rng(17).random((npose, 1, 4, 3))
+        nominal_step = 0.1  # mm, i.e. a typical 100 um fUSI pose step.
+        jitters = [0.0, 0.003, -0.001]  # mm, a few um of positioning jitter.
+        affines = np.stack([np.eye(4) for _ in range(npose)])
+        for i in range(npose):
+            affines[i, :3, 3][0] = i * nominal_step + jitters[i]
+
+        da = create_voxeldata(
+            data,
+            dims=["pose", "k", "j", "i"],
+            pose=np.arange(npose),
+            voxel_to_world=affines,
+        )
+
+        result = consolidate_poses(da)
+        assert result.sizes["k"] == npose
+
+    def test_gross_irregularity_still_raises_with_default_tolerance(self) -> None:
+        """Spacing deviations well beyond real stage jitter still raise ValueError."""
+        npose = 3
+        data = np.random.default_rng(19).random((npose, 1, 4, 3))
+        # Steps of 0.1 mm and 0.25 mm: a 0.15 mm deviation, far beyond any
+        # realistic stage jitter at this step size.
+        positions = [0.0, 0.1, 0.35]
+        affines = np.stack([np.eye(4) for _ in range(npose)])
+        for i in range(npose):
+            affines[i, :3, 3][0] = positions[i]
+
+        da = create_voxeldata(
+            data,
+            dims=["pose", "k", "j", "i"],
+            pose=np.arange(npose),
+            voxel_to_world=affines,
+        )
+
+        with pytest.raises(ValueError, match="not regularly spaced"):
+            consolidate_poses(da)
+
     def test_non_1d_sweep_warns(self, scan_3d_2d_sweep_path: Path) -> None:
         """consolidate_poses warns when the sweep has a significant secondary component.
 


### PR DESCRIPTION
## Summary
- `consolidate_poses` rejected any step-spacing jitter above 1% of the mean spacing, which is unrealistically tight at small step sizes (a 100 um step only tolerated ~1 um of jitter — below real stepper-stage repeatability).
- Adds an `atol` parameter (default 5 um), combined with the existing `rtol` (default 0.01, unchanged) via the standard `abs(spacing - mean_spacing) <= atol + rtol * abs(mean_spacing)` convention, so `atol` dominates at small steps and `rtol` still governs at larger ones.

Closes #363