### PR TITLE
feat(napari): responsive mouse source + pinnable signals

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,26 +15,20 @@ Current development version for the next ConfUSIus release.
 - Scrolling the sidebar with the mouse wheel no longer gets hijacked by whichever
   combo box or spin box the cursor happens to be over
   ([#431](https://github.com/confusius-tools/confusius/pull/431)).
-
-### :sparkles: Enhancements
-
-- **napari plugin:** The signal plotter's mouse source now updates when Shift is
-  pressed while the cursor is already resting on a voxel, not only while moving;
-  a live signal (mouse voxel, a point, or a label region) can now be pinned so it
-  persists across source-mode switches instead of being dropped, reusable
-  wherever stored signals are — imported and pinned signals now share one
-  concept (`StoredSignal`) throughout the signal store, plotter, and manager
+- The signal plotter's mouse source now updates when Shift is pressed while the
+  cursor is already resting on a voxel, not only while moving; a live signal
+  (mouse voxel, a point, or a label region) can now be pinned so it persists
+  across source-mode switches instead of being dropped, reusable wherever stored
+  signals are — imported and pinned signals now share one concept
+  (`StoredSignal`) throughout the signal store, plotter, and manager
   ([#429](https://github.com/confusius-tools/confusius/pull/429)).
-- **napari plugin:** A DVARS trace computed in the Quality Control panel is now
-  added to the shared signal store, making it selectable elsewhere in the plugin
-  without first exporting and re-importing it
+- Mouse-driven signal plotting no longer lags or jitters on large recordings —
+  updates are now throttled to the display refresh rate instead of running
+  unbounded on every raw mouse-move event
   ([#429](https://github.com/confusius-tools/confusius/pull/429)).
-
-### :zap: Performance
-
-- **napari plugin:** Mouse-driven signal plotting no longer lags or jitters on
-  large recordings — updates are now throttled to the display refresh rate
-  instead of running unbounded on every raw mouse-move event
+- A DVARS trace computed in the Quality Control panel is now added to the
+  shared signal store, making it selectable elsewhere in the plugin without
+  first exporting and re-importing it
   ([#429](https://github.com/confusius-tools/confusius/pull/429)).
 
 ## 0.7.0

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -25,6 +25,10 @@ Current development version for the next ConfUSIus release.
   wherever stored signals are — imported and pinned signals now share one
   concept (`StoredSignal`) throughout the signal store, plotter, and manager
   ([#429](https://github.com/confusius-tools/confusius/pull/429)).
+- **napari plugin:** A DVARS trace computed in the Quality Control panel is now
+  added to the shared signal store, making it selectable elsewhere in the plugin
+  without first exporting and re-importing it
+  ([#429](https://github.com/confusius-tools/confusius/pull/429)).
 
 ### :zap: Performance
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,23 @@ Current development version for the next ConfUSIus release.
   combo box or spin box the cursor happens to be over
   ([#431](https://github.com/confusius-tools/confusius/pull/431)).
 
+### :sparkles: Enhancements
+
+- **napari plugin:** The signal plotter's mouse source now updates when Shift is
+  pressed while the cursor is already resting on a voxel, not only while moving;
+  a live signal (mouse voxel, a point, or a label region) can now be pinned so it
+  persists across source-mode switches instead of being dropped, reusable
+  wherever stored signals are — imported and pinned signals now share one
+  concept (`StoredSignal`) throughout the signal store, plotter, and manager
+  ([#429](https://github.com/confusius-tools/confusius/pull/429)).
+
+### :zap: Performance
+
+- **napari plugin:** Mouse-driven signal plotting no longer lags or jitters on
+  large recordings — updates are now throttled to the display refresh rate
+  instead of running unbounded on every raw mouse-move event
+  ([#429](https://github.com/confusius-tools/confusius/pull/429)).
+
 ## 0.7.0
 
 Released 2026-08-31.

--- a/src/confusius/_napari/_qc/_panel.py
+++ b/src/confusius/_napari/_qc/_panel.py
@@ -24,6 +24,8 @@ from qtpy.QtWidgets import (
 
 from confusius._dims import TIME_DIM
 from confusius._napari._qc._plots import QCPlotsWidget
+from confusius._napari._signals._store import SignalStore
+from confusius._napari._utils import CATEGORICAL_COLORS
 from confusius.plotting.image import _prepare_carpet_data
 from confusius.plotting.napari import plot_napari
 from confusius.qc import compute_cv, compute_dvars, compute_tsnr
@@ -76,11 +78,18 @@ class QCPanel(QWidget):
     ----------
     viewer : napari.Viewer
         The active napari viewer instance.
+    signal_store : SignalStore, optional
+        Shared store of stored/live signals. If provided, each computed DVARS trace
+        is also added there (as `"DVARS (<layer>)"`), making it selectable as a
+        Preprocessing panel confound/sample mask.
     """
 
-    def __init__(self, viewer: napari.Viewer) -> None:
+    def __init__(
+        self, viewer: napari.Viewer, signal_store: SignalStore | None = None
+    ) -> None:
         super().__init__()
         self.viewer = viewer
+        self._signal_store = signal_store
         # Cached reference to the inner plot widget (survives dock closure because
         # napari re-parents it to None rather than destroying it).
         self._qc_plots: QCPlotsWidget | None = None
@@ -352,6 +361,7 @@ class QCPanel(QWidget):
 
                 if "dvars" in results:
                     qc_widget.update_dvars(results["dvars"], layer_name=layer_name)
+                    self._store_dvars_signal(results["dvars"], layer_name)
 
                 if "carpet" in results:
                     qc_widget.update_carpet(results["carpet"], layer_name=layer_name)
@@ -387,6 +397,23 @@ class QCPanel(QWidget):
             show_error(str(exc))
         finally:
             self._end_work()
+
+    def _store_dvars_signal(self, dvars_da: xr.DataArray, layer_name: str) -> None:
+        """Add a computed DVARS trace to the shared signal store, if any.
+
+        Re-pinned under a `layer_name`-derived origin, so recomputing DVARS for the
+        same layer updates the stored signal in place instead of duplicating it.
+        """
+        if self._signal_store is None:
+            return
+        self._signal_store.pin_signal(
+            origin=f"dvars-{layer_name}",
+            name=f"DVARS ({layer_name})",
+            x=dvars_da.coords[TIME_DIM].values,
+            y=dvars_da.values,
+            color=CATEGORICAL_COLORS[0],
+            source_label=f"QC: {layer_name}",
+        )
 
     def _on_compute_error(self, exc: Exception) -> None:
         self._end_work()

--- a/src/confusius/_napari/_signals/_manager.py
+++ b/src/confusius/_napari/_signals/_manager.py
@@ -1,4 +1,4 @@
-"""Floating manager window for imported signals."""
+"""Floating manager window for stored signals."""
 
 from __future__ import annotations
 
@@ -21,6 +21,11 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
+from confusius._napari._export import (
+    ExportSignal,
+    prompt_delimited_export_path,
+    write_delimited_signals,
+)
 from confusius._napari._signals._store import LiveSignal, SignalStore
 from confusius._napari._theme import get_napari_colors
 
@@ -57,16 +62,17 @@ def _colored_button_style(r: int, g: int, b: int) -> str:
 
 
 class SignalsManagerDialog(QDialog):
-    """Modeless dialog for managing live and imported signals.
+    """Modeless dialog for managing live and stored signals.
 
     Live signals (from mouse, points, or labels layers) appear at the top of the table.
-    They can be renamed, recolored, and hidden but not removed. Imported signals appear
-    below and support the full set of operations.
+    They can be renamed, recolored, and hidden but not removed. Stored signals — either
+    imported from a file or pinned from a live signal — appear below and support the
+    full set of operations.
 
     Parameters
     ----------
     store : SignalStore
-        Shared imported-signals store.
+        Shared stored-signals store.
     parent : QWidget | None, optional
         Optional parent widget.
     """
@@ -95,14 +101,22 @@ class SignalsManagerDialog(QDialog):
         self._import_btn.clicked.connect(self._import_file)
         button_row.addWidget(self._import_btn)
 
+        self._export_btn = QPushButton("Export Selected")
+        self._export_btn.setToolTip(
+            "Export selected stored signals to a CSV or TSV file"
+        )
+        self._export_btn.setStyleSheet(_colored_button_style(80, 120, 200))
+        self._export_btn.clicked.connect(self._export_selected)
+        button_row.addWidget(self._export_btn)
+
         self._remove_btn = QPushButton("Remove")
-        self._remove_btn.setToolTip("Remove selected imported signal")
+        self._remove_btn.setToolTip("Remove selected stored signal")
         self._remove_btn.setStyleSheet(_colored_button_style(200, 80, 80))
         self._remove_btn.clicked.connect(self._remove_selected)
         button_row.addWidget(self._remove_btn)
 
-        self._clear_btn = QPushButton("Clear All Imported")
-        self._clear_btn.setToolTip("Remove all imported signals")
+        self._clear_btn = QPushButton("Clear All Stored")
+        self._clear_btn.setToolTip("Remove all stored signals")
         self._clear_btn.setStyleSheet(_colored_button_style(200, 80, 80))
         self._clear_btn.clicked.connect(self._store.clear)
         button_row.addWidget(self._clear_btn)
@@ -139,16 +153,16 @@ class SignalsManagerDialog(QDialog):
         self._updating_table = True
         try:
             live_list = self._store.live_signals()
-            imported_list = self._store.imported_signals()
-            total = len(live_list) + len(imported_list)
+            stored_list = self._store.stored_signals()
+            total = len(live_list) + len(stored_list)
             self._table.setRowCount(total)
 
             row = 0
             for signal in live_list:
                 self._set_live_row(row, signal)
                 row += 1
-            for signal in imported_list:
-                self._set_imported_row(row, signal)
+            for signal in stored_list:
+                self._set_stored_row(row, signal)
                 row += 1
         finally:
             self._updating_table = False
@@ -192,8 +206,8 @@ class SignalsManagerDialog(QDialog):
         source_item.setFont(italic_font)
         self._table.setItem(row, 3, source_item)
 
-    def _set_imported_row(self, row: int, signal) -> None:
-        """Populate one table row from an imported signal."""
+    def _set_stored_row(self, row: int, signal) -> None:
+        """Populate one table row from a stored signal."""
         visible_item = QTableWidgetItem()
         visible_item.setFlags(
             Qt.ItemFlag.ItemIsEnabled
@@ -275,7 +289,7 @@ class SignalsManagerDialog(QDialog):
             current = live.color if live is not None else "#ffffff"
         else:
             current = next(
-                (s.color for s in self._store.imported_signals() if s.id == signal_id),
+                (s.color for s in self._store.stored_signals() if s.id == signal_id),
                 "#ffffff",
             )
 
@@ -291,12 +305,17 @@ class SignalsManagerDialog(QDialog):
         except Exception as exc:  # noqa: BLE001
             show_error(str(exc))
 
-    def _remove_selected(self) -> None:
-        """Remove the currently selected imported signal (live signals are skipped)."""
+    def _selected_stored_ids(self) -> list[str]:
+        """Return ids of the currently selected stored (non-live) rows.
+
+        Live rows are skipped: the manager only tracks their presentation
+        metadata, not the underlying data, so they can't be removed or exported
+        from here.
+        """
         signal_ids = []
         selection_model = self._table.selectionModel()
         if selection_model is None:
-            return
+            return signal_ids
         rows = [index.row() for index in selection_model.selectedRows()]
         if not rows and self._table.currentRow() >= 0:
             rows = [self._table.currentRow()]
@@ -307,7 +326,41 @@ class SignalsManagerDialog(QDialog):
             signal_id = item.data(Qt.ItemDataRole.UserRole)
             if isinstance(signal_id, str) and not self._is_live_id(signal_id):
                 signal_ids.append(signal_id)
-        self._store.remove_signals(signal_ids)
+        return signal_ids
+
+    def _remove_selected(self) -> None:
+        """Remove the currently selected stored signal (live signals are skipped)."""
+        self._store.remove_signals(self._selected_stored_ids())
+
+    def _export_selected(self) -> None:
+        """Export the currently selected stored signals to a CSV or TSV file."""
+        signal_ids = self._selected_stored_ids()
+        stored_by_id = {s.id: s for s in self._store.stored_signals()}
+        export_signals = [
+            ExportSignal(
+                stored_by_id[sid].name, stored_by_id[sid].x, stored_by_id[sid].y
+            )
+            for sid in signal_ids
+            if sid in stored_by_id
+        ]
+        if not export_signals:
+            show_error("Select one or more stored signals to export.")
+            return
+
+        export_selection = prompt_delimited_export_path(
+            self, "Export Signals", str(Path.home() / "signals.tsv")
+        )
+        if export_selection is None:
+            return
+        path, delimiter = export_selection
+
+        try:
+            write_delimited_signals(path, export_signals, delimiter=delimiter)
+        except Exception as exc:  # noqa: BLE001
+            show_error(str(exc))
+            return
+
+        show_info(f"Exported signals to {path}")
 
     def _import_file(self) -> None:
         """Import one or more CSV or TSV files into the shared store."""

--- a/src/confusius/_napari/_signals/_panel.py
+++ b/src/confusius/_napari/_signals/_panel.py
@@ -45,17 +45,26 @@ class SignalPanel(QWidget):
         The active napari viewer instance.
     event_store : EventStore, optional
         Shared store of temporal events whose intervals are shaded on the plot.
+    signal_store : SignalStore, optional
+        Shared store of stored/live signals. If not provided, a private store is
+        created. Pass the same instance used elsewhere (e.g. the QC panel) so
+        stored signals are available across panels.
     """
 
     def __init__(
-        self, viewer: napari.Viewer, event_store: EventStore | None = None
+        self,
+        viewer: napari.Viewer,
+        event_store: EventStore | None = None,
+        signal_store: SignalStore | None = None,
     ) -> None:
         super().__init__()
         self._viewer = viewer
         self._event_store = event_store
         self._plotter: SignalPlotter | None = None
         self._signals_manager: SignalsManagerDialog | None = None
-        self._signals_store = SignalStore(self)
+        self._signals_store = (
+            signal_store if signal_store is not None else SignalStore(self)
+        )
         self._cached_xaxis_dim_index: int | None = None
         self._setup_ui()
         viewer.events.theme.connect(self._on_theme_changed)

--- a/src/confusius/_napari/_signals/_plotter.py
+++ b/src/confusius/_napari/_signals/_plotter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, cast
 
@@ -14,6 +15,7 @@ from matplotlib.backends.backend_qtagg import NavigationToolbar2QT as Navigation
 from matplotlib.figure import Figure
 from napari.utils.colormaps import DirectLabelColormap
 from napari.utils.colormaps.standardize_color import transform_color
+from napari.utils.key_bindings import coerce_keybinding
 from napari.utils.notifications import show_error, show_info
 from qtpy.QtCore import QSize, QTimer, Signal
 from qtpy.QtWidgets import QSizePolicy, QVBoxLayout, QWidget
@@ -148,6 +150,21 @@ class SignalPlotter(QWidget):
         self._cursor_timer.setInterval(16)  # ms → ~60 fps
         self._cursor_timer.timeout.connect(self._flush_cursor)
 
+        # Throttle mouse-source updates to ~60 fps, leading-edge: process
+        # immediately when the last update was long enough ago (the common case,
+        # zero added latency), and otherwise schedule a single trailing update so
+        # the final cursor position still gets rendered once a fast burst of
+        # events (which would otherwise pile up faster than a redraw completes)
+        # subsides, rather than queuing every intermediate position.
+        self._mouse_update_min_interval_s = 1 / 60
+        self._last_mouse_update_time: float = 0.0
+        self._mouse_update_timer = QTimer(self)
+        self._mouse_update_timer.setSingleShot(True)
+        self._mouse_update_timer.timeout.connect(self._flush_mouse_update)
+
+        # Previous keymap handler displaced by binding Shift, restored on close.
+        self._displaced_shift_key = None
+
         self.setSizePolicy(
             QSizePolicy.Policy.Expanding,
             QSizePolicy.Policy.Expanding,
@@ -216,6 +233,61 @@ class SignalPlotter(QWidget):
         self._viewer.layers.events.inserted.connect(self._on_layer_change)
         self._viewer.layers.events.removed.connect(self._on_layer_change)
         self._viewer.layers.selection.events.active.connect(self._on_layer_change)
+        self._bind_shift_key()
+
+    def _bind_shift_key(self) -> None:
+        """Bind Shift in the napari keymap to plot the signal at the resting cursor.
+
+        Lets the user press Shift while the cursor is already stationary over an
+        image layer, instead of requiring mouse movement while Shift is held.
+        Any handler already bound to Shift is saved first so it can be restored
+        when the plotter closes.
+        """
+        keybinding = coerce_keybinding("Shift")
+        self._displaced_shift_key = self._viewer.keymap.get(keybinding)
+        self._viewer.bind_key("Shift", self._on_shift_pressed, overwrite=True)
+
+    def _unbind_shift_key(self) -> None:
+        """Restore the keymap entry displaced by `_bind_shift_key`."""
+        keybinding = coerce_keybinding("Shift")
+        if self._displaced_shift_key is not None:
+            self._viewer.keymap[keybinding] = self._displaced_shift_key
+        else:
+            self._viewer.keymap.pop(keybinding, None)
+        self._displaced_shift_key = None
+
+    def _on_shift_pressed(self, viewer: napari.Viewer) -> None:
+        """Plot the signal at the current cursor position when Shift is pressed."""
+        if self._source_mode != "mouse":
+            return
+        layer = self._active_layer()
+        if layer is None:
+            return
+        self._current_layer = layer
+        self._cursor_pos = np.array(viewer.cursor.position)
+        self._schedule_mouse_update()
+
+    def _schedule_mouse_update(self) -> None:
+        """Throttle mouse-source plot updates to ~60 updates per second.
+
+        Leading-edge: updates immediately if the minimum interval has already
+        elapsed, otherwise schedules exactly one trailing update for when it
+        will have elapsed, so a fast burst of events collapses to at most one
+        pending update instead of one call per event.
+        """
+        now = time.monotonic()
+        elapsed = now - self._last_mouse_update_time
+        if elapsed >= self._mouse_update_min_interval_s:
+            self._last_mouse_update_time = now
+            self._update_plot()
+        elif not self._mouse_update_timer.isActive():
+            remaining_ms = round((self._mouse_update_min_interval_s - elapsed) * 1000)
+            self._mouse_update_timer.start(max(remaining_ms, 0))
+
+    def _flush_mouse_update(self) -> None:
+        """Run the trailing update scheduled by `_schedule_mouse_update`."""
+        self._last_mouse_update_time = time.monotonic()
+        self._update_plot()
 
     def _get_colors(self) -> dict:
         """Get current theme colors."""
@@ -469,7 +541,7 @@ class SignalPlotter(QWidget):
         self._current_layer = layer
         # Store raw cursor position, rounding happens during data extraction.
         self._cursor_pos = np.array(viewer.cursor.position)
-        self._update_plot()
+        self._schedule_mouse_update()
 
     def _on_layer_change(self, event) -> None:
         """Handle layer insertion/removal or active-layer change events.
@@ -1379,6 +1451,26 @@ class SignalPlotter(QWidget):
         """
         return [ExportSignal(s.label, s.x_values, s.y_values) for s in signals]
 
+    def _set_ylim_from_data(
+        self, ts: np.ndarray, imported_signals: list[PlotSignal]
+    ) -> None:
+        """Autoscale the y-axis from already-extracted arrays.
+
+        Used by the mouse fast path instead of matplotlib's `relim()`/
+        `autoscale_view()`, which re-derive the data extent from every plotted
+        `Line2D` artist on every call — redundant work here since we already hold
+        the live and imported arrays as numpy arrays. Matches matplotlib's default
+        5% autoscale margin.
+        """
+        arrays = [ts, *(s.y_values for s in imported_signals)]
+        y = np.concatenate(arrays) if len(arrays) > 1 else arrays[0]
+        finite = y[np.isfinite(y)]
+        if finite.size == 0:
+            return
+        ymin, ymax = float(finite.min()), float(finite.max())
+        margin = (ymax - ymin) * 0.05 or (abs(ymin) * 0.05 or 0.5)
+        self._axes.set_ylim(ymin - margin, ymax + margin)
+
     def _try_fast_mouse_update(
         self,
         *,
@@ -1419,10 +1511,9 @@ class SignalPlotter(QWidget):
 
         self._update_legend_if_needed(colors, live_label, imported_signals)
 
-        self._axes.relim()
         self._restore_view(saved_xlim, saved_ylim)
         if self._autoscale:
-            self._axes.autoscale_view(scalex=False, scaley=True)
+            self._set_ylim_from_data(ts, imported_signals)
 
         self._has_plot = True
         self._prev_ts_valid = True
@@ -2021,6 +2112,7 @@ class SignalPlotter(QWidget):
         """
         if self._on_mouse_move in self._viewer.mouse_move_callbacks:
             self._viewer.mouse_move_callbacks.remove(self._on_mouse_move)
+        self._unbind_shift_key()
         if self._signals_store is not None:
             try:
                 self._signals_store.plot_data_changed.disconnect(

--- a/src/confusius/_napari/_signals/_plotter.py
+++ b/src/confusius/_napari/_signals/_plotter.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, cast
+from typing import TYPE_CHECKING, Literal, NamedTuple, cast
 
 import napari
 import numpy as np
@@ -29,9 +29,9 @@ from confusius._napari._export import (
     write_delimited_signals,
 )
 from confusius._napari._signals._store import (
-    ImportedSignal,
     LiveSignal,
     SignalStore,
+    StoredSignal,
 )
 from confusius._napari._theme import (
     create_export_button,
@@ -50,11 +50,36 @@ _LAYER_LINESTYLES = ["-", "--", "-.", ":"]
 """Line styles to cycle across reference layers for visual distinction when colors are the same."""
 
 
+class LivePlotSignal(NamedTuple):
+    """One currently plotted live signal, snapshotted for `_pin_current_signals`.
+
+    Attributes
+    ----------
+    origin : str
+        Identifier matching the source `LiveSignal.id`, used as the pinned
+        signal's `pin_origin` so re-pinning updates rather than duplicates.
+    name : str
+        Display name to pin.
+    x : numpy.ndarray
+        Time values.
+    y : numpy.ndarray
+        Signal values.
+    color : str
+        Hex color to pin.
+    """
+
+    origin: str
+    name: str
+    x: np.ndarray
+    y: np.ndarray
+    color: str
+
+
 class SignalPlotter(QWidget):
     """Bottom dock widget for live signals plotting.
 
     Supports three source modes: mouse hover (Shift + move), a Points layer, or a Labels
-    layer. Imported signals from a `SignalStore` are overlaid on every plot. The x-axis
+    layer. Stored signals from a `SignalStore` are overlaid on every plot. The x-axis
     dimension is resolved from xarray metadata when available, falling back to the first
     array dimension.
 
@@ -63,7 +88,7 @@ class SignalPlotter(QWidget):
     viewer : napari.Viewer
         The active napari viewer instance.
     store : SignalStore | None, optional
-        Shared store containing imported signals to overlay on the live plot.
+        Shared store containing stored signals to overlay on the live plot.
     event_store : EventStore | None, optional
         Shared store of temporal events whose intervals are shaded as background
         bands on the plot.
@@ -119,6 +144,11 @@ class SignalPlotter(QWidget):
         self._labels_layer = None
         self._ref_layers: list | None = None
 
+        # Currently plotted live signals, refreshed on every successful live plot
+        # update via _set_live_plot_signals. Consumed by _pin_current_signals to
+        # snapshot them into the store.
+        self._live_plot_signals: list[LivePlotSignal] = []
+
         # Debounce timer for labels data changes (painting is fast, replot is slow).
         self._labels_debounce = QTimer(self)
         self._labels_debounce.setSingleShot(True)
@@ -133,7 +163,7 @@ class SignalPlotter(QWidget):
         self._export_signals: list[ExportSignal] = []
         self._mouse_plot_dirty: bool = True
         self._mouse_live_line = None
-        self._mouse_imported_signature: tuple[str, ...] = ()
+        self._mouse_stored_signature: tuple[str, ...] = ()
         self._mouse_legend_signature: tuple[str, ...] = ()
         # Guard flag to prevent infinite color sync loops.
         self._syncing_color: bool = False
@@ -176,11 +206,11 @@ class SignalPlotter(QWidget):
             self._signals_store.plot_data_changed.connect(self._on_plot_data_changed)
             self._signals_store.changed.connect(self._refresh_plot)
             self._signals_store.changed.connect(self._sync_live_colors_to_layers)
-            # If there are already imported signals, plot them instead of showing
+            # If there are already stored signals, plot them instead of showing
             # instructions.
-            imported = self._signals_store.imported_signals()
-            if imported and self._render_imported_only():
-                pass  # Successfully plotted imported signal.
+            stored = self._signals_store.stored_signals()
+            if stored and self._render_stored_only():
+                pass  # Successfully plotted stored signal.
             else:
                 self._show_instructions()
         else:
@@ -218,6 +248,16 @@ class SignalPlotter(QWidget):
         )
         self._export_button.setEnabled(False)
         self._toolbar.addWidget(self._export_button)
+        self._pin_button = create_export_button(
+            self._toolbar,
+            "signalPinButton",
+            self._pin_current_signals,
+            text="Pin",
+            tooltip="Pin the currently plotted live signal(s) so they persist across "
+            "source-mode switches, as Stored signals.",
+        )
+        self._pin_button.setEnabled(False)
+        self._toolbar.addWidget(self._pin_button)
         layout.addWidget(self._toolbar)
         layout.addWidget(self._canvas)
 
@@ -303,6 +343,7 @@ class SignalPlotter(QWidget):
 
         style_plot_toolbar(self._toolbar, colors)
         style_export_button(self._export_button, colors)
+        style_export_button(self._pin_button, colors, icon_name="pin")
 
         for spine in self._axes.spines.values():
             spine.set_edgecolor(colors["fg"])
@@ -582,7 +623,7 @@ class SignalPlotter(QWidget):
     def _invalidate_mouse_cache(self) -> None:
         """Reset all mouse-plot cache state, forcing a full redraw on the next update."""
         self._mouse_live_line = None
-        self._mouse_imported_signature = ()
+        self._mouse_stored_signature = ()
         self._mouse_legend_signature = ()
         self._mouse_plot_dirty = True
 
@@ -590,6 +631,7 @@ class SignalPlotter(QWidget):
         """Show a centered message in the plot area with no axes or data."""
         self._clear_export_signals()
         self._invalidate_mouse_cache()
+        self._set_live_plot_signals([])
         self._axes.clear()
         colors = self._get_colors()
         self._axes.text(
@@ -637,7 +679,7 @@ class SignalPlotter(QWidget):
             self._update_plot()
 
     def _on_plot_data_changed(self) -> None:
-        """Reset auto x-range when plotted imported signal membership changes."""
+        """Reset auto x-range when plotted stored signal membership changes."""
         self._has_plot = False
         self._prev_ts_valid = False
         self._mouse_plot_dirty = True
@@ -645,7 +687,7 @@ class SignalPlotter(QWidget):
     def _update_plot(self) -> None:
         """Update the signals plot with current data."""
         if self._current_layer is None or self._cursor_pos is None:
-            self._render_imported_only()
+            self._render_stored_only()
             return
 
         # Preserve zoom state across voxel changes. X limits are always
@@ -700,8 +742,8 @@ class SignalPlotter(QWidget):
                 else None
             )
             if mouse_signal is not None and not mouse_signal.visible:
-                # Mouse signal hidden: only show imported.
-                self._render_imported_only(saved_xlim=saved_xlim, saved_ylim=saved_ylim)
+                # Mouse signal hidden: only show stored.
+                self._render_stored_only(saved_xlim=saved_xlim, saved_ylim=saved_ylim)
                 return
 
             live_label = (
@@ -713,7 +755,21 @@ class SignalPlotter(QWidget):
                 mouse_signal.color if mouse_signal is not None else colors["accent"]
             )
 
-            imported_signals = self._imported_plot_signals()
+            self._set_live_plot_signals(
+                [
+                    LivePlotSignal(
+                        origin=self._mouse_origin_key(
+                            self._current_layer, self._cursor_pos
+                        ),
+                        name=live_label,
+                        x=np.asarray(x_values),
+                        y=np.asarray(ts),
+                        color=live_color,
+                    )
+                ]
+            )
+
+            stored_signals = self._stored_plot_signals()
             coord_str = self._mouse_coord_string()
             title = f"{self._current_layer.name} — ({coord_str})"
 
@@ -726,7 +782,7 @@ class SignalPlotter(QWidget):
                 title=title,
                 saved_xlim=saved_xlim,
                 saved_ylim=saved_ylim,
-                imported_signals=imported_signals,
+                stored_signals=stored_signals,
                 colors=colors,
             ):
                 return
@@ -742,12 +798,12 @@ class SignalPlotter(QWidget):
             )
 
             self._mouse_live_line = self._axes.lines[-1]
-            self._plot_signal_lines(imported_signals, linewidth=1.4, alpha=0.95)
-            self._mouse_imported_signature = self._imported_signature(imported_signals)
-            export_imported = self._plot_signal_to_export(imported_signals)
+            self._plot_signal_lines(stored_signals, linewidth=1.4, alpha=0.95)
+            self._mouse_stored_signature = self._stored_signature(stored_signals)
+            export_stored = self._plot_signal_to_export(stored_signals)
             self._set_export_signals(
                 [ExportSignal(live_label, np.asarray(x_values), np.asarray(ts))]
-                + export_imported
+                + export_stored
             )
 
         if ts is not None:
@@ -764,10 +820,10 @@ class SignalPlotter(QWidget):
             self._prev_ts_valid = True
             self._mouse_plot_dirty = False
             self._mouse_legend_signature = self._legend_signature(
-                live_label, imported_signals
+                live_label, stored_signals
             )
         else:
-            if self._render_imported_only(saved_xlim=saved_xlim, saved_ylim=saved_ylim):
+            if self._render_stored_only(saved_xlim=saved_xlim, saved_ylim=saved_ylim):
                 return
             self._clear_export_signals()
             self._prev_ts_valid = False
@@ -931,6 +987,50 @@ class SignalPlotter(QWidget):
 
         return data[tuple(ind)]
 
+    def _mouse_origin_key(self, layer, cursor_pos: np.ndarray) -> str:
+        """Return a pin origin key identifying the voxel at the cursor.
+
+        Distinct per voxel (unlike the mouse `LiveSignal.id`, which is the fixed
+        `"mouse-0"`), so pinned voxels are never hidden by the live-signal dedup in
+        [_stored_plot_signals][confusius._napari._signals._plotter.SignalPlotter._stored_plot_signals]
+        while hovering — only re-pinning the exact same voxel updates it in place.
+        """
+        indices = [round(x) for x in layer.world_to_data(cursor_pos)]
+        xaxis_index = self._xaxis_dim_index(layer)
+        spatial = [v for i, v in enumerate(indices) if i != xaxis_index]
+        return "mouse-" + "-".join(str(v) for v in spatial)
+
+    def _set_live_plot_signals(self, signals: list[LivePlotSignal]) -> None:
+        """Update the currently-pinnable live signals and the Pin button state."""
+        self._live_plot_signals = signals
+        self._pin_button.setEnabled(bool(signals))
+
+    def _pin_current_signals(self) -> None:
+        """Pin every currently plotted live signal into the store as stored signals.
+
+        A pinned entry is hidden from the plot while a live signal with the same
+        origin is still active (see
+        [_stored_plot_signals][confusius._napari._signals._plotter.SignalPlotter._stored_plot_signals]),
+        so pinning without changing source mode or hiding the live signal has no
+        immediately visible effect on the plot itself — it will appear once you
+        switch away, hide the live signal, or the live source (e.g. a repainted
+        label) diverges from the snapshot. It always shows up in the Signal
+        Manager right away.
+        """
+        if self._signals_store is None or not self._live_plot_signals:
+            return
+        for signal in self._live_plot_signals:
+            self._signals_store.pin_signal(
+                origin=signal.origin,
+                # Distinct from the live signal's name so the two are never
+                # visually indistinguishable duplicates in the legend/manager.
+                name=f"{signal.name} (pinned)",
+                x=signal.x,
+                y=signal.y,
+                color=signal.color,
+                source_label=f"Pinned from {self._source_mode}",
+            )
+
     # ------------------------------------------------------------------
     # Source mode — public setters
     # ------------------------------------------------------------------
@@ -951,8 +1051,8 @@ class SignalPlotter(QWidget):
             # restore the [0, 1] xlim left by the cleared axes.
             self._has_plot = False
             self._prev_ts_valid = False
-            # Only show instructions if there are no imported signal to display.
-            if not self._render_imported_only():
+            # Only show instructions if there are no stored signal to display.
+            if not self._render_stored_only():
                 self._show_instructions()
         elif mode == "points":
             self._update_plot_from_points()
@@ -1334,11 +1434,11 @@ class SignalPlotter(QWidget):
         """Clear the currently exported signal."""
         self._set_export_signals([])
 
-    def _visible_imported_signals(self) -> list[ImportedSignal]:
-        """Return visible imported signals from the shared store."""
+    def _visible_stored_signals(self) -> list[StoredSignal]:
+        """Return visible stored signals from the shared store."""
         if self._signals_store is None:
             return []
-        return self._signals_store.visible_imported_signals()
+        return self._signals_store.visible_stored_signals()
 
     def _mouse_coord_string(self) -> str:
         """Return the current mouse coordinates formatted for the plot title.
@@ -1387,10 +1487,22 @@ class SignalPlotter(QWidget):
 
         return ", ".join(coord_parts)
 
-    def _imported_plot_signals(self) -> list[PlotSignal]:
-        """Return imported signals prepared for plotting and export."""
+    def _stored_plot_signals(self) -> list[PlotSignal]:
+        """Return stored signals prepared for plotting and export.
+
+        A pinned signal (`pin_origin` set) is skipped while a live signal with a
+        matching id is currently active, so pinning e.g. a label mean doesn't show
+        a duplicate line while that same label is live in the Labels source mode.
+        """
+        live_ids = (
+            {s.id for s in self._signals_store.live_signals()}
+            if self._signals_store is not None
+            else set()
+        )
         plotted = []
-        for signals in self._visible_imported_signals():
+        for signals in self._visible_stored_signals():
+            if signals.pin_origin is not None and signals.pin_origin in live_ids:
+                continue
             x_values = np.asarray(signals.x).copy()
             y_values = np.asarray(signals.y, dtype=float).copy()
             if self._zscore:
@@ -1425,15 +1537,15 @@ class SignalPlotter(QWidget):
                     label=s.label,
                 )
 
-    def _imported_signature(self, signals: list[PlotSignal]) -> tuple[str, ...]:
-        """Return a lightweight signature for imported signals already on the axes."""
+    def _stored_signature(self, signals: list[PlotSignal]) -> tuple[str, ...]:
+        """Return a lightweight signature for stored signals already on the axes."""
         return tuple(s.label for s in signals)
 
     def _legend_signature(
-        self, live_label: str, imported_signals: list[PlotSignal]
+        self, live_label: str, stored_signals: list[PlotSignal]
     ) -> tuple[str, ...]:
         """Return the legend content signature for the current mouse plot."""
-        return (live_label, *self._imported_signature(imported_signals))
+        return (live_label, *self._stored_signature(stored_signals))
 
     @staticmethod
     def _plot_signal_to_export(signals: list[PlotSignal]) -> list[ExportSignal]:
@@ -1452,17 +1564,17 @@ class SignalPlotter(QWidget):
         return [ExportSignal(s.label, s.x_values, s.y_values) for s in signals]
 
     def _set_ylim_from_data(
-        self, ts: np.ndarray, imported_signals: list[PlotSignal]
+        self, ts: np.ndarray, stored_signals: list[PlotSignal]
     ) -> None:
         """Autoscale the y-axis from already-extracted arrays.
 
         Used by the mouse fast path instead of matplotlib's `relim()`/
         `autoscale_view()`, which re-derive the data extent from every plotted
         `Line2D` artist on every call — redundant work here since we already hold
-        the live and imported arrays as numpy arrays. Matches matplotlib's default
+        the live and stored arrays as numpy arrays. Matches matplotlib's default
         5% autoscale margin.
         """
-        arrays = [ts, *(s.y_values for s in imported_signals)]
+        arrays = [ts, *(s.y_values for s in stored_signals)]
         y = np.concatenate(arrays) if len(arrays) > 1 else arrays[0]
         finite = y[np.isfinite(y)]
         if finite.size == 0:
@@ -1482,13 +1594,13 @@ class SignalPlotter(QWidget):
         title: str,
         saved_xlim,
         saved_ylim,
-        imported_signals: list[PlotSignal],
+        stored_signals: list[PlotSignal],
         colors: dict,
     ) -> bool:
-        """Update the mouse plot without rebuilding imported overlay lines."""
+        """Update the mouse plot without rebuilding stored overlay lines."""
         if self._mouse_plot_dirty or self._mouse_live_line is None:
             return False
-        if self._mouse_imported_signature != self._imported_signature(imported_signals):
+        if self._mouse_stored_signature != self._stored_signature(stored_signals):
             return False
 
         self._mouse_live_line.set_data(x_values, ts)
@@ -1496,7 +1608,7 @@ class SignalPlotter(QWidget):
         self._mouse_live_line.set_color(live_color)
         self._set_export_signals(
             [ExportSignal(live_label, x_values, ts)]
-            + self._plot_signal_to_export(imported_signals)
+            + self._plot_signal_to_export(stored_signals)
         )
 
         self._axes.set_xlabel(xlabel, color=colors["fg"], fontsize=9)
@@ -1509,11 +1621,11 @@ class SignalPlotter(QWidget):
         if self._show_grid:
             self._axes.grid(True, alpha=0.3, color=colors["fg"])
 
-        self._update_legend_if_needed(colors, live_label, imported_signals)
+        self._update_legend_if_needed(colors, live_label, stored_signals)
 
         self._restore_view(saved_xlim, saved_ylim)
         if self._autoscale:
-            self._set_ylim_from_data(ts, imported_signals)
+            self._set_ylim_from_data(ts, stored_signals)
 
         self._has_plot = True
         self._prev_ts_valid = True
@@ -1524,10 +1636,10 @@ class SignalPlotter(QWidget):
         return True
 
     def _update_legend_if_needed(
-        self, colors: dict, live_label: str, imported_signals: list[PlotSignal]
+        self, colors: dict, live_label: str, stored_signals: list[PlotSignal]
     ) -> None:
         """Update the legend only when its entries actually changed."""
-        signature = self._legend_signature(live_label, imported_signals)
+        signature = self._legend_signature(live_label, stored_signals)
         if signature == self._mouse_legend_signature:
             return
 
@@ -1545,24 +1657,25 @@ class SignalPlotter(QWidget):
             )
         self._mouse_legend_signature = signature
 
-    def _render_imported_only(self, saved_xlim=None, saved_ylim=None) -> bool:
-        """Render only imported signals when no live data can be drawn."""
-        imported_signals = self._imported_plot_signals()
-        if not imported_signals:
+    def _render_stored_only(self, saved_xlim=None, saved_ylim=None) -> bool:
+        """Render only stored signals when no live data can be drawn."""
+        self._set_live_plot_signals([])
+        stored_signals = self._stored_plot_signals()
+        if not stored_signals:
             return False
 
         colors = self._get_colors()
         self._axes.clear()
-        self._plot_signal_lines(imported_signals, linewidth=1.4, alpha=0.95)
-        self._set_export_signals(self._plot_signal_to_export(imported_signals))
+        self._plot_signal_lines(stored_signals, linewidth=1.4, alpha=0.95)
+        self._set_export_signals(self._plot_signal_to_export(stored_signals))
         self._mouse_live_line = None
-        self._mouse_imported_signature = self._imported_signature(imported_signals)
-        self._mouse_legend_signature = self._imported_signature(imported_signals)
+        self._mouse_stored_signature = self._stored_signature(stored_signals)
+        self._mouse_legend_signature = self._stored_signature(stored_signals)
         self._mouse_plot_dirty = True
         self._xaxis_coords = None
-        # Label from the active layer when one is present so the imported-only
+        # Label from the active layer when one is present so the stored-only
         # view stays consistent with the live plot; fall back to "Time" for
-        # standalone imported signals (typically a CSV time column).
+        # standalone stored signals (typically a CSV time column).
         xlabel = (
             self._get_xaxis_label(self._current_layer)
             if self._current_layer is not None
@@ -1572,8 +1685,8 @@ class SignalPlotter(QWidget):
             colors,
             xlabel,
             "Z-score" if self._zscore else "Value",
-            "Imported Signals",
-            with_legend=len(imported_signals) > 1,
+            "Stored Signals",
+            with_legend=len(stored_signals) > 1,
         )
         self._restore_view(saved_xlim, saved_ylim)
         self._has_plot = True
@@ -1582,15 +1695,15 @@ class SignalPlotter(QWidget):
         self._canvas.draw_idle()
         return True
 
-    def _show_message_or_imported(
+    def _show_message_or_stored(
         self,
         text: str,
         *,
         saved_xlim=None,
         saved_ylim=None,
     ) -> None:
-        """Show a message when no imported signals are visible, else plot imports only."""
-        if self._render_imported_only(saved_xlim=saved_xlim, saved_ylim=saved_ylim):
+        """Show a message when no stored signals are visible, else plot stored signals only."""
+        if self._render_stored_only(saved_xlim=saved_xlim, saved_ylim=saved_ylim):
             return
         self._show_message(text)
 
@@ -1748,7 +1861,7 @@ class SignalPlotter(QWidget):
             The reference image layers, or `None` if validation failed.
         """
         if source_layer is None:
-            self._show_message_or_imported(
+            self._show_message_or_stored(
                 f"No {source_name} layer selected.\n"
                 "Choose one in the Source section of the panel.",
                 saved_xlim=saved_xlim,
@@ -1757,7 +1870,7 @@ class SignalPlotter(QWidget):
             return None
         ref_layers = self._get_ref_image_layers()
         if not ref_layers:
-            self._show_message_or_imported(
+            self._show_message_or_stored(
                 "No reference image layer found.\nLoad a 4-D image layer first.",
                 saved_xlim=saved_xlim,
                 saved_ylim=saved_ylim,
@@ -1795,7 +1908,7 @@ class SignalPlotter(QWidget):
         saved_xlim,
         saved_ylim,
     ) -> None:
-        """Overlay imported signals, style the axes, and redraw after a multi-signals plot.
+        """Overlay stored signals, style the axes, and redraw after a multi-signals plot.
 
         Shared by `_update_plot_from_points` and `_update_plot_from_labels` once their
         per-signal loops have completed successfully.
@@ -1815,10 +1928,10 @@ class SignalPlotter(QWidget):
         saved_ylim : tuple or None
             Saved y-axis limits to restore.
         """
-        imported_signals = self._imported_plot_signals()
-        self._plot_signal_lines(imported_signals, linewidth=1.4, alpha=0.95)
+        stored_signals = self._stored_plot_signals()
+        self._plot_signal_lines(stored_signals, linewidth=1.4, alpha=0.95)
         self._set_export_signals(
-            export_signals + self._plot_signal_to_export(imported_signals)
+            export_signals + self._plot_signal_to_export(stored_signals)
         )
         xlabel = self._get_xaxis_label(ref_layers[0])
         ylabel = "Z-score" if self._zscore else "Intensity"
@@ -1855,7 +1968,7 @@ class SignalPlotter(QWidget):
 
             n_points = len(points_layer.data)
             if n_points == 0:
-                self._show_message_or_imported(
+                self._show_message_or_stored(
                     "The selected Points layer is empty.",
                     saved_xlim=saved_xlim,
                     saved_ylim=saved_ylim,
@@ -1872,6 +1985,7 @@ class SignalPlotter(QWidget):
             self._axes.clear()
             has_any = False
             export_signals: list[ExportSignal] = []
+            live_plot_signals: list[LivePlotSignal] = []
 
             for point_index in range(n_points):
                 # Check store for visibility/name/color overrides.
@@ -1945,7 +2059,24 @@ class SignalPlotter(QWidget):
                     # Keep x-axis coords from the last successful layer for cursor mapping.
                     self._xaxis_coords = xaxis_coords
                     self._current_layer = img_layer
+                    # Keep the last successful layer's data for pinning too, matching
+                    # the cursor-mapping choice above.
+                    live_plot_signals = [
+                        s
+                        for s in live_plot_signals
+                        if s.origin != f"point-{point_index}"
+                    ]
+                    live_plot_signals.append(
+                        LivePlotSignal(
+                            origin=f"point-{point_index}",
+                            name=pt_name,
+                            x=np.asarray(x),
+                            y=ts,
+                            color=pt_color,
+                        )
+                    )
 
+            self._set_live_plot_signals(live_plot_signals)
             if has_any:
                 self._finalize_multi_signals_plot(
                     export_signals,
@@ -1956,7 +2087,7 @@ class SignalPlotter(QWidget):
                     saved_ylim,
                 )
             else:
-                self._show_message_or_imported(
+                self._show_message_or_stored(
                     "No valid data at the point positions.\n",
                     saved_xlim=saved_xlim,
                     saved_ylim=saved_ylim,
@@ -1992,6 +2123,7 @@ class SignalPlotter(QWidget):
             has_any = False
             shape_mismatch = False
             export_signals: list[ExportSignal] = []
+            live_plot_signals: list[LivePlotSignal] = []
             # Collect all unique labels across layers for registration.
             all_unique_labels: set[int] = set()
 
@@ -2068,6 +2200,20 @@ class SignalPlotter(QWidget):
                         ExportSignal(label, np.asarray(x), np.asarray(ts))
                     )
                     has_any = True
+                    # Keep the last successful layer's data for pinning, matching the
+                    # cursor-mapping choice below.
+                    live_plot_signals = [
+                        s for s in live_plot_signals if s.origin != f"label-{lid_int}"
+                    ]
+                    live_plot_signals.append(
+                        LivePlotSignal(
+                            origin=f"label-{lid_int}",
+                            name=base_name,
+                            x=np.asarray(x),
+                            y=ts,
+                            color=lid_color,
+                        )
+                    )
 
                 # Keep time coords from the last successful layer for cursor mapping.
                 self._xaxis_coords = xaxis_coords
@@ -2077,6 +2223,7 @@ class SignalPlotter(QWidget):
             if all_unique_labels:
                 self._register_labels_live_signals(np.array(sorted(all_unique_labels)))
 
+            self._set_live_plot_signals(live_plot_signals)
             if has_any:
                 self._finalize_multi_signals_plot(
                     export_signals,
@@ -2087,14 +2234,14 @@ class SignalPlotter(QWidget):
                     saved_ylim,
                 )
             elif shape_mismatch:
-                self._show_message_or_imported(
+                self._show_message_or_stored(
                     "Spatial shape of the Labels layer does not match\n"
                     "the reference image. Make sure they share the same grid.",
                     saved_xlim=saved_xlim,
                     saved_ylim=saved_ylim,
                 )
             else:
-                self._show_message_or_imported(
+                self._show_message_or_stored(
                     "No valid data extracted from the Labels layer.",
                     saved_xlim=saved_xlim,
                     saved_ylim=saved_ylim,

--- a/src/confusius/_napari/_signals/_plotter.py
+++ b/src/confusius/_napari/_signals/_plotter.py
@@ -991,9 +991,9 @@ class SignalPlotter(QWidget):
         """Return a pin origin key identifying the voxel at the cursor.
 
         Distinct per voxel (unlike the mouse `LiveSignal.id`, which is the fixed
-        `"mouse-0"`), so pinned voxels are never hidden by the live-signal dedup in
-        [_stored_plot_signals][confusius._napari._signals._plotter.SignalPlotter._stored_plot_signals]
-        while hovering — only re-pinning the exact same voxel updates it in place.
+        `"mouse-0"`), so pinning two different voxels creates two separate stored
+        signals — only re-pinning the exact same voxel updates it in place (see
+        [SignalStore.pin_signal][confusius._napari._signals._store.SignalStore.pin_signal]).
         """
         indices = [round(x) for x in layer.world_to_data(cursor_pos)]
         xaxis_index = self._xaxis_dim_index(layer)
@@ -1006,17 +1006,7 @@ class SignalPlotter(QWidget):
         self._pin_button.setEnabled(bool(signals))
 
     def _pin_current_signals(self) -> None:
-        """Pin every currently plotted live signal into the store as stored signals.
-
-        A pinned entry is hidden from the plot while a live signal with the same
-        origin is still active (see
-        [_stored_plot_signals][confusius._napari._signals._plotter.SignalPlotter._stored_plot_signals]),
-        so pinning without changing source mode or hiding the live signal has no
-        immediately visible effect on the plot itself — it will appear once you
-        switch away, hide the live signal, or the live source (e.g. a repainted
-        label) diverges from the snapshot. It always shows up in the Signal
-        Manager right away.
-        """
+        """Pin every currently plotted live signal into the store as stored signals."""
         if self._signals_store is None or not self._live_plot_signals:
             return
         for signal in self._live_plot_signals:
@@ -1488,21 +1478,9 @@ class SignalPlotter(QWidget):
         return ", ".join(coord_parts)
 
     def _stored_plot_signals(self) -> list[PlotSignal]:
-        """Return stored signals prepared for plotting and export.
-
-        A pinned signal (`pin_origin` set) is skipped while a live signal with a
-        matching id is currently active, so pinning e.g. a label mean doesn't show
-        a duplicate line while that same label is live in the Labels source mode.
-        """
-        live_ids = (
-            {s.id for s in self._signals_store.live_signals()}
-            if self._signals_store is not None
-            else set()
-        )
+        """Return stored signals prepared for plotting and export."""
         plotted = []
         for signals in self._visible_stored_signals():
-            if signals.pin_origin is not None and signals.pin_origin in live_ids:
-                continue
             x_values = np.asarray(signals.x).copy()
             y_values = np.asarray(signals.y, dtype=float).copy()
             if self._zscore:
@@ -1686,7 +1664,9 @@ class SignalPlotter(QWidget):
             xlabel,
             "Z-score" if self._zscore else "Value",
             "Stored Signals",
-            with_legend=len(stored_signals) > 1,
+            # Unlike the mouse-hover title (which already names the voxel), this
+            # generic title doesn't identify a lone line, so always show the legend.
+            with_legend=bool(stored_signals),
         )
         self._restore_view(saved_xlim, saved_ylim)
         self._has_plot = True

--- a/src/confusius/_napari/_signals/_plotter.py
+++ b/src/confusius/_napari/_signals/_plotter.py
@@ -192,8 +192,10 @@ class SignalPlotter(QWidget):
         self._mouse_update_timer.setSingleShot(True)
         self._mouse_update_timer.timeout.connect(self._flush_mouse_update)
 
-        # Previous keymap handler displaced by binding Shift, restored on close.
+        # Previous keymap handler displaced by binding Shift, restored once Shift is
+        # unbound (leaving mouse source mode, or on close).
         self._displaced_shift_key = None
+        self._shift_bound: bool = False
 
         self.setSizePolicy(
             QSizePolicy.Policy.Expanding,
@@ -273,28 +275,37 @@ class SignalPlotter(QWidget):
         self._viewer.layers.events.inserted.connect(self._on_layer_change)
         self._viewer.layers.events.removed.connect(self._on_layer_change)
         self._viewer.layers.selection.events.active.connect(self._on_layer_change)
-        self._bind_shift_key()
+        if self._source_mode == "mouse":
+            self._bind_shift_key()
 
     def _bind_shift_key(self) -> None:
         """Bind Shift in the napari keymap to plot the signal at the resting cursor.
 
         Lets the user press Shift while the cursor is already stationary over an
-        image layer, instead of requiring mouse movement while Shift is held.
-        Any handler already bound to Shift is saved first so it can be restored
-        when the plotter closes.
+        image layer, instead of requiring mouse movement while Shift is held. Any
+        handler already bound to Shift is saved first so it can be restored once
+        Shift is unbound. Idempotent, and scoped to mouse source mode by
+        `set_source_mode` (rather than held for the plotter's whole lifetime) so
+        another binding on bare Shift is only displaced while actually in mouse mode.
         """
+        if self._shift_bound:
+            return
         keybinding = coerce_keybinding("Shift")
         self._displaced_shift_key = self._viewer.keymap.get(keybinding)
         self._viewer.bind_key("Shift", self._on_shift_pressed, overwrite=True)
+        self._shift_bound = True
 
     def _unbind_shift_key(self) -> None:
-        """Restore the keymap entry displaced by `_bind_shift_key`."""
+        """Restore the keymap entry displaced by `_bind_shift_key`. Idempotent."""
+        if not self._shift_bound:
+            return
         keybinding = coerce_keybinding("Shift")
         if self._displaced_shift_key is not None:
             self._viewer.keymap[keybinding] = self._displaced_shift_key
         else:
             self._viewer.keymap.pop(keybinding, None)
         self._displaced_shift_key = None
+        self._shift_bound = False
 
     def _on_shift_pressed(self, viewer: napari.Viewer) -> None:
         """Plot the signal at the current cursor position when Shift is pressed."""
@@ -1036,6 +1047,7 @@ class SignalPlotter(QWidget):
         self._source_mode = mode
         self._invalidate_mouse_cache()
         if mode == "mouse":
+            self._bind_shift_key()
             self._register_mouse_live_signal()
             # Invalidate the saved zoom state so the first mouse-hover plot does not
             # restore the [0, 1] xlim left by the cleared axes.
@@ -1045,8 +1057,10 @@ class SignalPlotter(QWidget):
             if not self._render_stored_only():
                 self._show_instructions()
         elif mode == "points":
+            self._unbind_shift_key()
             self._update_plot_from_points()
         else:
+            self._unbind_shift_key()
             self._update_plot_from_labels()
 
     def set_points_layer(self, layer) -> None:

--- a/src/confusius/_napari/_signals/_store.py
+++ b/src/confusius/_napari/_signals/_store.py
@@ -1,4 +1,4 @@
-"""Shared store for imported napari signals."""
+"""Shared store for stored (imported or pinned) napari signals."""
 
 from __future__ import annotations
 
@@ -14,13 +14,18 @@ from qtpy.QtCore import QObject, Signal
 from confusius._napari._utils import CATEGORICAL_COLORS
 from confusius.bids import load_physio
 
-_IMPORTED_SIGNAL_COLORS = CATEGORICAL_COLORS
-"""Palette cycled across imported signal columns."""
+_STORED_SIGNAL_COLORS = CATEGORICAL_COLORS
+"""Palette cycled across stored signal columns."""
 
 
 @dataclass(frozen=True, slots=True)
-class ImportedSignal:
-    """Imported signal stored for overlay in the plotter.
+class StoredSignal:
+    """Persistent signal stored for overlay in the plotter.
+
+    Unlike `LiveSignal`, a stored signal owns its data outright and survives
+    source-mode switches. It either comes from an imported file, or is a
+    snapshot pinned from a live signal (see
+    [`SignalStore.pin_signal`][confusius._napari._signals._store.SignalStore.pin_signal]).
 
     Attributes
     ----------
@@ -37,11 +42,17 @@ class ImportedSignal:
     color : str
         Hex color used for plotting.
     source_label : str
-        Human-readable source description, typically the file name.
-    file_path : pathlib.Path
-        Original imported file.
-    original_column_name : str
-        Column name from the imported file.
+        Human-readable source description (a file name, or e.g. `"Pinned voxel"`).
+    file_path : pathlib.Path | None
+        Original imported file, or `None` for a pinned signal.
+    original_column_name : str | None
+        Column name from the imported file, or `None` for a pinned signal.
+    pin_origin : str | None, optional
+        Identifier of the live signal this was pinned from (e.g. `"label-3"`,
+        `"mouse-12-34-56"`), or `None` for a signal imported from a file.
+        Re-pinning the same origin updates this entry in place instead of
+        creating a duplicate, and a pinned entry is hidden from the plot
+        whenever a live signal with a matching id is currently active.
     """
 
     id: str
@@ -51,17 +62,21 @@ class ImportedSignal:
     visible: bool
     color: str
     source_label: str
-    file_path: Path
-    original_column_name: str
+    file_path: Path | None
+    original_column_name: str | None
+    pin_origin: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
 class LiveSignal:
     """Live signal backed by a napari layer.
 
-    Unlike `ImportedSignal`, a live signal does not own its data: the plotter extracts
-    it from layers on each update. The store tracks only presentation metadata (name,
-    color, visibility) so the user can customise the plot.
+    Unlike `StoredSignal`, a live signal does not own its data: the plotter extracts
+    it from layers on each update, and it only exists while its source mode is active
+    — switching source modes replaces the whole live set. The store tracks only
+    presentation metadata (name, color, visibility) so the user can customise the
+    plot; to keep a live signal's current values around after switching modes, pin it
+    with [`SignalStore.pin_signal`][confusius._napari._signals._store.SignalStore.pin_signal].
 
     Attributes
     ----------
@@ -88,7 +103,7 @@ class LiveSignal:
 
 
 class SignalStore(QObject):
-    """Store imported and live signals shared between the panel and plotter.
+    """Store stored and live signals shared between the panel and plotter.
 
     The store is the single source of truth for signal presentation metadata (name,
     color, visibility). It is shared between the panel, plotter, and manager dialog.
@@ -104,29 +119,29 @@ class SignalStore(QObject):
 
     def __init__(self, parent: QObject | None = None) -> None:
         super().__init__(parent)
-        self._imported_signals: list[ImportedSignal] = []
+        self._stored_signals: list[StoredSignal] = []
         self._live_signals: dict[str, LiveSignal] = {}
         self._id_counter: int = 0
 
-    def imported_signals(self) -> list[ImportedSignal]:
-        """Return all imported signals.
+    def stored_signals(self) -> list[StoredSignal]:
+        """Return all stored signals.
 
         Returns
         -------
-        list[ImportedSignal]
-            Imported signals in insertion order.
+        list[StoredSignal]
+            Stored signals in insertion order.
         """
-        return list(self._imported_signals)
+        return list(self._stored_signals)
 
-    def visible_imported_signals(self) -> list[ImportedSignal]:
-        """Return only imported signals marked as visible.
+    def visible_stored_signals(self) -> list[StoredSignal]:
+        """Return only stored signals marked as visible.
 
         Returns
         -------
-        list[ImportedSignal]
-            Visible imported signals.
+        list[StoredSignal]
+            Visible stored signals.
         """
-        return [signal for signal in self._imported_signals if signal.visible]
+        return [signal for signal in self._stored_signals if signal.visible]
 
     def _emit_changed(self, *, plot_data: bool = False) -> None:
         """Emit changed signals.
@@ -141,14 +156,14 @@ class SignalStore(QObject):
         self.changed.emit()
 
     def clear(self) -> None:
-        """Remove all imported signals."""
-        if not self._imported_signals:
+        """Remove all stored signals."""
+        if not self._stored_signals:
             return
-        self._imported_signals.clear()
+        self._stored_signals.clear()
         self._emit_changed(plot_data=True)
 
     def rename_signal(self, signal_id: str, new_name: str) -> None:
-        """Rename one imported signal.
+        """Rename one stored signal.
 
         Parameters
         ----------
@@ -164,11 +179,11 @@ class SignalStore(QObject):
         """
         stripped = new_name.strip()
         if not stripped:
-            raise ValueError("Imported signal name cannot be empty.")
+            raise ValueError("Stored signal name cannot be empty.")
         self._replace_signal(signal_id, name=stripped)
 
     def set_signal_visible(self, signal_id: str, visible: bool) -> None:
-        """Update the visible flag for one imported signal.
+        """Update the visible flag for one stored signal.
 
         Parameters
         ----------
@@ -180,7 +195,7 @@ class SignalStore(QObject):
         self._replace_signal(signal_id, plot_data=True, visible=visible)
 
     def set_signal_color(self, signal_id: str, color: str) -> None:
-        """Update the plot color for one imported signal.
+        """Update the plot color for one stored signal.
 
         Parameters
         ----------
@@ -190,11 +205,11 @@ class SignalStore(QObject):
             Hex color string.
         """
         if not color:
-            raise ValueError("Imported signal color cannot be empty.")
+            raise ValueError("Stored signal color cannot be empty.")
         self._replace_signal(signal_id, color=color)
 
     def remove_signals(self, signal_ids: list[str]) -> None:
-        """Remove selected imported signals.
+        """Remove selected stored signals.
 
         Parameters
         ----------
@@ -205,13 +220,13 @@ class SignalStore(QObject):
             return
 
         ids = set(signal_ids)
-        kept = [signal for signal in self._imported_signals if signal.id not in ids]
-        if len(kept) == len(self._imported_signals):
+        kept = [signal for signal in self._stored_signals if signal.id not in ids]
+        if len(kept) == len(self._stored_signals):
             return
-        self._imported_signals = kept
+        self._stored_signals = kept
         self._emit_changed(plot_data=True)
 
-    def import_file(self, path: Path) -> list[ImportedSignal]:
+    def import_file(self, path: Path) -> list[StoredSignal]:
         """Import one CSV or TSV file into the store.
 
         Parameters
@@ -221,8 +236,8 @@ class SignalStore(QObject):
 
         Returns
         -------
-        list[ImportedSignal]
-            Imported signal created from the file.
+        list[StoredSignal]
+            Signals created from the file.
 
         Raises
         ------
@@ -231,9 +246,74 @@ class SignalStore(QObject):
         """
         frame = self._read_signals_table(path)
         imported = self._signal_from_frame(frame, path)
-        self._imported_signals.extend(imported)
+        self._stored_signals.extend(imported)
         self._emit_changed(plot_data=True)
         return imported
+
+    def pin_signal(
+        self,
+        origin: str,
+        name: str,
+        x: npt.NDArray[np.floating],
+        y: npt.NDArray[np.floating],
+        color: str,
+        source_label: str,
+    ) -> StoredSignal:
+        """Pin a live signal's current values as a persistent stored signal.
+
+        Re-pinning the same `origin` updates that entry's data in place rather than
+        creating a duplicate, so repeatedly pinning e.g. the same label id just
+        refreshes its snapshot (useful after repainting the label mask).
+
+        Parameters
+        ----------
+        origin : str
+            Identifier of the live signal being pinned (e.g. `"label-3"`,
+            `"mouse-12-34-56"`). Matches the corresponding `LiveSignal.id` so the
+            plotter can hide the pinned copy while that live signal is active.
+        name : str
+            Display name for the pinned signal.
+        x : numpy.ndarray
+            Time values.
+        y : numpy.ndarray
+            Signal values.
+        color : str
+            Hex color used for plotting.
+        source_label : str
+            Human-readable description of where this was pinned from.
+
+        Returns
+        -------
+        StoredSignal
+            The created or updated pinned signal.
+        """
+        x = np.asarray(x, dtype=float).copy()
+        y = np.asarray(y, dtype=float).copy()
+
+        for index, signal in enumerate(self._stored_signals):
+            if signal.pin_origin == origin:
+                updated = replace(signal, x=x, y=y)
+                self._stored_signals[index] = updated
+                self._emit_changed(plot_data=True)
+                return updated
+
+        signal_id = f"pinned-{self._id_counter}"
+        self._id_counter += 1
+        pinned = StoredSignal(
+            id=signal_id,
+            name=name,
+            x=x,
+            y=y,
+            visible=True,
+            color=color,
+            source_label=source_label,
+            file_path=None,
+            original_column_name=None,
+            pin_origin=origin,
+        )
+        self._stored_signals.append(pinned)
+        self._emit_changed(plot_data=True)
+        return pinned
 
     def _read_signals_table(self, path: Path) -> pd.DataFrame:
         """Read one CSV or TSV signals table from disk."""
@@ -257,10 +337,8 @@ class SignalStore(QObject):
             return path.suffixes[-2].lower()
         return path.suffix.lower()
 
-    def _signal_from_frame(
-        self, frame: pd.DataFrame, path: Path
-    ) -> list[ImportedSignal]:
-        """Convert a dataframe into imported signal entries."""
+    def _signal_from_frame(self, frame: pd.DataFrame, path: Path) -> list[StoredSignal]:
+        """Convert a dataframe into stored signal entries."""
         if "time" not in frame.columns:
             raise ValueError("Imported file must contain a 'time' column.")
 
@@ -283,12 +361,12 @@ class SignalStore(QObject):
         imported = []
 
         for offset, column in enumerate(value_columns):
-            color = _IMPORTED_SIGNAL_COLORS[
-                (self._id_counter + offset) % len(_IMPORTED_SIGNAL_COLORS)
+            color = _STORED_SIGNAL_COLORS[
+                (self._id_counter + offset) % len(_STORED_SIGNAL_COLORS)
             ]
             signal_id = f"imported-{self._id_counter + offset}"
             imported.append(
-                ImportedSignal(
+                StoredSignal(
                     id=signal_id,
                     name=str(column),
                     x=time_values.copy(),
@@ -447,12 +525,12 @@ class SignalStore(QObject):
         plot_data: bool = False,
         **changes,
     ) -> None:
-        """Replace one imported signal while preserving order."""
-        for index, signal in enumerate(self._imported_signals):
+        """Replace one stored signal while preserving order."""
+        for index, signal in enumerate(self._stored_signals):
             if signal.id != signal_id:
                 continue
-            self._imported_signals[index] = replace(signal, **changes)
+            self._stored_signals[index] = replace(signal, **changes)
             self._emit_changed(plot_data=plot_data)
             return
 
-        raise ValueError(f"Unknown imported signal id: {signal_id!r}.")
+        raise ValueError(f"Unknown stored signal id: {signal_id!r}.")

--- a/src/confusius/_napari/_signals/_store.py
+++ b/src/confusius/_napari/_signals/_store.py
@@ -51,8 +51,7 @@ class StoredSignal:
         Identifier of the live signal this was pinned from (e.g. `"label-3"`,
         `"mouse-12-34-56"`), or `None` for a signal imported from a file.
         Re-pinning the same origin updates this entry in place instead of
-        creating a duplicate, and a pinned entry is hidden from the plot
-        whenever a live signal with a matching id is currently active.
+        creating a duplicate.
     """
 
     id: str
@@ -269,8 +268,8 @@ class SignalStore(QObject):
         ----------
         origin : str
             Identifier of the live signal being pinned (e.g. `"label-3"`,
-            `"mouse-12-34-56"`). Matches the corresponding `LiveSignal.id` so the
-            plotter can hide the pinned copy while that live signal is active.
+            `"mouse-12-34-56"`), matching the corresponding `LiveSignal.id` where
+            applicable. Used only to detect re-pinning the same source.
         name : str
             Display name for the pinned signal.
         x : numpy.ndarray

--- a/src/confusius/_napari/_theme.py
+++ b/src/confusius/_napari/_theme.py
@@ -230,9 +230,17 @@ def make_lucide_icon(name: str, color: str, size: int = 16) -> QIcon:
 
 
 def create_export_button(
-    toolbar: QWidget, object_name: str, on_export, text: str = "Export"
+    toolbar: QWidget,
+    object_name: str,
+    on_export,
+    text: str = "Export",
+    tooltip: str = "Export the plotted data.",
 ) -> QToolButton:
-    """Create an export button for a matplotlib toolbar.
+    """Create a themed toolbar button for a matplotlib toolbar.
+
+    Despite the name, this is a generic themed-button factory (icon set
+    separately via [`style_export_button`][confusius._napari._theme.style_export_button]);
+    reused for e.g. a "Pin" button alongside the export button.
 
     Parameters
     ----------
@@ -243,17 +251,19 @@ def create_export_button(
     on_export : callable
         Callback triggered when the button is clicked.
     text : str, default: "Export"
-        Button label shown next to the export icon.
+        Button label shown next to the icon.
+    tooltip : str, default: "Export the plotted data."
+        Tooltip shown on hover.
 
     Returns
     -------
     QToolButton
-        Configured export button.
+        Configured button.
     """
     button = QToolButton(toolbar)
     button.setObjectName(object_name)
     button.setText(text)
-    button.setToolTip("Export the plotted data.")
+    button.setToolTip(tooltip)
     button.setAutoRaise(True)
     button.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextBesideIcon)
     button.clicked.connect(on_export)
@@ -261,18 +271,23 @@ def create_export_button(
     return button
 
 
-def style_export_button(button: QToolButton, colors: dict) -> None:
-    """Apply themed styling to an export button.
+def style_export_button(
+    button: QToolButton, colors: dict, icon_name: str = "download"
+) -> None:
+    """Apply themed styling to a toolbar button built by `create_export_button`.
 
     Parameters
     ----------
     button : QToolButton
-        Export button to style.
+        Button to style.
     colors : dict
         Napari theme color mapping produced by
         [`get_napari_colors`][confusius._napari._theme.get_napari_colors].
+    icon_name : str, default: "download"
+        Stem of the Lucide SVG asset to render, passed to
+        [`make_lucide_icon`][confusius._napari._theme.make_lucide_icon].
     """
-    button.setIcon(make_lucide_icon("download", colors["accent"], size=22))
+    button.setIcon(make_lucide_icon(icon_name, colors["accent"], size=22))
     button.setIconSize(QSize(22, 22))
     button.setToolButtonStyle(
         Qt.ToolButtonStyle.ToolButtonTextBesideIcon

--- a/src/confusius/_napari/_widget.py
+++ b/src/confusius/_napari/_widget.py
@@ -31,6 +31,7 @@ from qtpy.QtWidgets import (
 
 from confusius._napari._events._store import EventStore
 from confusius._napari._qt import install_no_scroll_wheel_filter
+from confusius._napari._signals._store import SignalStore
 from confusius._napari._theme import make_lucide_icon
 from confusius._napari._time_overlay import _TimeOverlay
 from confusius._utils.colors import RED, RED_DARK
@@ -255,6 +256,10 @@ class ConfUSIusWidget(QWidget):
         # Shared store of BIDS temporal events, used by the event panel, the signal
         # plotter (background shading) and the time overlay (active-event readout).
         self._event_store = EventStore(self)
+        # Shared store of stored/live signals, used by the Signals panel (source of
+        # truth) and the QC panel (adds computed DVARS traces so they're selectable
+        # elsewhere, e.g. as a scrubbing sample mask).
+        self._signal_store = SignalStore(self)
         self._apply_theme()
         self._setup_ui()
         self.viewer.events.theme.connect(self._on_theme_changed)
@@ -555,10 +560,14 @@ class ConfUSIusWidget(QWidget):
         panels = [
             data_panel,
             video_panel,
-            SignalPanel(self.viewer, event_store=self._event_store),
+            SignalPanel(
+                self.viewer,
+                event_store=self._event_store,
+                signal_store=self._signal_store,
+            ),
             RegistrationPanel(self.viewer),
             EventPanel(self.viewer, self._event_store),
-            QCPanel(self.viewer),
+            QCPanel(self.viewer, signal_store=self._signal_store),
         ]
         btns: list[QPushButton] = []
 

--- a/src/confusius/_napari/assets/pin.svg
+++ b/src/confusius/_napari/assets/pin.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 17v5" />
+  <path d="M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V16a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V7a1 1 0 0 1 1-1 2 2 0 0 0 0-4H8a2 2 0 0 0 0 4 1 1 0 0 1 1 1z" />
+</svg>

--- a/tests/unit/test_napari/test_qc_panel.py
+++ b/tests/unit/test_napari/test_qc_panel.py
@@ -100,3 +100,49 @@ class TestRefreshLayers:
         layer = viewer.add_image(np.zeros((10, 4, 6, 8)), name="my_layer")
         viewer.layers.remove(layer)
         assert qc_panel._layer_combo.count() == 0
+
+
+# ---------------------------------------------------------------------------
+# _store_dvars_signal
+# ---------------------------------------------------------------------------
+
+
+class TestStoreDvarsSignal:
+    def test_noop_without_a_signal_store(self, viewer):
+        from confusius._napari._qc._panel import QCPanel
+
+        panel = QCPanel(viewer)
+        dvars = xr.DataArray([0.1, 0.2, 0.3], dims=["time"], coords={"time": [0, 1, 2]})
+        panel._store_dvars_signal(dvars, "my_layer")  # Must not raise.
+
+    def test_adds_dvars_to_the_signal_store(self, viewer):
+        from confusius._napari._qc._panel import QCPanel
+        from confusius._napari._signals._store import SignalStore
+
+        store = SignalStore()
+        panel = QCPanel(viewer, signal_store=store)
+        dvars = xr.DataArray([0.1, 0.2, 0.3], dims=["time"], coords={"time": [0, 1, 2]})
+
+        panel._store_dvars_signal(dvars, "my_layer")
+
+        stored = store.stored_signals()
+        assert len(stored) == 1
+        assert stored[0].name == "DVARS (my_layer)"
+        np.testing.assert_array_equal(stored[0].y, [0.1, 0.2, 0.3])
+        np.testing.assert_array_equal(stored[0].x, [0, 1, 2])
+
+    def test_recomputing_updates_in_place_instead_of_duplicating(self, viewer):
+        from confusius._napari._qc._panel import QCPanel
+        from confusius._napari._signals._store import SignalStore
+
+        store = SignalStore()
+        panel = QCPanel(viewer, signal_store=store)
+        first = xr.DataArray([0.1, 0.2], dims=["time"], coords={"time": [0, 1]})
+        second = xr.DataArray([0.9, 0.8], dims=["time"], coords={"time": [0, 1]})
+
+        panel._store_dvars_signal(first, "my_layer")
+        panel._store_dvars_signal(second, "my_layer")
+
+        stored = store.stored_signals()
+        assert len(stored) == 1
+        np.testing.assert_array_equal(stored[0].y, [0.9, 0.8])

--- a/tests/unit/test_napari/test_signal_manager.py
+++ b/tests/unit/test_napari/test_signal_manager.py
@@ -34,25 +34,25 @@ def test_manager_applies_store_mutations(
     name_item = dialog._table.item(0, 1)
     assert name_item is not None
     name_item.setText("baseline")
-    assert signals_store.imported_signals()[0].name == "baseline"
+    assert signals_store.stored_signals()[0].name == "baseline"
 
     visible_item = dialog._table.item(0, 0)
     assert visible_item is not None
     visible_item.setCheckState(Qt.CheckState.Unchecked)
-    assert signals_store.imported_signals()[0].visible is False
+    assert signals_store.stored_signals()[0].visible is False
 
     monkeypatch.setattr(
         "confusius._napari._signals._manager.QColorDialog.getColor",
         lambda *args, **kwargs: QColor("#123456"),
     )
     dialog._choose_color(imported[0].id)
-    assert signals_store.imported_signals()[0].color == "#123456"
+    assert signals_store.stored_signals()[0].color == "#123456"
 
     dialog._table.selectRow(0)
     dialog._remove_selected()
     # Should have removed only the first signal, leaving the second.
-    assert len(signals_store.imported_signals()) == 1
-    assert signals_store.imported_signals()[0].name == "b"
+    assert len(signals_store.stored_signals()) == 1
+    assert signals_store.stored_signals()[0].name == "b"
 
 
 def test_manager_updates_on_store_change(qtbot, signals_store, signals_csv):
@@ -77,7 +77,7 @@ def test_manager_clear_all_button(qtbot, signals_store, signals_csv):
 
     dialog._clear_btn.click()
 
-    assert signals_store.imported_signals() == []
+    assert signals_store.stored_signals() == []
     assert dialog._table.rowCount() == 0
 
 
@@ -87,12 +87,49 @@ def test_manager_handles_multiple_selection(qtbot, signals_store, signals_csv):
     dialog = SignalsManagerDialog(signals_store)
     qtbot.addWidget(dialog)
 
-    assert len(signals_store.imported_signals()) == 2
+    assert len(signals_store.stored_signals()) == 2
 
     dialog._table.selectAll()
     dialog._remove_selected()
 
-    assert signals_store.imported_signals() == []
+    assert signals_store.stored_signals() == []
+
+
+def test_manager_export_selected_writes_only_selected_signals(
+    qtbot, signals_store, signals_csv, monkeypatch, tmp_path
+):
+    signals_store.import_file(signals_csv)
+    dialog = SignalsManagerDialog(signals_store)
+    qtbot.addWidget(dialog)
+
+    out_path = tmp_path / "selected.csv"
+    monkeypatch.setattr(
+        "confusius._napari._signals._manager.prompt_delimited_export_path",
+        lambda *args, **kwargs: (out_path, ","),
+    )
+
+    dialog._table.selectRow(0)
+    dialog._export_selected()
+
+    content = out_path.read_text()
+    assert "a" in content
+    assert "b" not in content.split("\n")[0]
+
+
+def test_manager_export_selected_shows_error_when_nothing_selected(
+    qtbot, signals_store, signals_csv, monkeypatch
+):
+    signals_store.import_file(signals_csv)
+    dialog = SignalsManagerDialog(signals_store)
+    qtbot.addWidget(dialog)
+    dialog._table.clearSelection()
+
+    errors = []
+    monkeypatch.setattr("confusius._napari._signals._manager.show_error", errors.append)
+
+    dialog._export_selected()
+
+    assert errors == ["Select one or more stored signals to export."]
 
 
 def test_manager_imports_multiple_files(qtbot, signals_store, monkeypatch, tmp_path):
@@ -111,7 +148,7 @@ def test_manager_imports_multiple_files(qtbot, signals_store, monkeypatch, tmp_p
 
     dialog._import_file()
 
-    assert [signal.name for signal in signals_store.imported_signals()] == ["a", "b"]
+    assert [signal.name for signal in signals_store.stored_signals()] == ["a", "b"]
 
 
 def test_manager_import_dialog_filters_supported_formats(

--- a/tests/unit/test_napari/test_signal_plotter.py
+++ b/tests/unit/test_napari/test_signal_plotter.py
@@ -15,7 +15,7 @@ import pytest
 import xarray as xr
 
 from confusius._napari._export import format_export_value
-from confusius._napari._signals._store import SignalStore
+from confusius._napari._signals._store import LiveSignal, SignalStore
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -780,8 +780,8 @@ class TestTsvExport:
         assert not plotter._export_button.isEnabled()
 
 
-class TestImportedSignalIntegration:
-    def test_overlays_imported_signals_with_live_mouse_plot(
+class TestStoredSignalIntegration:
+    def test_overlays_stored_signals_with_live_mouse_plot(
         self, plotter_with_store, store, tmp_path
     ):
         path = tmp_path / "imported.csv"
@@ -805,7 +805,7 @@ class TestImportedSignalIntegration:
             ["2", "23", "22"],
         ]
 
-    def test_plots_imported_signals_without_live_data(
+    def test_plots_stored_signals_without_live_data(
         self, plotter_with_store, store, tmp_path
     ):
         path = tmp_path / "imported.tsv"
@@ -986,7 +986,7 @@ class TestImportedSignalIntegration:
         store.import_file(path)
 
         plotter_with_store.set_zscore(True)
-        result = plotter_with_store._render_imported_only()
+        result = plotter_with_store._render_stored_only()
 
         assert result is True
         assert len(plotter_with_store._axes.lines) == 1
@@ -1002,7 +1002,7 @@ class TestImportedSignalIntegration:
         store.import_file(path)
 
         plotter_with_store.set_zscore(True)
-        result = plotter_with_store._render_imported_only()
+        result = plotter_with_store._render_stored_only()
 
         assert result is True
         assert len(plotter_with_store._axes.lines) == 1
@@ -1040,3 +1040,146 @@ class TestImportedSignalIntegration:
         store.import_file(path2)
 
         assert call_count["n"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Pinning and the live-signal dedup in _stored_plot_signals
+# ---------------------------------------------------------------------------
+
+
+class TestPinnedSignalDedup:
+    def test_pinned_signal_hidden_while_its_live_origin_is_active(
+        self, plotter_with_store, store
+    ):
+        store.pin_signal(
+            origin="label-3",
+            name="Label 3",
+            x=np.array([0.0, 1.0]),
+            y=np.array([1.0, 2.0]),
+            color="#123456",
+            source_label="Pinned from labels",
+        )
+        store.register_live_signals(
+            [
+                LiveSignal(
+                    id="label-3",
+                    name="Label 3",
+                    color="#123456",
+                    visible=True,
+                    source_type="label",
+                    source_id=3,
+                )
+            ]
+        )
+
+        names = [s.label for s in plotter_with_store._stored_plot_signals()]
+        assert "Label 3" not in names
+
+    def test_pinned_signal_shown_once_its_live_origin_is_no_longer_active(
+        self, plotter_with_store, store
+    ):
+        store.pin_signal(
+            origin="label-3",
+            name="Label 3",
+            x=np.array([0.0, 1.0]),
+            y=np.array([1.0, 2.0]),
+            color="#123456",
+            source_label="Pinned from labels",
+        )
+        # Switching to mouse mode replaces the live set entirely.
+        store.register_live_signals(
+            [
+                LiveSignal(
+                    id="mouse-0",
+                    name="Cursor",
+                    color="#abcdef",
+                    visible=True,
+                    source_type="mouse",
+                    source_id=None,
+                )
+            ]
+        )
+
+        names = [s.label for s in plotter_with_store._stored_plot_signals()]
+        assert "Label 3" in names
+
+    def test_pinned_mouse_voxel_is_never_hidden_by_the_fixed_mouse_id(
+        self, plotter_with_store, store
+    ):
+        # The live mouse signal always has the fixed id "mouse-0", not a per-voxel
+        # id, so a pinned voxel (a distinct "mouse-k-j-i" origin) must stay visible
+        # while hovering elsewhere.
+        store.pin_signal(
+            origin="mouse-1-2-3",
+            name="Pinned voxel",
+            x=np.array([0.0, 1.0]),
+            y=np.array([1.0, 2.0]),
+            color="#123456",
+            source_label="Pinned from mouse",
+        )
+        store.register_live_signals(
+            [
+                LiveSignal(
+                    id="mouse-0",
+                    name="Cursor",
+                    color="#abcdef",
+                    visible=True,
+                    source_type="mouse",
+                    source_id=None,
+                )
+            ]
+        )
+
+        names = [s.label for s in plotter_with_store._stored_plot_signals()]
+        assert "Pinned voxel" in names
+
+
+class TestPinCurrentSignals:
+    def test_pins_every_currently_plotted_live_signal(self, plotter_with_store, store):
+        from confusius._napari._signals._plotter import LivePlotSignal
+
+        plotter_with_store._set_live_plot_signals(
+            [
+                LivePlotSignal(
+                    origin="label-1",
+                    name="Label 1",
+                    x=np.array([0.0, 1.0]),
+                    y=np.array([1.0, 2.0]),
+                    color="#111111",
+                ),
+                LivePlotSignal(
+                    origin="label-2",
+                    name="Label 2",
+                    x=np.array([0.0, 1.0]),
+                    y=np.array([3.0, 4.0]),
+                    color="#222222",
+                ),
+            ]
+        )
+
+        plotter_with_store._pin_current_signals()
+
+        origins = {s.pin_origin for s in store.stored_signals()}
+        assert origins == {"label-1", "label-2"}
+
+    def test_pin_button_disabled_when_no_live_signal_is_plotted(
+        self, plotter_with_store
+    ):
+        plotter_with_store._set_live_plot_signals([])
+        assert plotter_with_store._pin_button.isEnabled() is False
+
+    def test_pin_button_enabled_when_a_live_signal_is_plotted(self, plotter_with_store):
+        from confusius._napari._signals._plotter import LivePlotSignal
+
+        plotter_with_store._set_live_plot_signals(
+            [
+                LivePlotSignal(
+                    origin="label-1",
+                    name="Label 1",
+                    x=np.array([0.0]),
+                    y=np.array([1.0]),
+                    color="#111111",
+                )
+            ]
+        )
+        assert plotter_with_store._pin_button.isEnabled() is True

--- a/tests/unit/test_napari/test_signal_plotter.py
+++ b/tests/unit/test_napari/test_signal_plotter.py
@@ -1047,13 +1047,17 @@ class TestStoredSignalIntegration:
 # ---------------------------------------------------------------------------
 
 
-class TestPinnedSignalDedup:
-    def test_pinned_signal_hidden_while_its_live_origin_is_active(
+class TestPinnedSignalAlwaysVisible:
+    def test_pinned_signal_stays_visible_while_its_live_origin_is_active(
         self, plotter_with_store, store
     ):
+        # A pinned signal is a distinct stored entry (see the "(pinned)" name
+        # suffix applied by _pin_current_signals) and must always render — it
+        # must not be silently hidden just because its live origin is still
+        # active, which previously made pinning look like it had no effect.
         store.pin_signal(
             origin="label-3",
-            name="Label 3",
+            name="Label 3 (pinned)",
             x=np.array([0.0, 1.0]),
             y=np.array([1.0, 2.0]),
             color="#123456",
@@ -1073,65 +1077,22 @@ class TestPinnedSignalDedup:
         )
 
         names = [s.label for s in plotter_with_store._stored_plot_signals()]
-        assert "Label 3" not in names
+        assert "Label 3 (pinned)" in names
 
-    def test_pinned_signal_shown_once_its_live_origin_is_no_longer_active(
-        self, plotter_with_store, store
+    def test_legend_shown_for_a_single_stored_signal(
+        self, plotter_with_store, store, tmp_path
     ):
-        store.pin_signal(
-            origin="label-3",
-            name="Label 3",
-            x=np.array([0.0, 1.0]),
-            y=np.array([1.0, 2.0]),
-            color="#123456",
-            source_label="Pinned from labels",
-        )
-        # Switching to mouse mode replaces the live set entirely.
-        store.register_live_signals(
-            [
-                LiveSignal(
-                    id="mouse-0",
-                    name="Cursor",
-                    color="#abcdef",
-                    visible=True,
-                    source_type="mouse",
-                    source_id=None,
-                )
-            ]
-        )
+        # _render_stored_only's title is generic ("Stored Signals"), unlike the
+        # mouse-hover title which already names the voxel, so even a lone line
+        # needs its own legend entry to be identifiable.
+        path = tmp_path / "single.csv"
+        path.write_text("time,a\n0,1\n1,2\n")
+        store.import_file(path)
 
-        names = [s.label for s in plotter_with_store._stored_plot_signals()]
-        assert "Label 3" in names
+        result = plotter_with_store._render_stored_only()
 
-    def test_pinned_mouse_voxel_is_never_hidden_by_the_fixed_mouse_id(
-        self, plotter_with_store, store
-    ):
-        # The live mouse signal always has the fixed id "mouse-0", not a per-voxel
-        # id, so a pinned voxel (a distinct "mouse-k-j-i" origin) must stay visible
-        # while hovering elsewhere.
-        store.pin_signal(
-            origin="mouse-1-2-3",
-            name="Pinned voxel",
-            x=np.array([0.0, 1.0]),
-            y=np.array([1.0, 2.0]),
-            color="#123456",
-            source_label="Pinned from mouse",
-        )
-        store.register_live_signals(
-            [
-                LiveSignal(
-                    id="mouse-0",
-                    name="Cursor",
-                    color="#abcdef",
-                    visible=True,
-                    source_type="mouse",
-                    source_id=None,
-                )
-            ]
-        )
-
-        names = [s.label for s in plotter_with_store._stored_plot_signals()]
-        assert "Pinned voxel" in names
+        assert result is True
+        assert plotter_with_store._axes.get_legend() is not None
 
 
 class TestPinCurrentSignals:

--- a/tests/unit/test_napari/test_signal_plotter.py
+++ b/tests/unit/test_napari/test_signal_plotter.py
@@ -180,6 +180,47 @@ class TestOnMouseMove:
 
 
 # ---------------------------------------------------------------------------
+# Shift keybinding scoped to mouse source mode
+# ---------------------------------------------------------------------------
+
+
+def _bound_shift_handler(viewer):
+    from napari.utils.key_bindings import coerce_keybinding
+
+    return viewer.keymap.get(coerce_keybinding("Shift"))
+
+
+class TestShiftKeyBinding:
+    def test_bound_by_default_in_mouse_mode(self, viewer, plotter):
+        assert _bound_shift_handler(viewer) == plotter._on_shift_pressed
+
+    def test_unbound_when_leaving_mouse_mode(self, viewer, plotter):
+        plotter.set_source_mode("labels")
+        assert _bound_shift_handler(viewer) is None
+
+    def test_rebound_when_returning_to_mouse_mode(self, viewer, plotter):
+        plotter.set_source_mode("labels")
+        plotter.set_source_mode("mouse")
+        assert _bound_shift_handler(viewer) == plotter._on_shift_pressed
+
+    def test_preserves_a_pre_existing_shift_binding_while_in_other_modes(
+        self, viewer, plotter
+    ):
+        def other_handler(viewer):
+            pass
+
+        # Simulate another binding claiming Shift while this widget isn't using it.
+        plotter.set_source_mode("labels")
+        viewer.bind_key("Shift", other_handler, overwrite=True)
+
+        plotter.set_source_mode("mouse")
+        assert _bound_shift_handler(viewer) == plotter._on_shift_pressed
+
+        plotter.set_source_mode("labels")
+        assert _bound_shift_handler(viewer) is other_handler
+
+
+# ---------------------------------------------------------------------------
 # _get_xaxis_coords
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_napari/test_signal_store.py
+++ b/tests/unit/test_napari/test_signal_store.py
@@ -97,13 +97,13 @@ def test_store_can_rename_toggle_recolor_and_remove_signals(signals_store, signa
     signals_store.set_signal_visible(imported[1].id, False)
     signals_store.set_signal_color(imported[1].id, "#123456")
 
-    updated = signals_store.imported_signals()
+    updated = signals_store.stored_signals()
     assert updated[0].name == "baseline"
     assert updated[1].visible is False
     assert updated[1].color == "#123456"
 
     signals_store.remove_signals([imported[0].id])
-    remaining = signals_store.imported_signals()
+    remaining = signals_store.stored_signals()
     assert len(remaining) == 1
     assert remaining[0].id == imported[1].id
 
@@ -139,10 +139,70 @@ def test_store_generates_unique_ids_after_removal(signals_store, signals_csv, tm
 
 def test_store_clear_removes_all_signals(signals_store, signals_csv):
     signals_store.import_file(signals_csv)
-    assert len(signals_store.imported_signals()) == 2
+    assert len(signals_store.stored_signals()) == 2
 
     signals_store.clear()
-    assert signals_store.imported_signals() == []
+    assert signals_store.stored_signals() == []
+
+
+def test_pin_signal_creates_a_stored_signal_with_matching_origin(signals_store):
+    pinned = signals_store.pin_signal(
+        origin="label-3",
+        name="Label 3",
+        x=np.array([0.0, 1.0]),
+        y=np.array([1.0, 2.0]),
+        color="#123456",
+        source_label="Pinned from labels",
+    )
+
+    assert pinned.pin_origin == "label-3"
+    assert signals_store.stored_signals() == [pinned]
+
+
+def test_repinning_the_same_origin_updates_in_place_instead_of_duplicating(
+    signals_store,
+):
+    signals_store.pin_signal(
+        origin="label-3",
+        name="Label 3",
+        x=np.array([0.0, 1.0]),
+        y=np.array([1.0, 2.0]),
+        color="#123456",
+        source_label="Pinned from labels",
+    )
+    signals_store.pin_signal(
+        origin="label-3",
+        name="Label 3",
+        x=np.array([0.0, 1.0]),
+        y=np.array([9.0, 9.0]),
+        color="#123456",
+        source_label="Pinned from labels",
+    )
+
+    stored = signals_store.stored_signals()
+    assert len(stored) == 1
+    npt.assert_array_equal(stored[0].y, np.array([9.0, 9.0]))
+
+
+def test_pinning_different_origins_creates_separate_signals(signals_store):
+    signals_store.pin_signal(
+        origin="label-1",
+        name="Label 1",
+        x=np.array([0.0]),
+        y=np.array([1.0]),
+        color="#123456",
+        source_label="Pinned from labels",
+    )
+    signals_store.pin_signal(
+        origin="label-2",
+        name="Label 2",
+        x=np.array([0.0]),
+        y=np.array([2.0]),
+        color="#123456",
+        source_label="Pinned from labels",
+    )
+
+    assert len(signals_store.stored_signals()) == 2
 
 
 class TestStoreSignals:


### PR DESCRIPTION
## Summary
- Throttle mouse-driven signal-plotter updates (leading-edge, no added latency in the common case) and let Shift-press-without-moving plot the resting cursor's signal.
- Rename `ImportedSignal`/`imported_signals` to `StoredSignal`/`stored_signals` across the signal store, manager, and plotter, since the store no longer only holds file imports.
- Add `SignalStore.pin_signal` + a "Pin" button on the plotter to snapshot a currently plotted live signal (mouse voxel, point, or label region) so it survives a source-mode switch instead of being dropped.
- Add an "Export Selected" button to the Signal Manager dialog.

Closes #428.