### PR TITLE
feat(registration): add auto interpolation to resample_volume/resample_like

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -94,6 +94,13 @@ Current development version for the next ConfUSIus release.
   matched against each voxel dimension's world-space direction); a sweep that
   isn't cleanly aligned with a single voxel dimension can never form the
   regular grid consolidation requires, so no override was needed.
+- [`resample_volume`][confusius.registration.resample_volume] and
+  [`resample_like`][confusius.registration.resample_like]'s `interpolation`
+  parameter defaults to `"auto"` instead of `"linear"`: `"nearest"` is picked for
+  integer-dtype data (e.g. atlas region labels) and `"linear"` otherwise, so
+  resampling an integer mask no longer silently blends label values unless
+  `interpolation` is explicitly overridden
+  ([#375](https://github.com/confusius-tools/confusius/issues/375)).
 
 ### :sparkles: Enhancements
 

--- a/src/confusius/registration/resampling.py
+++ b/src/confusius/registration/resampling.py
@@ -116,7 +116,7 @@ def resample_volume(
     output_spacing: Mapping[Hashable, SupportsFloat | SupportsIndex],
     output_origin: Mapping[Hashable, SupportsFloat | SupportsIndex],
     output_direction: npt.ArrayLike,
-    interpolation: Literal["linear", "nearest", "bspline"] = "linear",
+    interpolation: Literal["auto", "linear", "nearest", "bspline"] = "auto",
     fill_value: float | None = None,
     sitk_threads: int = -1,
 ) -> xr.DataArray:
@@ -172,8 +172,10 @@ def resample_volume(
         `(3, 3)` matrix whose columns are the unit world-space direction of each
         output voxel axis, in native `k/j/i` column order. `reference.fusi.direction`
         can be passed directly.
-    interpolation : {"linear", "nearest", "bspline"}, default: "linear"
-        Interpolation method used during resampling.
+    interpolation : {"auto", "linear", "nearest", "bspline"}, default: "auto"
+        Interpolation method used during resampling. `"auto"` picks `"nearest"` when
+        `moving` has an integer dtype (e.g. atlas region labels), and `"linear"`
+        otherwise.
     fill_value : float, optional
         Value assigned to voxels that fall outside the moving image's field of view
         after resampling. If not provided, defaults to `float(moving.min())`, which
@@ -262,11 +264,19 @@ def resample_volume(
     ref.SetOrigin(resolved_output_origin)
     ref.SetDirection(direction.ravel().tolist())
 
-    if interpolation == "nearest":
+    resolved_interpolation = interpolation
+    if resolved_interpolation == "auto":
+        # Integer dtypes hold discrete labels (e.g. atlas region masks), where linear
+        # blending would produce nonsense values between labels.
+        resolved_interpolation = (
+            "nearest" if np.issubdtype(moving.dtype, np.integer) else "linear"
+        )
+
+    if resolved_interpolation == "nearest":
         sitk_interpolation = sitk.sitkNearestNeighbor
-    elif interpolation == "linear":
+    elif resolved_interpolation == "linear":
         sitk_interpolation = sitk.sitkLinear
-    elif interpolation == "bspline":
+    elif resolved_interpolation == "bspline":
         sitk_interpolation = sitk.sitkBSpline
     else:
         raise ValueError(f"Invalid interpolation: {interpolation}")
@@ -332,7 +342,7 @@ def resample_like(
     moving: xr.DataArray,
     reference: xr.DataArray,
     transform: "npt.NDArray[np.floating] | xr.DataArray",
-    interpolation: Literal["linear", "nearest", "bspline"] = "linear",
+    interpolation: Literal["auto", "linear", "nearest", "bspline"] = "auto",
     fill_value: float | None = None,
     default_value: float | None = None,
     sitk_threads: int = -1,
@@ -371,8 +381,10 @@ def resample_like(
         When `transform` is a DataArray and spatial coordinate `units` metadata is
         present on both it and `reference`, those units must also match.
 
-    interpolation : {"linear", "nearest", "bspline"}, default: "linear"
-        Interpolation method used during resampling.
+    interpolation : {"auto", "linear", "nearest", "bspline"}, default: "auto"
+        Interpolation method used during resampling. `"auto"` picks `"nearest"` when
+        `moving` has an integer dtype (e.g. atlas region labels), and `"linear"`
+        otherwise.
     fill_value : float, optional
         Value assigned to voxels that fall outside the moving image's field of view
         after resampling. If not provided, defaults to `float(moving.min())`, which

--- a/tests/unit/test_registration/test_volume.py
+++ b/tests/unit/test_registration/test_volume.py
@@ -1154,6 +1154,43 @@ class TestResampleVolume:
             [grid["output_origin"][name] for name in WORLD_DIMS],
         )
 
+    def test_auto_interpolation_uses_nearest_for_integer_dtype(
+        self, sample_voxeldata_2d_registration
+    ):
+        """`interpolation="auto"` matches explicit "nearest" for integer-dtype data."""
+        moving = sample_voxeldata_2d_registration.astype(np.int32)
+        grid = _resample_volume_grid_kwargs(sample_voxeldata_2d_registration)
+
+        result_auto = resample_volume(moving, np.eye(4), interpolation="auto", **grid)
+        result_nearest = resample_volume(
+            moving, np.eye(4), interpolation="nearest", **grid
+        )
+        assert_array_equal(result_auto.values, result_nearest.values)
+
+    def test_auto_interpolation_uses_linear_for_float_dtype(
+        self, sample_voxeldata_2d_registration
+    ):
+        """`interpolation="auto"` matches explicit "linear" for float-dtype data."""
+        grid = _resample_volume_grid_kwargs(sample_voxeldata_2d_registration)
+        # A non-identity translation forces genuine blending between voxels, so a
+        # "nearest" result would diverge from "linear" here.
+        transform = np.eye(4)
+        transform[1, 3] = 0.05
+
+        result_auto = resample_volume(
+            sample_voxeldata_2d_registration,
+            transform,
+            interpolation="auto",
+            **grid,
+        )
+        result_linear = resample_volume(
+            sample_voxeldata_2d_registration,
+            transform,
+            interpolation="linear",
+            **grid,
+        )
+        assert_allclose(result_auto.values, result_linear.values)
+
     def test_multiple_extra_dims_matches_looped_resample(
         self,
         sample_voxeldata_2d_extra_dim_registration,
@@ -1942,6 +1979,20 @@ class TestResampleLike:
         )
         assert "time" not in result.dims
         assert_allclose(result.values, expected.values)
+
+    def test_default_interpolation_is_auto_for_integer_dtype(
+        self, sample_voxeldata_2d_registration
+    ):
+        """The default `interpolation="auto"` is forwarded, matching explicit "nearest"."""
+        moving = sample_voxeldata_2d_registration.astype(np.int32)
+        result_default = resample_like(moving, sample_voxeldata_2d_registration, np.eye(4))
+        result_nearest = resample_like(
+            moving,
+            sample_voxeldata_2d_registration,
+            np.eye(4),
+            interpolation="nearest",
+        )
+        assert_array_equal(result_default.values, result_nearest.values)
 
     def test_singleton_reference_dim_without_spacing_raises_helpful_error(self):
         """Thin references without defined spacing are rejected with a repair hint."""


### PR DESCRIPTION
## Summary
- `resample_volume`/`resample_like` required users to manually pick `interpolation`, so it was easy to forget `"nearest"` for integer-labeled data (e.g. atlas masks) and get blended nonsense.
- Adds `"auto"` interpolation, resolved from the input dtype (integer -> nearest, float -> linear), and makes it the new default for both functions.

Breaking change: default `interpolation` value changes from `"linear"` to `"auto"`.

Closes #375