### PR TITLE
chore: prepare v0.7.0 release

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -32,5 +32,5 @@ keywords:
   - Brain connectivity
   - Python
 license: BSD-3-Clause
-version: 0.6.1
-date-released: '2026-08-07'
+version: 0.7.0
+date-released: '2026-08-31'

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ and tutorials.
 
 If you use ConfUSIus in your research, please cite it using the following reference:
 
-> Le Meur-Diebolt, S., & Cybis Pereira, F. (2026). ConfUSIus (v0.6.1). Zenodo.
+> Le Meur-Diebolt, S., & Cybis Pereira, F. (2026). ConfUSIus (v0.7.0). Zenodo.
 > https://doi.org/10.5281/zenodo.18611124
 
 Or in BibTeX format:
@@ -126,7 +126,7 @@ Or in BibTeX format:
   title     = {ConfUSIus},
   year      = {2026},
   publisher = {Zenodo},
-  version   = {v0.6.1},
+  version   = {v0.7.0},
   doi       = {10.5281/zenodo.18611124},
   url       = {https://doi.org/10.5281/zenodo.18611124}
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,9 +6,9 @@ icon: lucide/history
 
 # Changelog
 
-## 0.7.0.dev0
+## 0.7.0
 
-Current development version for the next ConfUSIus release.
+Released 2026-08-31.
 
 ### :boom: Breaking changes
 

--- a/docs/citing.md
+++ b/docs/citing.md
@@ -8,7 +8,7 @@ icon: lucide/quote
 
 If you use ConfUSIus in your research, please cite it using the following reference:
 
-> Le Meur-Diebolt, S., & Cybis Pereira, F. (2026). ConfUSIus (v0.6.1). Zenodo.
+> Le Meur-Diebolt, S., & Cybis Pereira, F. (2026). ConfUSIus (v0.7.0). Zenodo.
 > https://doi.org/10.5281/zenodo.18611124
 
 Or in BibTeX format:
@@ -19,7 +19,7 @@ Or in BibTeX format:
   title     = {ConfUSIus},
   year      = {2026},
   publisher = {Zenodo},
-  version   = {v0.6.1},
+  version   = {v0.7.0},
   doi       = {10.5281/zenodo.18611124},
   url       = {https://doi.org/10.5281/zenodo.18611124}
 }

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -32,7 +32,7 @@ snippet in a Python environment:
 ```pycon
 >>> import confusius as cf
 >>> print(cf.__version__)
-'0.7.0.dev0'
+'0.7.0'
 ```
 
 If the installation was successful, this code will print the installed version of

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "confusius"
-version = "0.7.0.dev0"
+version = "0.7.0"
 description = "Python package for analysis and visualization of functional ultrasound imaging data."
 readme = "README.md"
 license = "BSD-3-Clause AND Apache-2.0 AND BSD-2-Clause"

--- a/uv.lock
+++ b/uv.lock
@@ -700,7 +700,7 @@ wheels = [
 
 [[package]]
 name = "confusius"
-version = "0.7.0.dev0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "brainglobe-atlasapi" },


### PR DESCRIPTION
## Summary
- finalize version metadata for `v0.7.0`
- convert the changelog entry from development to released form
- update release citation metadata and docs references