### PR TITLE
napari: stop combo/spin boxes from hijacking sidebar scroll

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,7 +232,8 @@ Scopes: `io`/`nifti`/`autc`/`zarr` (I/O), `signal`/`spatial`/`iq`/`reduce`/`clut
 current development version's `X.Y.Z.devN` heading (never a released version), under
 section labels in this order (only add the ones you need):
 `:boom: Breaking changes`, `:sparkles: Enhancements`, `:zap: Performance`,
-`:bug: Fixes`, `:books: Documentation`, `:wrench: Maintenance`. napari-plugin entries
-may be prefixed **[Napari plugin]**. Write from the user's perspective (effect, not
-implementation), ending with a PR link:
-`([#123](https://github.com/confusius-tools/confusius/pull/123))`.
+`:bug: Fixes`, `:books: Documentation`, `:wrench: Maintenance`, `:frame_photo: Napari
+plugin`. Any entry about the napari plugin goes under `:frame_photo: Napari plugin`
+instead of its type section, and that section always comes last in the version.
+Write from the user's perspective (effect, not implementation), ending with a PR
+link: `([#123](https://github.com/confusius-tools/confusius/pull/123))`.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,10 +10,10 @@ icon: lucide/history
 
 Current development version for the next ConfUSIus release.
 
-### :bug: Fixes
+### :frame_photo: Napari plugin
 
-- **napari plugin:** Scrolling the sidebar with the mouse wheel no longer gets
-  hijacked by whichever combo box or spin box the cursor happens to be over
+- Scrolling the sidebar with the mouse wheel no longer gets hijacked by whichever
+  combo box or spin box the cursor happens to be over
   ([#431](https://github.com/confusius-tools/confusius/pull/431)).
 
 ## 0.7.0

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,12 @@ icon: lucide/history
 
 Current development version for the next ConfUSIus release.
 
+### :bug: Fixes
+
+- **napari plugin:** Scrolling the sidebar with the mouse wheel no longer gets
+  hijacked by whichever combo box or spin box the cursor happens to be over
+  ([#431](https://github.com/confusius-tools/confusius/pull/431)).
+
 ## 0.7.0
 
 Released 2026-08-31.

--- a/src/confusius/_napari/_qt.py
+++ b/src/confusius/_napari/_qt.py
@@ -2,7 +2,65 @@
 
 from __future__ import annotations
 
-from qtpy.QtWidgets import QMainWindow, QWidget
+from qtpy.QtCore import QEvent, QObject
+from qtpy.QtWidgets import (
+    QAbstractScrollArea,
+    QAbstractSpinBox,
+    QApplication,
+    QComboBox,
+    QMainWindow,
+    QWidget,
+)
+
+
+class _NoScrollWheelFilter(QObject):
+    """Forward wheel events to the enclosing scroll area instead of the control.
+
+    Without this, scrolling the sidebar with the cursor over a combo box or spin
+    box changes that control's value instead of scrolling the sidebar — installed
+    on every such control so the whole scroll area behaves like one continuous
+    surface. Unconditional (regardless of focus): these controls are also
+    reachable via their up/down arrows or by typing, so trading away
+    wheel-to-adjust entirely removes any risk of the sidebar scroll still being
+    hijacked by a control that Qt considers focused.
+    """
+
+    def eventFilter(self, watched: QObject | None, event: QEvent | None) -> bool:  # type: ignore
+        """Redirect the watched control's wheel events to its scroll area."""
+        if (
+            event is not None
+            and event.type() == QEvent.Type.Wheel
+            and isinstance(watched, QWidget)
+        ):
+            ancestor = watched.parentWidget()
+            while ancestor is not None and not isinstance(
+                ancestor, QAbstractScrollArea
+            ):
+                ancestor = ancestor.parentWidget()
+            if ancestor is not None:
+                # QAbstractScrollArea only reacts to wheel events delivered to its
+                # viewport, not to the scroll area widget itself.
+                QApplication.sendEvent(ancestor.viewport(), event)
+            return True
+        return super().eventFilter(watched, event)
+
+
+def install_no_scroll_wheel_filter(root: QWidget) -> None:
+    """Stop combo/spin boxes under `root` from capturing sidebar scroll events.
+
+    Recursively installs a shared `_NoScrollWheelFilter` on every `QComboBox` and
+    `QAbstractSpinBox` descendant of `root` (the latter covers both `QSpinBox` and
+    `QDoubleSpinBox`). Call once after a panel's widgets are constructed — new
+    descendants added later are not covered.
+
+    Parameters
+    ----------
+    root : QWidget
+        Widget to search for combo/spin box descendants.
+    """
+    wheel_filter = _NoScrollWheelFilter(root)
+    for widget in root.findChildren((QComboBox, QAbstractSpinBox)):
+        widget.installEventFilter(wheel_filter)
 
 
 def find_main_window(widget: QWidget) -> QMainWindow | None:

--- a/src/confusius/_napari/_qt.py
+++ b/src/confusius/_napari/_qt.py
@@ -17,12 +17,9 @@ class _NoScrollWheelFilter(QObject):
     """Forward wheel events to the enclosing scroll area instead of the control.
 
     Without this, scrolling the sidebar with the cursor over a combo box or spin
-    box changes that control's value instead of scrolling the sidebar — installed
+    box changes that control's value instead of scrolling the sidebar. Installed
     on every such control so the whole scroll area behaves like one continuous
-    surface. Unconditional (regardless of focus): these controls are also
-    reachable via their up/down arrows or by typing, so trading away
-    wheel-to-adjust entirely removes any risk of the sidebar scroll still being
-    hijacked by a control that Qt considers focused.
+    surface.
     """
 
     def eventFilter(self, watched: QObject | None, event: QEvent | None) -> bool:  # type: ignore

--- a/src/confusius/_napari/_widget.py
+++ b/src/confusius/_napari/_widget.py
@@ -30,6 +30,7 @@ from qtpy.QtWidgets import (
 )
 
 from confusius._napari._events._store import EventStore
+from confusius._napari._qt import install_no_scroll_wheel_filter
 from confusius._napari._theme import make_lucide_icon
 from confusius._napari._time_overlay import _TimeOverlay
 from confusius._utils.colors import RED, RED_DARK
@@ -653,5 +654,9 @@ class ConfUSIusWidget(QWidget):
         self._accordion_panels = dict(zip([e[0] for e in tab_entries], panels))
         # Exposed so the guided tour can follow in-flight panel animations.
         self._accordion_anims = panel_anims
+
+        # A combo/spin box under the cursor otherwise captures wheel scrolling
+        # (changing its value) instead of letting it scroll the sidebar.
+        install_no_scroll_wheel_filter(container)
 
         return container

--- a/tests/unit/test_napari/test_qt.py
+++ b/tests/unit/test_napari/test_qt.py
@@ -1,0 +1,74 @@
+"""Unit tests for shared Qt helpers."""
+
+from __future__ import annotations
+
+from qtpy.QtCore import QPoint, QPointF, Qt
+from qtpy.QtGui import QWheelEvent
+from qtpy.QtWidgets import QApplication, QComboBox, QScrollArea, QVBoxLayout, QWidget
+
+from confusius._napari._qt import install_no_scroll_wheel_filter
+
+
+def _wheel_event() -> QWheelEvent:
+    return QWheelEvent(
+        QPointF(5, 5),
+        QPointF(5, 5),
+        QPoint(0, 0),
+        QPoint(0, -120),
+        Qt.MouseButton.NoButton,
+        Qt.KeyboardModifier.NoModifier,
+        Qt.ScrollPhase.NoScrollPhase,
+        False,
+    )
+
+
+def test_wheel_over_combo_box_scrolls_area_instead_of_changing_value(qtbot):
+    scroll = QScrollArea()
+    content = QWidget()
+    layout = QVBoxLayout(content)
+    combo = QComboBox()
+    combo.addItems(["a", "b", "c"])
+    layout.addWidget(combo)
+    # Pad well past the scroll area's viewport so there is something to scroll.
+    for _ in range(50):
+        pad = QWidget()
+        pad.setMinimumHeight(20)
+        layout.addWidget(pad)
+    scroll.setWidget(content)
+    scroll.setWidgetResizable(True)
+    scroll.resize(200, 100)
+    qtbot.addWidget(scroll)
+    scroll.show()
+    qtbot.waitExposed(scroll)
+    QApplication.processEvents()
+
+    install_no_scroll_wheel_filter(content)
+
+    vbar = scroll.verticalScrollBar()
+    assert vbar is not None
+    assert vbar.maximum() > 0  # sanity: there is actually something to scroll
+    before_index, before_scroll = combo.currentIndex(), vbar.value()
+
+    QApplication.sendEvent(combo, _wheel_event())
+    QApplication.processEvents()
+
+    assert combo.currentIndex() == before_index
+    assert vbar.value() != before_scroll
+
+
+def test_combo_box_without_scroll_area_ancestor_still_swallows_wheel(qtbot):
+    # No QAbstractScrollArea anywhere in the ancestry: the filter must still
+    # swallow the event (leaving the combo's value untouched) rather than error
+    # out looking for somewhere to forward it.
+    parent = QWidget()
+    layout = QVBoxLayout(parent)
+    combo = QComboBox()
+    combo.addItems(["a", "b", "c"])
+    layout.addWidget(combo)
+    qtbot.addWidget(parent)
+    install_no_scroll_wheel_filter(parent)
+
+    before_index = combo.currentIndex()
+    QApplication.sendEvent(combo, _wheel_event())
+
+    assert combo.currentIndex() == before_index


### PR DESCRIPTION
## Summary
Install a shared event filter on every combo/spin box in the sidebar accordion that redirects wheel events to the enclosing scroll area's viewport instead of letting the control change its own value — the mouse wheel now always scrolls the sidebar, regardless of which control is under the cursor or whether it's focused.

Closes #430.