### PR TITLE
fix(timing): reject pose-dependent time coordinates in resampling

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -180,11 +180,6 @@ Current development version for the next ConfUSIus release.
   with string coordinates (e.g. a recording-id stack dim); such a dimension now
   falls back to scale 1/origin 0 like any other missing world geometry
   ([#409](https://github.com/confusius-tools/confusius/pull/409)).
-- `resample_time`/`resample_to_uniform_time` now raise a clear error on
-  unconsolidated multi-pose data's `(time, pose)`-shaped `time` coordinate
-  instead of crashing with scipy's generic error; consolidate poses first with
-  `consolidate_poses`
-  ([#424](https://github.com/confusius-tools/confusius/pull/424)).
 
 ### :wrench: Maintenance
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -180,6 +180,11 @@ Current development version for the next ConfUSIus release.
   with string coordinates (e.g. a recording-id stack dim); such a dimension now
   falls back to scale 1/origin 0 like any other missing world geometry
   ([#409](https://github.com/confusius-tools/confusius/pull/409)).
+- `resample_time`/`resample_to_uniform_time` now raise a clear error on
+  unconsolidated multi-pose data's `(time, pose)`-shaped `time` coordinate
+  instead of crashing with scipy's generic error; consolidate poses first with
+  `consolidate_poses`
+  ([#424](https://github.com/confusius-tools/confusius/pull/424)).
 
 ### :wrench: Maintenance
 

--- a/src/confusius/timing.py
+++ b/src/confusius/timing.py
@@ -460,10 +460,13 @@ def resample_time(
     Raises
     ------
     ValueError
-        If `data` does not have a `time` dimension, has only 1 timepoint, or its `time`
-        coordinate is not strictly increasing.
+        If `data` does not have a `time` dimension, has only 1 timepoint, its `time`
+        coordinate is not strictly increasing, or its `time` coordinate is not 1D
+        (e.g. pose-dependent multi-pose data).
     """
-    validate_time_series(data, "time resampling", require_sorted_time=True)
+    validate_time_series(
+        data, "time resampling", require_sorted_time=True, require_1d_time=True
+    )
 
     time_coord = data.coords[TIME_DIM].values
     new_time_arr = np.asarray(new_time)
@@ -568,7 +571,8 @@ def resample_to_uniform_time(
     Raises
     ------
     ValueError
-        If `data` does not have a `time` dimension or has only 1 timepoint.
+        If `data` does not have a `time` dimension, has only 1 timepoint, or its `time`
+        coordinate is not 1D (e.g. pose-dependent multi-pose data).
     ValueError
         If `start` is greater than or equal to `stop`, if `step` is not positive,
         or if no valid representative step can be derived.
@@ -579,7 +583,7 @@ def resample_to_uniform_time(
         If the original time coordinate is not uniform and `step` is not provided.
         In that case the median step is used.
     """
-    validate_time_series(data, "uniform time resampling")
+    validate_time_series(data, "uniform time resampling", require_1d_time=True)
 
     time_values = data.coords[TIME_DIM].values
 

--- a/src/confusius/validation/time_series.py
+++ b/src/confusius/validation/time_series.py
@@ -78,10 +78,8 @@ def validate_unchunked_time(data: xr.DataArray, operation_name: str) -> None:
 def validate_sorted_time(data: xr.DataArray, operation_name: str) -> None:
     """Validate that `time` coordinates are strictly increasing.
 
-    For a pose-dependent `(time, pose)`-shaped `time` coordinate, checks the whole
-    per-`(time, pose)` acquisition sequence -- poses are swept sequentially within
-    each `time` repetition (`time` major, `pose` minor) -- not just each pose's own
-    column.
+    For a pose-dependent `(time, pose)`-shaped `time` coordinate, checks each pose's
+    own timestamps along the `time` axis, not across poses.
 
     Parameters
     ----------
@@ -95,8 +93,9 @@ def validate_sorted_time(data: xr.DataArray, operation_name: str) -> None:
     ValueError
         If `time` coordinates are not strictly increasing.
     """
-    time_coord = data.coords[TIME_DIM].transpose(TIME_DIM, ...)
-    if np.any(np.diff(time_coord.values.ravel()) <= 0):
+    time_coord = data.coords[TIME_DIM]
+    time_axis = time_coord.dims.index(TIME_DIM)
+    if np.any(np.diff(time_coord.values, axis=time_axis) <= 0):
         raise ValueError(
             f"time coordinates must be strictly increasing for {operation_name}."
         )

--- a/src/confusius/validation/time_series.py
+++ b/src/confusius/validation/time_series.py
@@ -90,9 +90,35 @@ def validate_sorted_time(data: xr.DataArray, operation_name: str) -> None:
     ValueError
         If `time` coordinates are not strictly increasing.
     """
-    if np.any(np.diff(data.coords[TIME_DIM].values) <= 0):
+    time_coord = data.coords[TIME_DIM]
+    time_axis = time_coord.dims.index(TIME_DIM)
+    if np.any(np.diff(time_coord.values, axis=time_axis) <= 0):
         raise ValueError(
             f"time coordinates must be strictly increasing for {operation_name}."
+        )
+
+
+def validate_one_dimensional_time(data: xr.DataArray, operation_name: str) -> None:
+    """Validate that `time` is a plain 1D dimension coordinate.
+
+    Parameters
+    ----------
+    data : xarray.DataArray
+        DataArray with a `time` dimension.
+    operation_name : str
+        Name of the operation used in error messages.
+
+    Raises
+    ------
+    ValueError
+        If the `time` coordinate has more than one dimension (e.g. a pose-dependent
+        `(time, pose)`-shaped `time` coordinate from unconsolidated multi-pose data).
+    """
+    if data.coords[TIME_DIM].ndim > 1:
+        raise ValueError(
+            f"{operation_name.capitalize()} requires a 1D 'time' coordinate, got a "
+            f"{data.coords[TIME_DIM].dims}-shaped 'time' coordinate. Consolidate "
+            "multi-pose data first with confusius.multipose.consolidate_poses."
         )
 
 
@@ -141,6 +167,7 @@ def validate_time_series(  # numpydoc ignore=GL08,PR01,RT01
     require_unchunked_time: bool = True,
     require_sorted_time: bool = False,
     require_uniform_time: Literal[False] = False,
+    require_1d_time: bool = False,
     uniformity_tolerance: float = 1e-2,
 ) -> tuple[int, None]: ...
 
@@ -152,6 +179,7 @@ def validate_time_series(  # numpydoc ignore=GL08,PR01,RT01
     require_unchunked_time: bool = True,
     require_sorted_time: bool = False,
     require_uniform_time: Literal[True] = True,
+    require_1d_time: bool = False,
     uniformity_tolerance: float = 1e-2,
 ) -> tuple[int, float]: ...
 
@@ -162,6 +190,7 @@ def validate_time_series(
     require_unchunked_time: bool = True,
     require_sorted_time: bool = False,
     require_uniform_time: bool = False,
+    require_1d_time: bool = False,
     uniformity_tolerance: float = 1e-2,
 ) -> tuple[int, float | None]:
     """Validate time series for time series processing operations.
@@ -171,8 +200,9 @@ def validate_time_series(
     1. Time series have a `time` dimension.
     2. Time dimension has more than 1 timepoint.
     3. Time dimension is not chunked for Dask arrays (optional).
-    4. Time coordinate is strictly increasing (optional).
-    5. Time coordinate is uniformly sampled (optional).
+    4. Time coordinate is 1D, not pose-dependent (optional).
+    5. Time coordinate is strictly increasing (optional).
+    6. Time coordinate is uniformly sampled (optional).
 
     Parameters
     ----------
@@ -188,6 +218,9 @@ def validate_time_series(
         Whether to require strictly increasing `time` coordinates.
     require_uniform_time : bool, default: False
         Whether to require uniformly sampled `time` coordinates and return their spacing.
+    require_1d_time : bool, default: False
+        Whether to require a 1D `time` coordinate, rejecting pose-dependent
+        `(time, pose)`-shaped `time` coordinates from unconsolidated multi-pose data.
     uniformity_tolerance : float, default: 1e-2
         Maximum allowed relative range of consecutive time intervals, defined as
         `(max_interval - min_interval) / median_interval`. Raise a `ValueError` if the
@@ -205,12 +238,16 @@ def validate_time_series(
     ValueError
         If `time_series` has no `time` dimension, if the `time` dimension has only 1
         timepoint, if the `time` dimension is chunked in a Dask array (when
-        `require_unchunked_time=True`), if `require_sorted_time=True` and the `time`
-        coordinate is not strictly increasing, or if `require_uniform_time=True` and the
-        `time` coordinate is not uniformly sampled.
+        `require_unchunked_time=True`), if `require_1d_time=True` and the `time`
+        coordinate is not 1D, if `require_sorted_time=True` and the `time` coordinate is
+        not strictly increasing, or if `require_uniform_time=True` and the `time`
+        coordinate is not uniformly sampled.
     """
     validate_required_time_dimension(time_series)
     validate_timepoint_count(time_series, operation_name)
+
+    if require_1d_time:
+        validate_one_dimensional_time(time_series, operation_name)
 
     time_axis = time_series.get_axis_num(TIME_DIM)
 

--- a/src/confusius/validation/time_series.py
+++ b/src/confusius/validation/time_series.py
@@ -78,6 +78,11 @@ def validate_unchunked_time(data: xr.DataArray, operation_name: str) -> None:
 def validate_sorted_time(data: xr.DataArray, operation_name: str) -> None:
     """Validate that `time` coordinates are strictly increasing.
 
+    For a pose-dependent `(time, pose)`-shaped `time` coordinate, checks the whole
+    per-`(time, pose)` acquisition sequence -- poses are swept sequentially within
+    each `time` repetition (`time` major, `pose` minor) -- not just each pose's own
+    column.
+
     Parameters
     ----------
     data : xarray.DataArray
@@ -90,9 +95,8 @@ def validate_sorted_time(data: xr.DataArray, operation_name: str) -> None:
     ValueError
         If `time` coordinates are not strictly increasing.
     """
-    time_coord = data.coords[TIME_DIM]
-    time_axis = time_coord.dims.index(TIME_DIM)
-    if np.any(np.diff(time_coord.values, axis=time_axis) <= 0):
+    time_coord = data.coords[TIME_DIM].transpose(TIME_DIM, ...)
+    if np.any(np.diff(time_coord.values.ravel()) <= 0):
         raise ValueError(
             f"time coordinates must be strictly increasing for {operation_name}."
         )

--- a/tests/unit/test_timing.py
+++ b/tests/unit/test_timing.py
@@ -256,6 +256,32 @@ def test_resample_time_rejects_missing_time_coordinate() -> None:
         resample_time(data, [0.5, 1.5])
 
 
+def test_resample_time_rejects_pose_dependent_time_coordinate() -> None:
+    """Resample raises for a pose-dependent (time, pose)-shaped time coordinate."""
+    time = xr.DataArray(
+        [[0.0, 0.1], [1.0, 1.2], [2.0, 2.3]], dims=("time", "pose")
+    )
+    data = xr.DataArray(
+        np.zeros((3, 2)), dims=("time", "pose"), coords={"time": time}
+    )
+
+    with pytest.raises(ValueError, match="1D 'time' coordinate"):
+        resample_time(data, [0.5, 1.5])
+
+
+def test_resample_to_uniform_time_rejects_pose_dependent_time_coordinate() -> None:
+    """Resample to uniform time raises for a pose-dependent time coordinate."""
+    time = xr.DataArray(
+        [[0.0, 0.1], [1.0, 1.2], [2.0, 2.3]], dims=("time", "pose")
+    )
+    data = xr.DataArray(
+        np.zeros((3, 2)), dims=("time", "pose"), coords={"time": time}
+    )
+
+    with pytest.raises(ValueError, match="1D 'time' coordinate"):
+        resample_to_uniform_time(data)
+
+
 def test_resample_to_uniform_time_uses_provided_step() -> None:
     """Resample to uniform time uses provided step and matches scipy reference."""
     time_values = [0.0, 1.0, 2.0, 3.0]

--- a/tests/unit/test_validation/test_time_series.py
+++ b/tests/unit/test_validation/test_time_series.py
@@ -66,17 +66,37 @@ def test_validate_time_series_allows_pose_dependent_time_by_default():
     validate_time_series(signals, "resampling")
 
 
-def test_validate_time_series_checks_sortedness_along_time_axis_for_pose_data():
-    """Sorted-time validation should diff along time, not the trailing pose axis."""
-    # Each pose's own timestamps are strictly increasing, but pose 1's timestamps are
-    # smaller than pose 0's at every timepoint -- a naive default-axis np.diff would
-    # misread that as unsorted.
-    time = xr.DataArray([[1.0, 0.5], [2.0, 1.5], [3.0, 2.5]], dims=["time", "pose"])
+def test_validate_time_series_accepts_sorted_pose_dependent_acquisition_order():
+    """Sorted-time validation should pass a genuinely increasing acquisition order.
+
+    Poses are swept sequentially within each time repetition (time major, pose
+    minor), so a valid (time, pose) time coordinate increases when raveled in that
+    order even though no single axis alone is sorted.
+    """
+    time = xr.DataArray(
+        [[0.0, 0.5], [1.0, 1.5], [2.0, 2.5]], dims=["time", "pose"]
+    )
     signals = xr.DataArray(
         np.zeros((3, 2)), dims=["time", "pose"], coords={"time": time}
     )
 
     validate_time_series(signals, "resampling", require_sorted_time=True)
+
+
+def test_validate_time_series_rejects_poses_out_of_order_within_a_repetition():
+    """Sorted-time validation should reject poses out of order within a repetition.
+
+    Each pose's own timestamps are strictly increasing across repetitions, but pose
+    1's timestamps are smaller than pose 0's at every repetition -- a per-column
+    check alone would miss this, but the poses were not swept in increasing order.
+    """
+    time = xr.DataArray([[1.0, 0.5], [2.0, 1.5], [3.0, 2.5]], dims=["time", "pose"])
+    signals = xr.DataArray(
+        np.zeros((3, 2)), dims=["time", "pose"], coords={"time": time}
+    )
+
+    with pytest.raises(ValueError, match="strictly increasing"):
+        validate_time_series(signals, "resampling", require_sorted_time=True)
 
 
 def test_validate_time_series_returns_spacing_when_uniform_time_required():

--- a/tests/unit/test_validation/test_time_series.py
+++ b/tests/unit/test_validation/test_time_series.py
@@ -45,6 +45,40 @@ def test_validate_time_series_raises_for_unsorted_time_when_required():
         validate_time_series(signals, "resampling", require_sorted_time=True)
 
 
+def test_validate_time_series_raises_for_pose_dependent_time_when_1d_required():
+    """1D-time validation should reject a (time, pose)-shaped time coordinate."""
+    time = xr.DataArray([[0.0, 0.1], [1.0, 1.2], [2.0, 2.3]], dims=["time", "pose"])
+    signals = xr.DataArray(
+        np.zeros((3, 2)), dims=["time", "pose"], coords={"time": time}
+    )
+
+    with pytest.raises(ValueError, match="1D 'time' coordinate"):
+        validate_time_series(signals, "resampling", require_1d_time=True)
+
+
+def test_validate_time_series_allows_pose_dependent_time_by_default():
+    """1D-time validation should be opt-in, not enforced by default."""
+    time = xr.DataArray([[0.0, 0.1], [1.0, 1.2], [2.0, 2.3]], dims=["time", "pose"])
+    signals = xr.DataArray(
+        np.zeros((3, 2)), dims=["time", "pose"], coords={"time": time}
+    )
+
+    validate_time_series(signals, "resampling")
+
+
+def test_validate_time_series_checks_sortedness_along_time_axis_for_pose_data():
+    """Sorted-time validation should diff along time, not the trailing pose axis."""
+    # Each pose's own timestamps are strictly increasing, but pose 1's timestamps are
+    # smaller than pose 0's at every timepoint -- a naive default-axis np.diff would
+    # misread that as unsorted.
+    time = xr.DataArray([[1.0, 0.5], [2.0, 1.5], [3.0, 2.5]], dims=["time", "pose"])
+    signals = xr.DataArray(
+        np.zeros((3, 2)), dims=["time", "pose"], coords={"time": time}
+    )
+
+    validate_time_series(signals, "resampling", require_sorted_time=True)
+
+
 def test_validate_time_series_returns_spacing_when_uniform_time_required():
     """Uniform-time validation should return the time spacing."""
     signals = xr.DataArray(

--- a/tests/unit/test_validation/test_time_series.py
+++ b/tests/unit/test_validation/test_time_series.py
@@ -66,37 +66,17 @@ def test_validate_time_series_allows_pose_dependent_time_by_default():
     validate_time_series(signals, "resampling")
 
 
-def test_validate_time_series_accepts_sorted_pose_dependent_acquisition_order():
-    """Sorted-time validation should pass a genuinely increasing acquisition order.
-
-    Poses are swept sequentially within each time repetition (time major, pose
-    minor), so a valid (time, pose) time coordinate increases when raveled in that
-    order even though no single axis alone is sorted.
-    """
-    time = xr.DataArray(
-        [[0.0, 0.5], [1.0, 1.5], [2.0, 2.5]], dims=["time", "pose"]
-    )
-    signals = xr.DataArray(
-        np.zeros((3, 2)), dims=["time", "pose"], coords={"time": time}
-    )
-
-    validate_time_series(signals, "resampling", require_sorted_time=True)
-
-
-def test_validate_time_series_rejects_poses_out_of_order_within_a_repetition():
-    """Sorted-time validation should reject poses out of order within a repetition.
-
-    Each pose's own timestamps are strictly increasing across repetitions, but pose
-    1's timestamps are smaller than pose 0's at every repetition -- a per-column
-    check alone would miss this, but the poses were not swept in increasing order.
-    """
+def test_validate_time_series_checks_sortedness_along_time_axis_for_pose_data():
+    """Sorted-time validation should diff along time, not the trailing pose axis."""
+    # Each pose's own timestamps are strictly increasing, but pose 1's timestamps are
+    # smaller than pose 0's at every timepoint -- a naive default-axis np.diff would
+    # misread that as unsorted.
     time = xr.DataArray([[1.0, 0.5], [2.0, 1.5], [3.0, 2.5]], dims=["time", "pose"])
     signals = xr.DataArray(
         np.zeros((3, 2)), dims=["time", "pose"], coords={"time": time}
     )
 
-    with pytest.raises(ValueError, match="strictly increasing"):
-        validate_time_series(signals, "resampling", require_sorted_time=True)
+    validate_time_series(signals, "resampling", require_sorted_time=True)
 
 
 def test_validate_time_series_returns_spacing_when_uniform_time_required():


### PR DESCRIPTION
## Summary
- `resample_time`/`resample_to_uniform_time` assumed a 1D `time` coordinate and crashed with scipy's generic error on unconsolidated multi-pose data's `(time, pose)`-shaped `time` coordinate; they now raise a clear `ValueError` pointing at `consolidate_poses`, via a new `require_1d_time` flag on `validate_time_series`.
- Also fixes `validate_sorted_time`, which diffed along the default last axis of the time coordinate array -- correct for 1D `time`, but wrong (`pose` axis) for `(time, pose)`-shaped ones.

Fixes #423.