### PR TITLE
chore: start 0.7.1.dev0 development

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,10 @@ icon: lucide/history
 
 # Changelog
 
+## 0.7.1.dev0
+
+Current development version for the next ConfUSIus release.
+
 ## 0.7.0
 
 Released 2026-08-31.

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -32,7 +32,7 @@ snippet in a Python environment:
 ```pycon
 >>> import confusius as cf
 >>> print(cf.__version__)
-'0.7.0'
+'0.7.1.dev0'
 ```
 
 If the installation was successful, this code will print the installed version of

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "confusius"
-version = "0.7.0"
+version = "0.7.1.dev0"
 description = "Python package for analysis and visualization of functional ultrasound imaging data."
 readme = "README.md"
 license = "BSD-3-Clause AND Apache-2.0 AND BSD-2-Clause"

--- a/uv.lock
+++ b/uv.lock
@@ -700,7 +700,7 @@ wheels = [
 
 [[package]]
 name = "confusius"
-version = "0.7.0"
+version = "0.7.1.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "brainglobe-atlasapi" },


### PR DESCRIPTION
## Summary
- bump the repository version to `0.7.1.dev0`
- start the next changelog section
- restore development-version metadata after the release