### PR TITLE
feat(napari): add Preprocessing panel

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,26 +15,20 @@ Current development version for the next ConfUSIus release.
 - Scrolling the sidebar with the mouse wheel no longer gets hijacked by whichever
   combo box or spin box the cursor happens to be over
   ([#431](https://github.com/confusius-tools/confusius/pull/431)).
-
-### :sparkles: Enhancements
-
-- **napari plugin:** The signal plotter's mouse source now updates when Shift is
-  pressed while the cursor is already resting on a voxel, not only while moving;
-  a live signal (mouse voxel, a point, or a label region) can now be pinned so it
-  persists across source-mode switches instead of being dropped, reusable
-  wherever stored signals are — imported and pinned signals now share one
-  concept (`StoredSignal`) throughout the signal store, plotter, and manager
+- The signal plotter's mouse source now updates when Shift is pressed while the
+  cursor is already resting on a voxel, not only while moving; a live signal
+  (mouse voxel, a point, or a label region) can now be pinned so it persists
+  across source-mode switches instead of being dropped, reusable wherever stored
+  signals are — imported and pinned signals now share one concept
+  (`StoredSignal`) throughout the signal store, plotter, and manager
   ([#429](https://github.com/confusius-tools/confusius/pull/429)).
-- **napari plugin:** A DVARS trace computed in the Quality Control panel is now
-  added to the shared signal store, making it selectable elsewhere in the plugin
-  without first exporting and re-importing it
+- Mouse-driven signal plotting no longer lags or jitters on large recordings —
+  updates are now throttled to the display refresh rate instead of running
+  unbounded on every raw mouse-move event
   ([#429](https://github.com/confusius-tools/confusius/pull/429)).
-
-### :zap: Performance
-
-- **napari plugin:** Mouse-driven signal plotting no longer lags or jitters on
-  large recordings — updates are now throttled to the display refresh rate
-  instead of running unbounded on every raw mouse-move event
+- A DVARS trace computed in the Quality Control panel is now added to the
+  shared signal store, making it selectable elsewhere in the plugin without
+  first exporting and re-importing it
   ([#429](https://github.com/confusius-tools/confusius/pull/429)).
 
 ## 0.7.0

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -30,6 +30,11 @@ Current development version for the next ConfUSIus release.
   shared signal store, making it selectable elsewhere in the plugin without
   first exporting and re-importing it
   ([#429](https://github.com/confusius-tools/confusius/pull/429)).
+- Added a Preprocessing panel, covering temporal resampling, spatial smoothing,
+  detrending, temporal filtering, standardization, confound regression
+  (including CompCor confound extraction), and scrubbing, with sample masks
+  and confounds sourced directly from stored signals
+  ([#435](https://github.com/confusius-tools/confusius/pull/435)).
 
 ## 0.7.0
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -25,6 +25,10 @@ Current development version for the next ConfUSIus release.
   wherever stored signals are — imported and pinned signals now share one
   concept (`StoredSignal`) throughout the signal store, plotter, and manager
   ([#429](https://github.com/confusius-tools/confusius/pull/429)).
+- **napari plugin:** A DVARS trace computed in the Quality Control panel is now
+  added to the shared signal store, making it selectable elsewhere in the plugin
+  without first exporting and re-importing it
+  ([#429](https://github.com/confusius-tools/confusius/pull/429)).
 
 ### :zap: Performance
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,23 @@ Current development version for the next ConfUSIus release.
   combo box or spin box the cursor happens to be over
   ([#431](https://github.com/confusius-tools/confusius/pull/431)).
 
+### :sparkles: Enhancements
+
+- **napari plugin:** The signal plotter's mouse source now updates when Shift is
+  pressed while the cursor is already resting on a voxel, not only while moving;
+  a live signal (mouse voxel, a point, or a label region) can now be pinned so it
+  persists across source-mode switches instead of being dropped, reusable
+  wherever stored signals are — imported and pinned signals now share one
+  concept (`StoredSignal`) throughout the signal store, plotter, and manager
+  ([#429](https://github.com/confusius-tools/confusius/pull/429)).
+
+### :zap: Performance
+
+- **napari plugin:** Mouse-driven signal plotting no longer lags or jitters on
+  large recordings — updates are now throttled to the display refresh rate
+  instead of running unbounded on every raw mouse-move event
+  ([#429](https://github.com/confusius-tools/confusius/pull/429)).
+
 ## 0.7.0
 
 Released 2026-08-31.

--- a/src/confusius/_napari/_preprocessing/__init__.py
+++ b/src/confusius/_napari/_preprocessing/__init__.py
@@ -1,0 +1,1 @@
+"""Signal preprocessing panel for the ConfUSIus napari plugin."""

--- a/src/confusius/_napari/_preprocessing/_panel.py
+++ b/src/confusius/_napari/_preprocessing/_panel.py
@@ -1,0 +1,1579 @@
+"""Preprocessing control panel for the ConfUSIus sidebar."""
+
+from __future__ import annotations
+
+import multiprocessing
+from collections.abc import Generator
+from concurrent.futures import ProcessPoolExecutor
+from typing import Literal, NamedTuple, TypeVar, cast
+
+import napari
+import numpy as np
+import xarray as xr
+from napari.qt.threading import thread_worker
+from napari.utils.notifications import show_error
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import (
+    QAbstractItemView,
+    QAbstractSpinBox,
+    QCheckBox,
+    QComboBox,
+    QDoubleSpinBox,
+    QFormLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QListWidget,
+    QListWidgetItem,
+    QProgressBar,
+    QPushButton,
+    QSpinBox,
+    QToolButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from confusius._dims import TIME_DIM
+from confusius._napari._signals._store import LiveSignal, SignalStore
+from confusius._napari._utils import (
+    CATEGORICAL_COLORS,
+    extract_label_mean_trace,
+    extract_voxel_trace,
+)
+from confusius._utils.coordinates import get_representative_step
+from confusius.plotting.napari import plot_napari
+from confusius.signal import clean, compute_compcor_confounds
+from confusius.spatial import smooth_volume
+from confusius.timing import resample_time, resample_to_uniform_time
+
+_SPIN_WIDTH = 70
+"""Maximum width, in pixels, for compact numeric spin boxes (small integers)."""
+
+_SPIN_WIDTH_WIDE = 92
+"""Maximum width, in pixels, for spin boxes showing decimals (cutoffs, tolerance,
+pad length) — wide enough to read the value while typing without forcing the
+sidebar wider than the napari dock.
+"""
+
+_COMBO_CHARS_NARROW = 8
+_COMBO_CHARS_MEDIUM = 12
+_COMBO_CHARS_WIDE = 16
+"""Minimum-contents-length presets for `_narrow_combo`, in characters.
+
+Paired with `QComboBox.SizeAdjustPolicy.AdjustToMinimumContentsLengthWithIcon`, this
+caps a combo box's width to roughly this many characters regardless of how long its
+longest item's text is (e.g. "Match reference layer", arbitrary layer/signal names).
+The popup itself still shows the full text; only the closed box is capped.
+"""
+
+_STANDARDIZE_LABELS: dict[str, str | None] = {
+    "None": None,
+    "Z-score": "zscore",
+    "Percent signal change": "psc",
+}
+
+_INTERPOLATE_METHODS = (
+    "linear",
+    "nearest",
+    "zero",
+    "slinear",
+    "quadratic",
+    "cubic",
+    "quintic",
+    "pchip",
+    "barycentric",
+    "krogh",
+    "akima",
+    "makima",
+)
+
+_RESAMPLE_METHODS = (
+    "linear",
+    "nearest",
+    "nearest-up",
+    "zero",
+    "slinear",
+    "quadratic",
+    "cubic",
+    "previous",
+    "next",
+)
+_ResampleMethod = Literal[
+    "linear",
+    "nearest",
+    "nearest-up",
+    "zero",
+    "slinear",
+    "quadratic",
+    "cubic",
+    "previous",
+    "next",
+]
+
+_NO_SIGNAL = "None"
+_NO_RESAMPLING = "No resampling"
+_UNIFORM_GRID = "Uniform grid"
+_MATCH_REFERENCE = "Match reference layer"
+
+_SpinBoxT = TypeVar("_SpinBoxT", bound=QAbstractSpinBox)
+
+# A raw, unaligned (x, y) signal pulled from either a stored (imported or pinned)
+# signal or a live napari source (point/label trace). Alignment onto the pipeline's
+# actual time grid is deferred to the background thread, since that grid is only
+# known once resampling (which may change its length) has run.
+_RawSignal = tuple["np.ndarray | None", "np.ndarray"]
+
+_MASK_ALREADY_BINARY = "Binary"
+_MASK_KEEP_ABOVE = "Keep where value >"
+_MASK_KEEP_BELOW = "Keep where value <"
+
+
+class _MaskSpec(NamedTuple):
+    """A raw sample-mask signal plus how to threshold it into a boolean mask.
+
+    Attributes
+    ----------
+    x : numpy.ndarray or None
+        Time values for `y`, or `None` to align positionally (see `_align_series`).
+    y : numpy.ndarray
+        Raw signal values.
+    threshold : float or None
+        Threshold to compare `y` against after alignment, or `None` if `y` is
+        already binary (nonzero values are kept).
+    keep_above : bool
+        Whether values above `threshold` are kept (`True`) or values below
+        `threshold` are kept (`False`). Ignored when `threshold` is `None`.
+    """
+
+    x: np.ndarray | None
+    y: np.ndarray
+    threshold: float | None
+    keep_above: bool
+
+
+@thread_worker
+def _run_pipeline(
+    signals: xr.DataArray,
+    resample_spec: tuple[str, dict] | None,
+    smooth_kwargs: dict | None,
+    clean_kwargs: dict,
+    confounds_raw: list[_RawSignal],
+    mask_raw: _MaskSpec | None,
+) -> xr.DataArray:
+    """Run temporal resampling, spatial smoothing, and signal cleaning.
+
+    Runs in a background thread, in that order, so temporal filtering (which
+    requires uniformly-sampled time) always sees a regular grid when resampling is
+    requested.
+
+    Parameters
+    ----------
+    signals : xarray.DataArray
+        Source signals to process.
+    resample_spec : tuple[str, dict] or None
+        `(mode, kwargs)` pair, where `mode` is `"Uniform grid"` (kwargs forwarded to
+        `confusius.timing.resample_to_uniform_time`) or anything else (`kwargs`
+        forwarded to `confusius.timing.resample_time`, expected to contain
+        `new_time` and `method`). If not provided, no resampling is applied.
+    smooth_kwargs : dict, optional
+        Keyword arguments forwarded to `confusius.spatial.smooth_volume`. If not
+        provided, no smoothing is applied.
+    clean_kwargs : dict
+        Keyword arguments forwarded to `confusius.signal.clean`. Mutated in place to
+        add `confounds`/`sample_mask` when `confounds_raw`/`mask_raw` are provided.
+    confounds_raw : list[tuple[numpy.ndarray or None, numpy.ndarray]]
+        Raw `(x, y)` confound series to align onto the post-resampling time grid
+        and stack together along a `confound` dimension. Empty means no confound
+        regression is applied.
+    mask_raw : _MaskSpec, optional
+        Raw series plus thresholding info to turn into a sample mask, aligned onto
+        the post-resampling time grid. If not provided, no scrubbing is applied.
+
+    Returns
+    -------
+    xarray.DataArray
+        Fully processed signals.
+    """
+    signals = _resample_and_smooth(signals, resample_spec, smooth_kwargs)
+
+    if confounds_raw:
+        aligned_confounds = [_align_series(x, y, signals) for x, y in confounds_raw]
+        clean_kwargs["confounds"] = xr.concat(aligned_confounds, dim="confound")
+    if mask_raw is not None:
+        aligned = _align_series(mask_raw.x, mask_raw.y, signals)
+        clean_kwargs["sample_mask"] = _threshold_mask(aligned, mask_raw)
+
+    return clean(signals, **clean_kwargs)
+
+
+def _threshold_mask(aligned: xr.DataArray, mask_raw: _MaskSpec) -> xr.DataArray:
+    """Turn an aligned raw series into a boolean keep/censor mask.
+
+    Parameters
+    ----------
+    aligned : xarray.DataArray
+        Raw mask series already aligned onto the pipeline's time grid (see
+        `_align_series`).
+    mask_raw : _MaskSpec
+        Thresholding info: `mask_raw.threshold`/`mask_raw.keep_above`.
+
+    Returns
+    -------
+    xarray.DataArray
+        Boolean DataArray with the same shape/coords as `aligned`.
+    """
+    if mask_raw.threshold is None:
+        boolean = aligned.values.astype(bool)
+    elif mask_raw.keep_above:
+        boolean = aligned.values > mask_raw.threshold
+    else:
+        boolean = aligned.values < mask_raw.threshold
+    return aligned.copy(data=boolean)
+
+
+def _resample_and_smooth(
+    signals: xr.DataArray,
+    resample_spec: tuple[str, dict] | None,
+    smooth_kwargs: dict | None,
+) -> xr.DataArray:
+    """Apply the panel's temporal resampling and spatial smoothing steps.
+
+    Shared by `_run_pipeline` and `_run_compcor` so CompCor components are
+    always extracted from the same resampled/smoothed stage the main signals
+    are cleaned from.
+    """
+    if resample_spec is not None:
+        mode, kwargs = resample_spec
+        if mode == _UNIFORM_GRID:
+            signals = resample_to_uniform_time(signals, **kwargs)
+        else:
+            method = cast(_ResampleMethod, kwargs["method"])
+            signals = resample_time(signals, kwargs["new_time"], method=method)
+
+    if smooth_kwargs is not None:
+        signals = smooth_volume(signals, **smooth_kwargs)
+
+    return signals
+
+
+def _compcor_subprocess(
+    values: np.ndarray,
+    dims: tuple[str, ...],
+    time_values: np.ndarray,
+    noise_mask_values: np.ndarray | None,
+    variance_threshold: float | None,
+    n_components: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Extract CompCor components in a separate OS process.
+
+    A real recording's component-extraction step can take minutes, and nothing
+    guarantees every numpy/scipy call inside `compute_compcor_confounds` releases
+    the GIL for that whole stretch — a QThread alone doesn't protect the main Qt
+    event loop from that. Running it in its own process sidesteps the question
+    entirely: a separate process has its own interpreter and GIL, so it can never
+    block the main process's event loop no matter what it's doing internally.
+
+    Module-level (not a closure) and arguments/return value are plain numpy
+    arrays only, both required for `ProcessPoolExecutor` to pickle this call
+    across the process boundary — `compute_compcor_confounds` is explicitly
+    documented (see AGENTS.md's "dual-input consumers") to accept a plain,
+    `VoxelToWorldIndex`-free `xarray.DataArray` just like this, so nothing here
+    is a special case for the subprocess path.
+
+    Parameters
+    ----------
+    values : numpy.ndarray
+        Signal data, `dims`-ordered with a leading `time` axis.
+    dims : tuple[str, ...]
+        Dimension names for `values` (index 0 must be `"time"`).
+    time_values : numpy.ndarray
+        Time coordinate values.
+    noise_mask_values : numpy.ndarray, optional
+        Boolean noise mask over `values`'s non-time (spatial) axes.
+    variance_threshold : float, optional
+        Forwarded to `confusius.signal.compute_compcor_confounds`.
+    n_components : int
+        Forwarded to `confusius.signal.compute_compcor_confounds`.
+
+    Returns
+    -------
+    time_values : numpy.ndarray
+        Time coordinate values of the resulting components.
+    components : numpy.ndarray
+        `(time, component)` CompCor components.
+    """
+    signals = xr.DataArray(values, dims=dims, coords={TIME_DIM: time_values})
+    noise_mask = (
+        xr.DataArray(noise_mask_values, dims=dims[1:])
+        if noise_mask_values is not None
+        else None
+    )
+    result = compute_compcor_confounds(
+        signals,
+        noise_mask=noise_mask,
+        variance_threshold=variance_threshold,
+        n_components=n_components,
+    )
+    return np.asarray(result.coords[TIME_DIM].values), np.asarray(result.values)
+
+
+@thread_worker
+def _run_compcor(
+    signals: xr.DataArray,
+    resample_spec: tuple[str, dict] | None,
+    smooth_kwargs: dict | None,
+    noise_mask: xr.DataArray | None,
+    variance_threshold: float | None,
+    n_components: int,
+) -> Generator[str, None, xr.DataArray]:
+    """Resample/smooth, then extract CompCor noise components.
+
+    Parameters
+    ----------
+    signals : xarray.DataArray
+        Source signals to process.
+    resample_spec : tuple[str, dict] or None
+        Forwarded to `_resample_and_smooth`.
+    smooth_kwargs : dict, optional
+        Forwarded to `_resample_and_smooth`.
+    noise_mask : xarray.DataArray, optional
+        Forwarded to `confusius.signal.compute_compcor_confounds`.
+    variance_threshold : float, optional
+        Forwarded to `confusius.signal.compute_compcor_confounds`.
+    n_components : int
+        Forwarded to `confusius.signal.compute_compcor_confounds`.
+
+    Yields
+    ------
+    str
+        Human-readable label for the current stage, so the caller can show real
+        progress (via `worker.yielded`) instead of a static busy state — the
+        component-extraction stage in particular scales with timepoints ×
+        selected voxels and can take a while on a large recording or a broad
+        noise mask.
+
+    Returns
+    -------
+    xarray.DataArray
+        `(time, component)` CompCor components.
+    """
+    yield "Resampling/smoothing…"
+    signals = _resample_and_smooth(signals, resample_spec, smooth_kwargs)
+
+    yield "Extracting components…"
+    # "spawn", not the platform-default "fork" on Linux: this runs on a QThread,
+    # and fork() only clones the calling thread — any lock another thread (Qt's
+    # own internals, the GIL) held at that instant stays permanently locked in
+    # the child, which can hang it deterministically. spawn always starts a
+    # clean interpreter instead.
+    context = multiprocessing.get_context("spawn")
+    with ProcessPoolExecutor(max_workers=1, mp_context=context) as pool:
+        result_time, result_values = pool.submit(
+            _compcor_subprocess,
+            np.ascontiguousarray(signals.values),
+            tuple(str(d) for d in signals.dims),
+            np.asarray(signals.coords[TIME_DIM].values),
+            None if noise_mask is None else np.asarray(noise_mask.values),
+            variance_threshold,
+            n_components,
+        ).result()
+
+    return xr.DataArray(
+        result_values,
+        dims=[TIME_DIM, "component"],
+        coords={
+            TIME_DIM: result_time,
+            "component": np.arange(n_components),
+        },
+    )
+
+
+def _build_noise_mask(
+    reference: xr.DataArray, labels_data: np.ndarray
+) -> xr.DataArray | None:
+    """Build a boolean noise mask from a Labels layer, for CompCor.
+
+    Parameters
+    ----------
+    reference : xarray.DataArray
+        Source signals the mask must spatially match (its own `time` dimension is
+        collapsed away).
+    labels_data : numpy.ndarray
+        Labels array, either the same shape as `reference` or its spatial shape
+        (i.e. `reference`'s shape with the `time` axis removed).
+
+    Returns
+    -------
+    xarray.DataArray or None
+        Boolean mask sharing `reference`'s spatial dims/coords (nonzero labels are
+        `True`), or `None` if `labels_data`'s shape matches neither directly nor
+        spatially.
+    """
+    xaxis_index = list(reference.dims).index(TIME_DIM)
+    img_spatial = tuple(s for i, s in enumerate(reference.shape) if i != xaxis_index)
+
+    if labels_data.shape == reference.shape:
+        labels_spatial = np.max(labels_data, axis=xaxis_index)
+    elif labels_data.shape == img_spatial:
+        labels_spatial = labels_data
+    else:
+        return None
+
+    mask = xr.zeros_like(reference.isel({TIME_DIM: 0}, drop=True), dtype=bool)
+    mask.values[...] = labels_spatial != 0
+    return mask
+
+
+def _align_series(
+    x: np.ndarray | None, y: np.ndarray, reference: xr.DataArray
+) -> xr.DataArray:
+    """Align a raw `(x, y)` series onto a reference DataArray's `time` grid.
+
+    Parameters
+    ----------
+    x : numpy.ndarray or None
+        Time values for `y`. If not provided, `y` is assumed to already share
+        `reference`'s time axis positionally (its length must match).
+    y : numpy.ndarray
+        Series values.
+    reference : xarray.DataArray
+        DataArray whose `time` dimension/coordinate the series is aligned to.
+
+    Returns
+    -------
+    xarray.DataArray
+        1D DataArray with a `time` dimension matching `reference`.
+
+    Raises
+    ------
+    ValueError
+        If interpolation is not possible (no time coordinate on `reference`, or no
+        `x` values for `y`) and `y`'s length does not match the number of
+        timepoints in `reference`.
+    """
+    n_timepoints = reference.sizes[TIME_DIM]
+    time_coord = (
+        reference.coords[TIME_DIM].values if TIME_DIM in reference.coords else None
+    )
+
+    if time_coord is not None and x is not None:
+        source = xr.DataArray(y, dims=TIME_DIM, coords={TIME_DIM: x})
+        values = source.interp({TIME_DIM: time_coord}).values
+    else:
+        if len(y) != n_timepoints:
+            raise ValueError(
+                f"Signal has {len(y)} samples, but the source has {n_timepoints} "
+                "timepoints and no shared 'time' coordinate to align by."
+            )
+        values = np.asarray(y, dtype=float)
+
+    coords = {TIME_DIM: time_coord} if time_coord is not None else None
+    return xr.DataArray(values, dims=TIME_DIM, coords=coords)
+
+
+def _capped_spin(spin: _SpinBoxT, width: int = _SPIN_WIDTH) -> _SpinBoxT:
+    """Cap a spin box's width so it cannot force the sidebar wider than the dock."""
+    spin.setMaximumWidth(width)
+    return spin
+
+
+def _narrow_combo(combo: QComboBox, chars: int = _COMBO_CHARS_MEDIUM) -> QComboBox:
+    """Cap a combo box's width to `chars` characters, regardless of item length.
+
+    Without this, a combo box grows to fit its longest item (e.g. "Match reference
+    layer", or an arbitrary layer/signal name), which forces the sidebar wider than
+    the napari dock. The dropdown popup itself is unaffected and still shows full
+    item text.
+    """
+    combo.setSizeAdjustPolicy(
+        QComboBox.SizeAdjustPolicy.AdjustToMinimumContentsLengthWithIcon
+    )
+    combo.setMinimumContentsLength(chars)
+    return combo
+
+
+def _form_label(text: str, *, tooltip: str | None = None) -> QLabel:
+    """Return a `QFormLayout` row label with its own tooltip.
+
+    Building the label explicitly (rather than passing a bare string to
+    `QFormLayout.addRow`) lets the label carry its own tooltip. Without one, Qt
+    forwards unhandled tooltip events to the parent widget, which is why leaving a
+    row's label/field without a tooltip previously surfaced the enclosing
+    QGroupBox's tooltip instead.
+    """
+    label = QLabel(text)
+    if tooltip is not None:
+        label.setToolTip(tooltip)
+    return label
+
+
+def _wrap_form(form: QFormLayout) -> QFormLayout:
+    """Apply the narrow-dock-safe wrap policy used throughout the registration panel.
+
+    Wrapping long rows (label above field, rather than side by side) keeps a form
+    row's minimum width to the widest of the label or the field alone, instead of
+    their sum — the same fix used for the registration panel's overflow (see PR
+    #216 and the signals panel's issue #183).
+    """
+    form.setRowWrapPolicy(QFormLayout.RowWrapPolicy.WrapLongRows)
+    form.setFieldGrowthPolicy(QFormLayout.FieldGrowthPolicy.ExpandingFieldsGrow)
+    return form
+
+
+class PreprocessingPanel(QWidget):
+    """Right-side panel for resampling, smoothing, and cleaning fUSI signals.
+
+    A single "Apply" runs, in order: temporal resampling
+    (`confusius.timing.resample_time` / `confusius.timing.resample_to_uniform_time`,
+    unless "No resampling" is selected), spatial smoothing
+    (`confusius.spatial.smooth_volume`, when enabled), and signal cleaning
+    (`confusius.signal.clean`, always). The pipeline runs in a background thread and
+    adds its result to the viewer as a new image layer named
+    `"{source layer} — cleaned"`.
+
+    Parameters
+    ----------
+    viewer : napari.Viewer
+        The active napari viewer instance.
+    signal_store : SignalStore
+        Shared store of stored and live signals, used to populate the confounds
+        and sample mask dropdowns. Pass the same instance used by the Signals panel
+        so its stored and live (point/label) signals are available here too.
+    """
+
+    def __init__(self, viewer: napari.Viewer, signal_store: SignalStore) -> None:
+        super().__init__()
+        self._viewer = viewer
+        self._signal_store = signal_store
+        # Set by _begin_work; tracks which button ("Apply" or "Compute CompCor")
+        # triggered the current background job so _end_work can restore its text.
+        self._working_button: QPushButton | None = None
+        self._working_button_text = ""
+        self._setup_ui()
+
+        viewer.layers.events.inserted.connect(self._refresh_layer_combos)
+        viewer.layers.events.removed.connect(self._refresh_layer_combos)
+        signal_store.changed.connect(self._refresh_signal_combos)
+
+    # ------------------------------------------------------------------
+    # UI construction
+    # ------------------------------------------------------------------
+
+    def _setup_ui(self) -> None:
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(10, 10, 10, 10)
+        layout.setSpacing(8)
+
+        layout.addWidget(self._make_source_group())
+        layout.addWidget(self._make_resample_group())
+        layout.addWidget(self._make_smooth_group())
+        layout.addWidget(self._make_detrend_group())
+        layout.addWidget(self._make_filter_group())
+        layout.addWidget(self._make_standardize_group())
+        layout.addWidget(self._make_confounds_group())
+        layout.addWidget(self._make_scrub_group())
+
+        self._apply_btn = QPushButton("Apply")
+        self._apply_btn.setObjectName("primary_btn")
+        self._apply_btn.clicked.connect(self._apply)
+        layout.addWidget(self._apply_btn)
+
+        self._progress = QProgressBar()
+        self._progress.setRange(0, 0)
+        self._progress.setMaximumHeight(4)
+        self._progress.hide()
+        layout.addWidget(self._progress)
+
+        layout.addStretch()
+
+        self._refresh_layer_combos()
+        self._refresh_signal_combos()
+
+    def _make_source_group(self) -> QGroupBox:
+        group = QGroupBox("Source")
+        group_layout = QVBoxLayout(group)
+        group_layout.setSpacing(4)
+        self._source_combo = _narrow_combo(QComboBox(), _COMBO_CHARS_WIDE)
+        self._source_combo.setToolTip(
+            "Image layer to process. Only layers with a 'time' dimension are listed."
+        )
+        self._source_combo.currentTextChanged.connect(self._prefill_resample_defaults)
+        group_layout.addWidget(self._source_combo)
+        return group
+
+    def _make_resample_group(self) -> QGroupBox:
+        group = QGroupBox("Temporal Resampling")
+        group_layout = QVBoxLayout(group)
+        group_layout.setSpacing(4)
+
+        self._resample_mode_combo = _narrow_combo(QComboBox(), _COMBO_CHARS_WIDE)
+        self._resample_mode_combo.addItems(
+            [_NO_RESAMPLING, _UNIFORM_GRID, _MATCH_REFERENCE]
+        )
+        self._resample_mode_combo.currentTextChanged.connect(
+            self._on_resample_mode_changed
+        )
+        group_layout.addWidget(self._resample_mode_combo)
+
+        # Uniform grid: step only. Start/stop always default to the recording's own
+        # first/last timepoint (resample_to_uniform_time's own default).
+        self._uniform_widget = QWidget()
+        uniform_row = QHBoxLayout(self._uniform_widget)
+        uniform_row.setContentsMargins(0, 0, 0, 0)
+        uniform_row.setSpacing(4)
+        uniform_row.addWidget(_form_label("Step"))
+        self._resample_step_spin = _capped_spin(QDoubleSpinBox(), _SPIN_WIDTH_WIDE)
+        self._resample_step_spin.setRange(1e-6, 1e6)
+        self._resample_step_spin.setDecimals(4)
+        self._resample_step_spin.setValue(0.5)
+        self._resample_step_spin.setToolTip(
+            "Uniform time step, in seconds. Prefilled with the source layer's "
+            "median temporal spacing."
+        )
+        uniform_row.addWidget(self._resample_step_spin)
+        uniform_row.addStretch()
+        group_layout.addWidget(self._uniform_widget)
+        self._uniform_widget.hide()
+
+        # Match reference: borrow another layer's time coordinate as the new grid.
+        self._reference_widget = QWidget()
+        reference_form = _wrap_form(QFormLayout(self._reference_widget))
+        reference_form.setContentsMargins(0, 0, 0, 0)
+        reference_form.setSpacing(4)
+        self._resample_reference_combo = _narrow_combo(QComboBox(), _COMBO_CHARS_WIDE)
+        self._resample_reference_combo.setToolTip(
+            "Layer whose time coordinate is used as the new time grid."
+        )
+        reference_form.addRow(_form_label("Reference"), self._resample_reference_combo)
+        group_layout.addWidget(self._reference_widget)
+        self._reference_widget.hide()
+
+        self._resample_method_widget = QWidget()
+        method_row = QHBoxLayout(self._resample_method_widget)
+        method_row.setContentsMargins(0, 0, 0, 0)
+        method_row.setSpacing(4)
+        method_row.addWidget(_form_label("Method"))
+        self._resample_method_combo = _narrow_combo(QComboBox(), _COMBO_CHARS_MEDIUM)
+        self._resample_method_combo.addItems(list(_RESAMPLE_METHODS))
+        method_row.addWidget(self._resample_method_combo, stretch=1)
+        group_layout.addWidget(self._resample_method_widget)
+        self._resample_method_widget.hide()
+
+        return group
+
+    def _make_smooth_group(self) -> QGroupBox:
+        group = QGroupBox("Spatial Smoothing")
+        group_layout = QVBoxLayout(group)
+        group_layout.setSpacing(4)
+
+        fwhm_row = QHBoxLayout()
+        self._smooth_enable_check = QCheckBox("FWHM")
+        self._smooth_enable_check.setToolTip(
+            "Whether to apply isotropic Gaussian spatial smoothing before cleaning."
+        )
+        self._smooth_fwhm_spin = _capped_spin(QDoubleSpinBox(), _SPIN_WIDTH_WIDE)
+        self._smooth_fwhm_spin.setRange(0.0, 100.0)
+        self._smooth_fwhm_spin.setDecimals(3)
+        self._smooth_fwhm_spin.setValue(0.3)
+        self._smooth_fwhm_spin.setEnabled(False)
+        self._smooth_fwhm_spin.setToolTip(
+            "Full width at half maximum of an isotropic Gaussian kernel, in the "
+            "source layer's physical (spatial coordinate) units."
+        )
+        self._smooth_enable_check.toggled.connect(self._smooth_fwhm_spin.setEnabled)
+        fwhm_row.addWidget(self._smooth_enable_check)
+        fwhm_row.addWidget(self._smooth_fwhm_spin)
+        fwhm_row.addStretch()
+        group_layout.addLayout(fwhm_row)
+
+        self._smooth_ensure_finite_check = QCheckBox("Interpolate Inf/Nan")
+        self._smooth_ensure_finite_check.setToolTip(
+            "Replace non-finite values with zero before filtering, so they don't "
+            "spread to neighbouring voxels through the Gaussian kernel."
+        )
+        group_layout.addWidget(self._smooth_ensure_finite_check)
+        return group
+
+    def _make_detrend_group(self) -> QGroupBox:
+        group = QGroupBox("Detrending")
+        group_layout = QHBoxLayout(group)
+        self._detrend_check = QCheckBox("Order")
+        self._detrend_check.setToolTip(
+            "Whether to remove a polynomial trend before filtering/standardizing."
+        )
+        self._detrend_order_spin = _capped_spin(QSpinBox())
+        self._detrend_order_spin.setRange(0, 10)
+        self._detrend_order_spin.setValue(1)
+        self._detrend_order_spin.setEnabled(False)
+        self._detrend_order_spin.setToolTip(
+            "0: remove mean. 1: remove linear trend (default). 2+: polynomial trend."
+        )
+        self._detrend_check.toggled.connect(self._detrend_order_spin.setEnabled)
+        group_layout.addWidget(self._detrend_check)
+        group_layout.addWidget(self._detrend_order_spin)
+        group_layout.addStretch()
+        return group
+
+    def _make_filter_group(self) -> QGroupBox:
+        group = QGroupBox("Temporal Filter")
+        group.setToolTip("Zero-phase Butterworth low-/high-/band-pass filter.")
+        group_layout = QVBoxLayout(group)
+        group_layout.setSpacing(4)
+
+        cutoff_form = _wrap_form(QFormLayout())
+        cutoff_form.setSpacing(4)
+
+        self._low_cutoff_check = QCheckBox("High-pass (Hz)")
+        self._low_cutoff_check.setToolTip(
+            "Attenuates frequencies below this cutoff (low_cutoff)."
+        )
+        self._low_cutoff_spin = _capped_spin(QDoubleSpinBox(), _SPIN_WIDTH_WIDE)
+        self._low_cutoff_spin.setRange(0.0, 100.0)
+        self._low_cutoff_spin.setDecimals(4)
+        self._low_cutoff_spin.setSingleStep(0.01)
+        self._low_cutoff_spin.setValue(0.01)
+        self._low_cutoff_spin.setEnabled(False)
+        self._low_cutoff_spin.setToolTip(
+            "Attenuates frequencies below this cutoff (low_cutoff)."
+        )
+        self._low_cutoff_check.toggled.connect(self._low_cutoff_spin.setEnabled)
+        cutoff_form.addRow(self._low_cutoff_check, self._low_cutoff_spin)
+
+        self._high_cutoff_check = QCheckBox("Low-pass (Hz)")
+        self._high_cutoff_check.setToolTip(
+            "Attenuates frequencies above this cutoff (high_cutoff)."
+        )
+        self._high_cutoff_spin = _capped_spin(QDoubleSpinBox(), _SPIN_WIDTH_WIDE)
+        self._high_cutoff_spin.setRange(0.0, 100.0)
+        self._high_cutoff_spin.setDecimals(4)
+        self._high_cutoff_spin.setSingleStep(0.01)
+        self._high_cutoff_spin.setValue(1.0)
+        self._high_cutoff_spin.setEnabled(False)
+        self._high_cutoff_spin.setToolTip(
+            "Attenuates frequencies above this cutoff (high_cutoff)."
+        )
+        self._high_cutoff_check.toggled.connect(self._high_cutoff_spin.setEnabled)
+        cutoff_form.addRow(self._high_cutoff_check, self._high_cutoff_spin)
+        group_layout.addLayout(cutoff_form)
+
+        # Foldable advanced section, matching the registration panel's pattern
+        # (PR #216): a checkable QToolButton with an arrow indicator toggles a
+        # QFormLayout indented underneath, collapsed by default.
+        advanced_header = QWidget()
+        advanced_header_layout = QHBoxLayout(advanced_header)
+        advanced_header_layout.setContentsMargins(0, 0, 0, 0)
+        advanced_header_layout.setSpacing(6)
+        self._advanced_toggle = QToolButton()
+        self._advanced_toggle.setCheckable(True)
+        self._advanced_toggle.setAutoRaise(True)
+        self._advanced_toggle.setToolButtonStyle(
+            Qt.ToolButtonStyle.ToolButtonTextBesideIcon
+        )
+        self._advanced_toggle.setText("Advanced")
+        self._advanced_toggle.setArrowType(Qt.ArrowType.RightArrow)
+        self._advanced_toggle.toggled.connect(self._on_advanced_toggled)
+        advanced_header_layout.addWidget(self._advanced_toggle)
+        advanced_header_layout.addStretch(1)
+        group_layout.addWidget(advanced_header)
+
+        # Every row below sets its own tooltip on both the label and the field:
+        # Qt forwards an unhandled ToolTip event to the parent widget, so a
+        # tooltip-less child here would otherwise show this group's tooltip
+        # ("Zero-phase Butterworth...") instead of its own.
+        self._advanced_widget = QWidget()
+        advanced_form = _wrap_form(QFormLayout(self._advanced_widget))
+        advanced_form.setContentsMargins(9, 6, 0, 0)
+        advanced_form.setSpacing(4)
+
+        self._filter_order_spin = _capped_spin(QSpinBox())
+        self._filter_order_spin.setRange(1, 20)
+        self._filter_order_spin.setValue(5)
+        order_tooltip = (
+            "Filter order. Higher orders give steeper roll-off but may be less stable."
+        )
+        self._filter_order_spin.setToolTip(order_tooltip)
+        advanced_form.addRow(
+            _form_label("Order", tooltip=order_tooltip), self._filter_order_spin
+        )
+
+        self._padtype_combo = _narrow_combo(QComboBox(), _COMBO_CHARS_NARROW)
+        self._padtype_combo.addItems(["odd", "even", "constant", "None"])
+        padtype_tooltip = (
+            "Type of padding applied at each end before filtering, to reduce edge "
+            "effects. 'None' disables padding."
+        )
+        self._padtype_combo.setToolTip(padtype_tooltip)
+        advanced_form.addRow(
+            _form_label("Pad type", tooltip=padtype_tooltip), self._padtype_combo
+        )
+
+        self._padlen_spin = _capped_spin(QSpinBox(), _SPIN_WIDTH_WIDE)
+        self._padlen_spin.setRange(0, 10000)
+        self._padlen_spin.setSpecialValueText("Auto")
+        padlen_tooltip = (
+            "Number of samples to pad at each end. Auto uses scipy's default "
+            "padding length."
+        )
+        self._padlen_spin.setToolTip(padlen_tooltip)
+        advanced_form.addRow(
+            _form_label("Pad length", tooltip=padlen_tooltip), self._padlen_spin
+        )
+
+        self._uniformity_tolerance_spin = _capped_spin(
+            QDoubleSpinBox(), _SPIN_WIDTH_WIDE
+        )
+        self._uniformity_tolerance_spin.setRange(1e-6, 1.0)
+        self._uniformity_tolerance_spin.setDecimals(6)
+        self._uniformity_tolerance_spin.setSingleStep(0.001)
+        self._uniformity_tolerance_spin.setValue(1e-2)
+        tolerance_tooltip = (
+            "Maximum allowed relative deviation between consecutive time "
+            "intervals. Increase to tolerate slight timestamp jitter (e.g. from "
+            "acquisition clocks or dropped volumes)."
+        )
+        self._uniformity_tolerance_spin.setToolTip(tolerance_tooltip)
+        advanced_form.addRow(
+            _form_label("Timing tolerance", tooltip=tolerance_tooltip),
+            self._uniformity_tolerance_spin,
+        )
+
+        group_layout.addWidget(self._advanced_widget)
+        self._advanced_widget.hide()
+
+        return group
+
+    def _make_standardize_group(self) -> QGroupBox:
+        group = QGroupBox("Standardization")
+        group_layout = QVBoxLayout(group)
+        self._standardize_combo = _narrow_combo(QComboBox(), _COMBO_CHARS_WIDE)
+        self._standardize_combo.addItems(list(_STANDARDIZE_LABELS))
+        group_layout.addWidget(self._standardize_combo)
+        return group
+
+    def _make_confounds_group(self) -> QGroupBox:
+        group = QGroupBox("Confound Regression")
+        group_layout = QVBoxLayout(group)
+        group_layout.setSpacing(4)
+
+        confound_tooltip = (
+            "Stored or live (point/label) signals to regress out together as "
+            "nuisance confounds. Click, Ctrl/Shift-click, or drag to select "
+            "several at once (e.g. a batch of CompCor components)."
+        )
+        group.setToolTip(confound_tooltip)
+        self._confounds_list = QListWidget()
+        self._confounds_list.setToolTip(confound_tooltip)
+        self._confounds_list.setSelectionMode(
+            QAbstractItemView.SelectionMode.ExtendedSelection
+        )
+        # Tall enough for a handful of items without eating the whole sidebar;
+        # the list itself scrolls once there are more.
+        self._confounds_list.setMaximumHeight(110)
+        group_layout.addWidget(self._confounds_list)
+
+        group_layout.addWidget(self._make_compcor_subgroup())
+        return group
+
+    def _make_compcor_subgroup(self) -> QGroupBox:
+        group = QGroupBox("CompCor")
+        group.setToolTip(
+            "Compute noise components with confusius.signal.compute_compcor_confounds "
+            "and store each one, selectable above as a confound."
+        )
+        layout = QVBoxLayout(group)
+        layout.setSpacing(4)
+
+        form = _wrap_form(QFormLayout())
+        form.setSpacing(4)
+
+        self._compcor_mask_combo = _narrow_combo(QComboBox(), _COMBO_CHARS_MEDIUM)
+        mask_tooltip = (
+            "Labels layer marking the noise region (e.g. white matter or CSF)."
+        )
+        self._compcor_mask_combo.setToolTip(mask_tooltip)
+        form.addRow(
+            _form_label("Noise mask", tooltip=mask_tooltip), self._compcor_mask_combo
+        )
+
+        self._compcor_variance_check = QCheckBox("Variance threshold")
+        self._compcor_variance_spin = _capped_spin(QDoubleSpinBox(), _SPIN_WIDTH_WIDE)
+        self._compcor_variance_spin.setRange(0.001, 0.999)
+        self._compcor_variance_spin.setDecimals(3)
+        self._compcor_variance_spin.setSingleStep(0.01)
+        self._compcor_variance_spin.setValue(0.02)
+        self._compcor_variance_spin.setEnabled(False)
+        variance_tooltip = (
+            "Select the top fraction of highest-variance voxels — within the "
+            "noise mask if one is set, otherwise across the whole volume "
+            "(tCompCor)."
+        )
+        self._compcor_variance_check.setToolTip(variance_tooltip)
+        self._compcor_variance_spin.setToolTip(variance_tooltip)
+        self._compcor_variance_check.toggled.connect(
+            self._compcor_variance_spin.setEnabled
+        )
+        form.addRow(self._compcor_variance_check, self._compcor_variance_spin)
+
+        self._compcor_components_spin = _capped_spin(QSpinBox())
+        self._compcor_components_spin.setRange(1, 20)
+        self._compcor_components_spin.setValue(5)
+        form.addRow(_form_label("Components"), self._compcor_components_spin)
+        layout.addLayout(form)
+
+        self._compcor_btn = QPushButton("Compute CompCor confounds")
+        self._compcor_btn.setToolTip(
+            "Resample/smooth the source layer (as currently configured above) and "
+            "extract noise components, stored as selectable confound signals."
+        )
+        self._compcor_btn.clicked.connect(self._compute_compcor)
+        layout.addWidget(self._compcor_btn)
+
+        # A busy indicator right here, not just the shared one below the (possibly
+        # scrolled-out-of-view) Apply button, so computing CompCor confounds stays
+        # visibly in progress right where it was triggered.
+        self._compcor_progress = QProgressBar()
+        self._compcor_progress.setRange(0, 0)
+        self._compcor_progress.setMaximumHeight(4)
+        self._compcor_progress.hide()
+        layout.addWidget(self._compcor_progress)
+
+        return group
+
+    def _make_scrub_group(self) -> QGroupBox:
+        group = QGroupBox("Scrubbing")
+        group_layout = QVBoxLayout(group)
+        group_layout.setSpacing(4)
+
+        form = _wrap_form(QFormLayout())
+        form.setSpacing(4)
+        self._mask_combo = _narrow_combo(QComboBox(), _COMBO_CHARS_MEDIUM)
+        mask_tooltip = (
+            "Stored or live (point/label) signal turned into a keep/censor mask, "
+            "either directly (already binary) or by thresholding a continuous "
+            "metric such as framewise displacement."
+        )
+        self._mask_combo.setToolTip(mask_tooltip)
+        form.addRow(_form_label("Sample mask", tooltip=mask_tooltip), self._mask_combo)
+
+        self._mask_mode_combo = _narrow_combo(QComboBox(), _COMBO_CHARS_WIDE)
+        self._mask_mode_combo.addItems(
+            [_MASK_ALREADY_BINARY, _MASK_KEEP_ABOVE, _MASK_KEEP_BELOW]
+        )
+        mask_mode_tooltip = (
+            "How to turn the selected signal into a keep/censor mask: use it as-is "
+            "(nonzero = keep), or threshold a continuous metric."
+        )
+        self._mask_mode_combo.setToolTip(mask_mode_tooltip)
+        self._mask_mode_combo.currentTextChanged.connect(self._on_mask_mode_changed)
+        form.addRow(
+            _form_label("Mask mode", tooltip=mask_mode_tooltip), self._mask_mode_combo
+        )
+
+        self._mask_threshold_spin = _capped_spin(QDoubleSpinBox(), _SPIN_WIDTH_WIDE)
+        self._mask_threshold_spin.setRange(-1e6, 1e6)
+        self._mask_threshold_spin.setDecimals(4)
+        self._mask_threshold_spin.setSingleStep(0.01)
+        threshold_tooltip = "Threshold compared against the (aligned) signal's values."
+        self._mask_threshold_spin.setToolTip(threshold_tooltip)
+        self._mask_threshold_spin.setEnabled(False)
+        form.addRow(
+            _form_label("Mask threshold", tooltip=threshold_tooltip),
+            self._mask_threshold_spin,
+        )
+
+        self._interpolate_method_combo = _narrow_combo(QComboBox(), _COMBO_CHARS_NARROW)
+        self._interpolate_method_combo.addItems(list(_INTERPOLATE_METHODS))
+        interp_tooltip = (
+            "Interpolation method used to fill censored samples before "
+            "detrending/filtering."
+        )
+        self._interpolate_method_combo.setToolTip(interp_tooltip)
+        form.addRow(
+            _form_label("Interpolation", tooltip=interp_tooltip),
+            self._interpolate_method_combo,
+        )
+        group_layout.addLayout(form)
+
+        self._ensure_finite_check = QCheckBox("Interpolate Inf/Nan")
+        self._ensure_finite_check.setToolTip(
+            "Repair non-finite values in the signals (and confounds) by "
+            "interpolating along time before cleaning."
+        )
+        group_layout.addWidget(self._ensure_finite_check)
+        return group
+
+    # ------------------------------------------------------------------
+    # Layer / signal list helpers
+    # ------------------------------------------------------------------
+
+    def _eligible_source_layers(self) -> list[str]:
+        """Return names of image layers with a multi-element `time` dimension."""
+        names = []
+        for layer in self._viewer.layers:
+            if layer._type_string != "image":
+                continue
+            da = layer.metadata.get("xarray")
+            if da is not None and TIME_DIM in da.dims and da.sizes[TIME_DIM] > 1:
+                names.append(layer.name)
+        return names
+
+    def _eligible_mask_layers(self) -> list[str]:
+        """Return names of Labels layers in the viewer."""
+        return [
+            layer.name
+            for layer in self._viewer.layers
+            if layer._type_string == "labels"
+        ]
+
+    def _refresh_layer_combos(self, _event=None) -> None:
+        """Repopulate the source, resample-reference, and CompCor mask combos."""
+        names = self._eligible_source_layers()
+        for combo in (self._source_combo, self._resample_reference_combo):
+            current = combo.currentText()
+            combo.blockSignals(True)
+            try:
+                combo.clear()
+                combo.addItems(names)
+                index = combo.findText(current)
+                if index >= 0:
+                    combo.setCurrentIndex(index)
+            finally:
+                combo.blockSignals(False)
+
+        mask_names = self._eligible_mask_layers()
+        current_mask = self._compcor_mask_combo.currentText()
+        self._compcor_mask_combo.blockSignals(True)
+        try:
+            self._compcor_mask_combo.clear()
+            self._compcor_mask_combo.addItem(_NO_SIGNAL)
+            self._compcor_mask_combo.addItems(mask_names)
+            index = self._compcor_mask_combo.findText(current_mask)
+            self._compcor_mask_combo.setCurrentIndex(max(index, 0))
+        finally:
+            self._compcor_mask_combo.blockSignals(False)
+
+        self._prefill_resample_defaults()
+
+    def _refresh_signal_combos(self) -> None:
+        """Repopulate the confounds list and sample-mask combo from stored/live signals."""
+        names = [signal.name for signal in self._signal_store.stored_signals()]
+        names += [
+            live.name
+            for live in self._signal_store.live_signals()
+            if live.source_type != "mouse"
+        ]
+
+        selected = set(self._selected_confound_names())
+        self._confounds_list.clear()
+        for name in names:
+            item = QListWidgetItem(name)
+            self._confounds_list.addItem(item)
+            item.setSelected(name in selected)
+
+        current_mask = self._mask_combo.currentText()
+        self._mask_combo.blockSignals(True)
+        try:
+            self._mask_combo.clear()
+            self._mask_combo.addItem(_NO_SIGNAL)
+            self._mask_combo.addItems(names)
+            index = self._mask_combo.findText(current_mask)
+            self._mask_combo.setCurrentIndex(max(index, 0))
+        finally:
+            self._mask_combo.blockSignals(False)
+
+    def _selected_confound_names(self) -> list[str]:
+        """Return the names of every currently selected confound signal."""
+        return [item.text() for item in self._confounds_list.selectedItems()]
+
+    def _prefill_resample_defaults(self, _text: str = "") -> None:
+        """Prefill the uniform-grid step from the source layer's median spacing."""
+        layer_name = self._source_combo.currentText()
+        if not layer_name:
+            return
+        try:
+            layer = self._viewer.layers[layer_name]
+        except KeyError:
+            return
+
+        da = layer.metadata.get("xarray")
+        if da is None or TIME_DIM not in da.coords:
+            return
+
+        time_values = np.asarray(da.coords[TIME_DIM].values)
+        if len(time_values) < 2:
+            return
+
+        step, _approximate = get_representative_step(time_values)
+        if step is not None:
+            self._resample_step_spin.setValue(float(step))
+
+    def _on_resample_mode_changed(self, mode: str) -> None:
+        self._uniform_widget.setVisible(mode == _UNIFORM_GRID)
+        self._reference_widget.setVisible(mode == _MATCH_REFERENCE)
+        self._resample_method_widget.setVisible(mode != _NO_RESAMPLING)
+
+    def _on_advanced_toggled(self, checked: bool) -> None:
+        self._advanced_widget.setVisible(checked)
+        self._advanced_toggle.setArrowType(
+            Qt.ArrowType.DownArrow if checked else Qt.ArrowType.RightArrow
+        )
+
+    def _on_mask_mode_changed(self, mode: str) -> None:
+        self._mask_threshold_spin.setEnabled(mode != _MASK_ALREADY_BINARY)
+
+    # ------------------------------------------------------------------
+    # Busy helpers
+    # ------------------------------------------------------------------
+
+    def _begin_work(self, button: QPushButton) -> None:
+        """Disable the Apply/Compute-CompCor buttons and show the busy state.
+
+        Both buttons are disabled regardless of which one triggered the work,
+        since both run in the background. Only the triggering button's own busy
+        indicator is shown, so it stays visible next to whichever action is
+        actually running instead of only at the bottom of the panel.
+        """
+        self._apply_btn.setEnabled(False)
+        self._compcor_btn.setEnabled(False)
+        self._working_button = button
+        self._working_button_text = button.text()
+        button.setText("Working…")
+        if button is self._compcor_btn:
+            self._compcor_progress.show()
+        else:
+            self._progress.show()
+
+    def _end_work(self) -> None:
+        self._apply_btn.setEnabled(True)
+        self._compcor_btn.setEnabled(True)
+        if self._working_button is not None:
+            self._working_button.setText(self._working_button_text)
+        self._progress.hide()
+        self._compcor_progress.hide()
+
+    # ------------------------------------------------------------------
+    # Source lookup
+    # ------------------------------------------------------------------
+
+    def _get_source(
+        self, combo: QComboBox, *, label: str = "source"
+    ) -> tuple[str, xr.DataArray] | None:
+        """Look up the layer selected in `combo` and its DataArray metadata.
+
+        Parameters
+        ----------
+        combo : QComboBox
+            Combo box to read the layer name from.
+        label : str, default: "source"
+            Noun used in the "No {label} layer selected." error message.
+
+        Returns
+        -------
+        tuple[str, xarray.DataArray] or None
+            `(layer_name, dataarray)`, or `None` (after calling `show_error`) if no
+            layer is selected or it carries no DataArray metadata.
+        """
+        layer_name = combo.currentText()
+        if not layer_name:
+            show_error(f"No {label} layer selected.")
+            return None
+
+        layer = self._viewer.layers[layer_name]
+        da = layer.metadata.get("xarray")
+        if da is None:
+            show_error(
+                "Selected layer has no DataArray metadata. "
+                "Load the file using the Data panel or the File menu."
+            )
+            return None
+        return layer_name, da
+
+    # ------------------------------------------------------------------
+    # Confound / sample-mask resolution
+    # ------------------------------------------------------------------
+
+    def _extract_live_series(self, live: LiveSignal, image_layer) -> _RawSignal | None:
+        """Re-extract a live signal's raw trace against `image_layer`.
+
+        Parameters
+        ----------
+        live : LiveSignal
+            Live signal to extract. Must be of type `"point"` or `"label"`.
+        image_layer : napari.layers.Image
+            Image layer to pull voxel intensities from (the Preprocessing panel's
+            selected source layer, not necessarily the layer the signal was
+            plotted against in the Signals panel).
+
+        Returns
+        -------
+        tuple[numpy.ndarray or None, numpy.ndarray] or None
+            `(time_values_or_none, trace)`, or `None` if the backing Points/Labels
+            layer no longer exists, the point index is out of range, or no voxel
+            matches the label.
+        """
+        if live.layer_name is None:
+            return None
+        try:
+            spatial_layer = self._viewer.layers[live.layer_name]
+        except KeyError:
+            return None
+
+        da = image_layer.metadata.get("xarray")
+        xaxis_index = (
+            list(da.dims).index(TIME_DIM)
+            if da is not None and TIME_DIM in da.dims
+            else 0
+        )
+        x = (
+            np.asarray(da.coords[TIME_DIM].values)
+            if da is not None and TIME_DIM in da.coords
+            else None
+        )
+
+        if live.source_type == "point":
+            point_index = live.source_id
+            if point_index is None or point_index >= len(spatial_layer.data):
+                return None
+            pt_data = np.asarray(spatial_layer.data[point_index], dtype=float)
+            n_pt = len(pt_data)
+            scale = np.asarray(spatial_layer.scale, dtype=float)[-n_pt:]
+            translate = np.asarray(spatial_layer.translate, dtype=float)[-n_pt:]
+            pt_world = pt_data * scale + translate
+            img_ndim = image_layer.data.ndim
+            if n_pt < img_ndim:
+                padded = np.zeros(img_ndim)
+                padded[-n_pt:] = pt_world
+                pt_world = padded
+            y = extract_voxel_trace(image_layer, pt_world, xaxis_index)
+        elif live.source_type == "label":
+            label_id = live.source_id
+            if label_id is None:
+                return None
+            y = extract_label_mean_trace(
+                image_layer, np.asarray(spatial_layer.data), label_id, xaxis_index
+            )
+        else:
+            return None
+
+        if y is None:
+            return None
+        return x, y
+
+    def _resolve_raw_signal(self, name: str, source_layer) -> _RawSignal | None:
+        """Look up a confound/mask signal by name and return its raw `(x, y)` trace.
+
+        Parameters
+        ----------
+        name : str
+            Combo box selection. `"None"` (or empty) resolves to `None`.
+        source_layer : napari.layers.Image
+            Currently selected source layer, used as the reference image when the
+            named signal is a live point/label signal.
+
+        Returns
+        -------
+        tuple[numpy.ndarray or None, numpy.ndarray] or None
+            Raw, unaligned `(x, y)` signal, or `None` if no signal was selected.
+
+        Raises
+        ------
+        ValueError
+            If the named signal cannot be found, or a live signal's trace could
+            not be re-extracted.
+        """
+        if not name or name == _NO_SIGNAL:
+            return None
+
+        for signal in self._signal_store.stored_signals():
+            if signal.name == name:
+                return signal.x, signal.y
+
+        for live in self._signal_store.live_signals():
+            if live.name == name and live.source_type != "mouse":
+                extracted = self._extract_live_series(live, source_layer)
+                if extracted is None:
+                    raise ValueError(
+                        f"Could not extract signal {name!r} from layer "
+                        f"{source_layer.name!r}."
+                    )
+                return extracted
+
+        raise ValueError(f"Signal {name!r} not found.")
+
+    def _build_mask_spec(self, source_layer) -> _MaskSpec | None:
+        """Resolve the sample-mask combo/mode/threshold controls into a `_MaskSpec`.
+
+        Parameters
+        ----------
+        source_layer : napari.layers.Image
+            Currently selected source layer, forwarded to `_resolve_raw_signal`.
+
+        Returns
+        -------
+        _MaskSpec or None
+            `None` if no sample-mask signal is selected.
+        """
+        raw = self._resolve_raw_signal(self._mask_combo.currentText(), source_layer)
+        if raw is None:
+            return None
+        x, y = raw
+        mode = self._mask_mode_combo.currentText()
+        if mode == _MASK_ALREADY_BINARY:
+            return _MaskSpec(x, y, threshold=None, keep_above=True)
+        return _MaskSpec(
+            x,
+            y,
+            threshold=self._mask_threshold_spin.value(),
+            keep_above=mode == _MASK_KEEP_ABOVE,
+        )
+
+    # ------------------------------------------------------------------
+    # Pipeline
+    # ------------------------------------------------------------------
+
+    def _build_clean_kwargs(self) -> dict:
+        """Read the panel's controls into `confusius.signal.clean` keyword arguments."""
+        padtype_text = self._padtype_combo.currentText()
+        return {
+            "detrend_order": (
+                self._detrend_order_spin.value()
+                if self._detrend_check.isChecked()
+                else None
+            ),
+            "standardize_method": _STANDARDIZE_LABELS[
+                self._standardize_combo.currentText()
+            ],
+            "low_cutoff": (
+                self._low_cutoff_spin.value()
+                if self._low_cutoff_check.isChecked()
+                else None
+            ),
+            "high_cutoff": (
+                self._high_cutoff_spin.value()
+                if self._high_cutoff_check.isChecked()
+                else None
+            ),
+            "filter_method": "butterworth",
+            "filter_kwargs": {
+                "order": self._filter_order_spin.value(),
+                "padtype": None if padtype_text == "None" else padtype_text,
+                "padlen": self._padlen_spin.value() or None,
+                "uniformity_tolerance": self._uniformity_tolerance_spin.value(),
+            },
+            "standardize_confounds": True,
+            "ensure_finite": self._ensure_finite_check.isChecked(),
+            "interpolate_method": self._interpolate_method_combo.currentText(),
+        }
+
+    def _build_resample_spec(self) -> tuple[str, dict] | None:
+        """Read the resampling controls into a `(mode, kwargs)` pipeline spec.
+
+        Returns
+        -------
+        tuple[str, dict] or None
+            `None` if `"No resampling"` is selected.
+
+        Raises
+        ------
+        ValueError
+            If "Match reference layer" is selected but no valid reference layer
+            (with a `time` coordinate) is available.
+        """
+        mode = self._resample_mode_combo.currentText()
+        if mode == _NO_RESAMPLING:
+            return None
+
+        method = self._resample_method_combo.currentText()
+        if mode == _UNIFORM_GRID:
+            return _UNIFORM_GRID, {
+                "start": None,
+                "stop": None,
+                "step": self._resample_step_spin.value(),
+                "method": method,
+            }
+
+        # Look up the reference layer directly (rather than via _get_source) so a
+        # missing/invalid reference raises once here instead of also emitting its
+        # own show_error — _apply's except block is the single place that surfaces
+        # this failure to the user.
+        reference_name = self._resample_reference_combo.currentText()
+        if not reference_name:
+            raise ValueError("No reference layer selected.")
+        reference_da = self._viewer.layers[reference_name].metadata.get("xarray")
+        if reference_da is None:
+            raise ValueError(
+                "Reference layer has no DataArray metadata. "
+                "Load the file using the Data panel or the File menu."
+            )
+        if TIME_DIM not in reference_da.coords:
+            raise ValueError("Reference layer has no 'time' coordinate.")
+        return _MATCH_REFERENCE, {
+            "new_time": reference_da.coords[TIME_DIM].values,
+            "method": method,
+        }
+
+    def _build_smooth_kwargs(self) -> dict | None:
+        """Read the smoothing controls into `confusius.spatial.smooth_volume` kwargs.
+
+        Returns
+        -------
+        dict or None
+            `None` if smoothing is not enabled.
+        """
+        if not self._smooth_enable_check.isChecked():
+            return None
+        return {
+            "fwhm": self._smooth_fwhm_spin.value(),
+            "ensure_finite": self._smooth_ensure_finite_check.isChecked(),
+        }
+
+    def _compute_compcor(self) -> None:
+        """Resample/smooth the source layer and extract CompCor noise components.
+
+        Each resulting component is pinned into the shared `SignalStore` as its
+        own stored signal, immediately selectable in the Confound combo above —
+        re-running with the same source layer updates those signals in place
+        instead of duplicating them (see `SignalStore.pin_signal`).
+        """
+        source = self._get_source(self._source_combo)
+        if source is None:
+            return
+        layer_name, da = source
+
+        mask_name = self._compcor_mask_combo.currentText()
+        use_variance = self._compcor_variance_check.isChecked()
+        if (not mask_name or mask_name == _NO_SIGNAL) and not use_variance:
+            show_error("CompCor needs a noise mask, a variance threshold, or both.")
+            return
+
+        noise_mask = None
+        if mask_name and mask_name != _NO_SIGNAL:
+            try:
+                labels_layer = self._viewer.layers[mask_name]
+            except KeyError:
+                show_error(f"Labels layer {mask_name!r} not found.")
+                return
+            noise_mask = _build_noise_mask(da, np.asarray(labels_layer.data))
+            if noise_mask is None:
+                show_error(
+                    f"Labels layer {mask_name!r}'s spatial shape doesn't match "
+                    f"{layer_name!r}."
+                )
+                return
+
+        try:
+            resample_spec = self._build_resample_spec()
+        except ValueError as exc:
+            show_error(str(exc))
+            return
+        smooth_kwargs = self._build_smooth_kwargs()
+        variance_threshold = (
+            self._compcor_variance_spin.value() if use_variance else None
+        )
+        n_components = self._compcor_components_spin.value()
+
+        self._begin_work(self._compcor_btn)
+        worker = _run_compcor(
+            da,
+            resample_spec,
+            smooth_kwargs,
+            noise_mask,
+            variance_threshold,
+            n_components,
+        )
+        worker.yielded.connect(self._compcor_btn.setText)
+        worker.returned.connect(
+            lambda result: self._on_compcor_returned(result, layer_name)
+        )
+        worker.errored.connect(self._on_worker_error)
+        worker.start()
+
+    def _on_compcor_returned(self, result: xr.DataArray, layer_name: str) -> None:
+        """Pin each CompCor component into the shared store as a stored signal."""
+        try:
+            time_values = (
+                np.asarray(result.coords[TIME_DIM].values)
+                if TIME_DIM in result.coords
+                else np.arange(result.sizes[TIME_DIM], dtype=float)
+            )
+            for i in range(result.sizes["component"]):
+                self._signal_store.pin_signal(
+                    origin=f"compcor-{layer_name}-{i}",
+                    name=f"CompCor {i} ({layer_name})",
+                    x=time_values,
+                    y=np.asarray(result.isel(component=i).values, dtype=float),
+                    color=CATEGORICAL_COLORS[i % len(CATEGORICAL_COLORS)],
+                    source_label=f"CompCor from {layer_name}",
+                )
+        except Exception as exc:  # noqa: BLE001
+            show_error(str(exc))
+        finally:
+            self._end_work()
+
+    def _apply(self) -> None:
+        source = self._get_source(self._source_combo)
+        if source is None:
+            return
+        layer_name, da = source
+        layer = self._viewer.layers[layer_name]
+
+        try:
+            confounds_raw = [
+                raw
+                for name in self._selected_confound_names()
+                if (raw := self._resolve_raw_signal(name, layer)) is not None
+            ]
+            mask_raw = self._build_mask_spec(layer)
+            resample_spec = self._build_resample_spec()
+        except ValueError as exc:
+            show_error(str(exc))
+            return
+
+        smooth_kwargs = self._build_smooth_kwargs()
+        clean_kwargs = self._build_clean_kwargs()
+
+        standardized = clean_kwargs["standardize_method"] is not None
+
+        self._begin_work(self._apply_btn)
+        worker = _run_pipeline(
+            da, resample_spec, smooth_kwargs, clean_kwargs, confounds_raw, mask_raw
+        )
+        worker.returned.connect(
+            lambda result: self._on_pipeline_returned(result, layer_name, standardized)
+        )
+        worker.errored.connect(self._on_worker_error)
+        worker.start()
+
+    def _on_pipeline_returned(
+        self, result: xr.DataArray, layer_name: str, standardized: bool
+    ) -> None:
+        try:
+            if standardized:
+                # Z-scored/PSC output is centered on zero, so a diverging colormap
+                # with a symmetric range reads far better than the default
+                # sequential one (which would clip negative values to the same
+                # color as zero).
+                peak = float(np.nanmax(np.abs(np.asarray(result.values)))) or 1.0
+                plot_napari(
+                    result,
+                    viewer=self._viewer,
+                    name=f"{layer_name} — cleaned",
+                    colormap="twilight",
+                    contrast_limits=(-peak, peak),
+                )
+            else:
+                plot_napari(result, viewer=self._viewer, name=f"{layer_name} — cleaned")
+        except Exception as exc:  # noqa: BLE001
+            show_error(str(exc))
+        finally:
+            self._end_work()
+
+    def _on_worker_error(self, exc: Exception) -> None:
+        """Reset the busy state after a worker error.
+
+        Doesn't show the error itself: `@thread_worker` already relays any
+        exception raised inside the worker to napari's own notification
+        manager (see `napari._qt.qthreading._NotifyingMixin`), so doing it here
+        too would show the same error twice.
+        """
+        self._end_work()

--- a/src/confusius/_napari/_preprocessing/_panel.py
+++ b/src/confusius/_napari/_preprocessing/_panel.py
@@ -10,6 +10,7 @@ from typing import Literal, NamedTuple, TypeVar, cast
 import napari
 import numpy as np
 import xarray as xr
+from napari.layers import Layer
 from napari.qt.threading import thread_worker
 from napari.utils.notifications import show_error
 from qtpy.QtCore import Qt
@@ -1192,14 +1193,16 @@ class PreprocessingPanel(QWidget):
     # Confound / sample-mask resolution
     # ------------------------------------------------------------------
 
-    def _extract_live_series(self, live: LiveSignal, image_layer) -> _RawSignal | None:
+    def _extract_live_series(
+        self, live: LiveSignal, image_layer: Layer
+    ) -> _RawSignal | None:
         """Re-extract a live signal's raw trace against `image_layer`.
 
         Parameters
         ----------
         live : LiveSignal
             Live signal to extract. Must be of type `"point"` or `"label"`.
-        image_layer : napari.layers.Image
+        image_layer : Layer
             Image layer to pull voxel intensities from (the Preprocessing panel's
             selected source layer, not necessarily the layer the signal was
             plotted against in the Signals panel).
@@ -1259,14 +1262,14 @@ class PreprocessingPanel(QWidget):
             return None
         return x, y
 
-    def _resolve_raw_signal(self, name: str, source_layer) -> _RawSignal | None:
+    def _resolve_raw_signal(self, name: str, source_layer: Layer) -> _RawSignal | None:
         """Look up a confound/mask signal by name and return its raw `(x, y)` trace.
 
         Parameters
         ----------
         name : str
             Combo box selection. `"None"` (or empty) resolves to `None`.
-        source_layer : napari.layers.Image
+        source_layer : Layer
             Currently selected source layer, used as the reference image when the
             named signal is a live point/label signal.
 
@@ -1300,12 +1303,12 @@ class PreprocessingPanel(QWidget):
 
         raise ValueError(f"Signal {name!r} not found.")
 
-    def _build_mask_spec(self, source_layer) -> _MaskSpec | None:
+    def _build_mask_spec(self, source_layer: Layer) -> _MaskSpec | None:
         """Resolve the sample-mask combo/mode/threshold controls into a `_MaskSpec`.
 
         Parameters
         ----------
-        source_layer : napari.layers.Image
+        source_layer : Layer
             Currently selected source layer, forwarded to `_resolve_raw_signal`.
 
         Returns
@@ -1489,16 +1492,32 @@ class PreprocessingPanel(QWidget):
         worker.start()
 
     def _on_compcor_returned(self, result: xr.DataArray, layer_name: str) -> None:
-        """Pin each CompCor component into the shared store as a stored signal."""
+        """Pin each CompCor component into the shared store as a stored signal.
+
+        Recomputing with fewer components than a previous run drops the
+        now-unproduced trailing components from the store instead of leaving them
+        behind as stale signals.
+        """
         try:
+            n_components = result.sizes["component"]
+            origin_prefix = f"compcor-{layer_name}-"
+            stale_ids = [
+                signal.id
+                for signal in self._signal_store.stored_signals()
+                if signal.pin_origin is not None
+                and signal.pin_origin.startswith(origin_prefix)
+                and int(signal.pin_origin.removeprefix(origin_prefix)) >= n_components
+            ]
+            self._signal_store.remove_signals(stale_ids)
+
             time_values = (
                 np.asarray(result.coords[TIME_DIM].values)
                 if TIME_DIM in result.coords
                 else np.arange(result.sizes[TIME_DIM], dtype=float)
             )
-            for i in range(result.sizes["component"]):
+            for i in range(n_components):
                 self._signal_store.pin_signal(
-                    origin=f"compcor-{layer_name}-{i}",
+                    origin=f"{origin_prefix}{i}",
                     name=f"CompCor {i} ({layer_name})",
                     x=time_values,
                     y=np.asarray(result.isel(component=i).values, dtype=float),

--- a/src/confusius/_napari/_qc/_panel.py
+++ b/src/confusius/_napari/_qc/_panel.py
@@ -24,6 +24,8 @@ from qtpy.QtWidgets import (
 
 from confusius._dims import TIME_DIM
 from confusius._napari._qc._plots import QCPlotsWidget
+from confusius._napari._signals._store import SignalStore
+from confusius._napari._utils import CATEGORICAL_COLORS
 from confusius.plotting.image import _prepare_carpet_data
 from confusius.plotting.napari import plot_napari
 from confusius.qc import compute_cv, compute_dvars, compute_tsnr
@@ -76,11 +78,18 @@ class QCPanel(QWidget):
     ----------
     viewer : napari.Viewer
         The active napari viewer instance.
+    signal_store : SignalStore, optional
+        Shared store of stored/live signals. If provided, each computed DVARS trace
+        is also added there (as `"DVARS (<layer>)"`), making it selectable as a
+        Preprocessing panel confound/sample mask.
     """
 
-    def __init__(self, viewer: napari.Viewer) -> None:
+    def __init__(
+        self, viewer: napari.Viewer, signal_store: SignalStore | None = None
+    ) -> None:
         super().__init__()
         self.viewer = viewer
+        self._signal_store = signal_store
         # Cached reference to the inner plot widget (survives dock closure because
         # napari re-parents it to None rather than destroying it).
         self._qc_plots: QCPlotsWidget | None = None
@@ -352,6 +361,7 @@ class QCPanel(QWidget):
 
                 if "dvars" in results:
                     qc_widget.update_dvars(results["dvars"], layer_name=layer_name)
+                    self._store_dvars_signal(results["dvars"], layer_name)
 
                 if "carpet" in results:
                     qc_widget.update_carpet(results["carpet"], layer_name=layer_name)
@@ -387,6 +397,23 @@ class QCPanel(QWidget):
             show_error(str(exc))
         finally:
             self._end_work()
+
+    def _store_dvars_signal(self, dvars_da: xr.DataArray, layer_name: str) -> None:
+        """Add a computed DVARS trace to the shared signal store, if any.
+
+        Re-pinned under a `layer_name`-derived origin, so recomputing DVARS for the
+        same layer updates the stored signal in place instead of duplicating it.
+        """
+        if self._signal_store is None:
+            return
+        self._signal_store.pin_signal(
+            origin=f"dvars-{layer_name}",
+            name=f"DVARS ({layer_name})",
+            x=dvars_da.coords[TIME_DIM].values,
+            y=dvars_da.values,
+            color=CATEGORICAL_COLORS[0],
+            source_label=f"QC: {layer_name}",
+        )
 
     def _on_compute_error(self, exc: Exception) -> None:
         self._end_work()

--- a/src/confusius/_napari/_signals/_manager.py
+++ b/src/confusius/_napari/_signals/_manager.py
@@ -1,4 +1,4 @@
-"""Floating manager window for imported signals."""
+"""Floating manager window for stored signals."""
 
 from __future__ import annotations
 
@@ -21,6 +21,11 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
+from confusius._napari._export import (
+    ExportSignal,
+    prompt_delimited_export_path,
+    write_delimited_signals,
+)
 from confusius._napari._signals._store import LiveSignal, SignalStore
 from confusius._napari._theme import get_napari_colors
 
@@ -57,16 +62,17 @@ def _colored_button_style(r: int, g: int, b: int) -> str:
 
 
 class SignalsManagerDialog(QDialog):
-    """Modeless dialog for managing live and imported signals.
+    """Modeless dialog for managing live and stored signals.
 
     Live signals (from mouse, points, or labels layers) appear at the top of the table.
-    They can be renamed, recolored, and hidden but not removed. Imported signals appear
-    below and support the full set of operations.
+    They can be renamed, recolored, and hidden but not removed. Stored signals — either
+    imported from a file or pinned from a live signal — appear below and support the
+    full set of operations.
 
     Parameters
     ----------
     store : SignalStore
-        Shared imported-signals store.
+        Shared stored-signals store.
     parent : QWidget | None, optional
         Optional parent widget.
     """
@@ -95,14 +101,22 @@ class SignalsManagerDialog(QDialog):
         self._import_btn.clicked.connect(self._import_file)
         button_row.addWidget(self._import_btn)
 
+        self._export_btn = QPushButton("Export Selected")
+        self._export_btn.setToolTip(
+            "Export selected stored signals to a CSV or TSV file"
+        )
+        self._export_btn.setStyleSheet(_colored_button_style(80, 120, 200))
+        self._export_btn.clicked.connect(self._export_selected)
+        button_row.addWidget(self._export_btn)
+
         self._remove_btn = QPushButton("Remove")
-        self._remove_btn.setToolTip("Remove selected imported signal")
+        self._remove_btn.setToolTip("Remove selected stored signal")
         self._remove_btn.setStyleSheet(_colored_button_style(200, 80, 80))
         self._remove_btn.clicked.connect(self._remove_selected)
         button_row.addWidget(self._remove_btn)
 
-        self._clear_btn = QPushButton("Clear All Imported")
-        self._clear_btn.setToolTip("Remove all imported signals")
+        self._clear_btn = QPushButton("Clear All Stored")
+        self._clear_btn.setToolTip("Remove all stored signals")
         self._clear_btn.setStyleSheet(_colored_button_style(200, 80, 80))
         self._clear_btn.clicked.connect(self._store.clear)
         button_row.addWidget(self._clear_btn)
@@ -139,16 +153,16 @@ class SignalsManagerDialog(QDialog):
         self._updating_table = True
         try:
             live_list = self._store.live_signals()
-            imported_list = self._store.imported_signals()
-            total = len(live_list) + len(imported_list)
+            stored_list = self._store.stored_signals()
+            total = len(live_list) + len(stored_list)
             self._table.setRowCount(total)
 
             row = 0
             for signal in live_list:
                 self._set_live_row(row, signal)
                 row += 1
-            for signal in imported_list:
-                self._set_imported_row(row, signal)
+            for signal in stored_list:
+                self._set_stored_row(row, signal)
                 row += 1
         finally:
             self._updating_table = False
@@ -192,8 +206,8 @@ class SignalsManagerDialog(QDialog):
         source_item.setFont(italic_font)
         self._table.setItem(row, 3, source_item)
 
-    def _set_imported_row(self, row: int, signal) -> None:
-        """Populate one table row from an imported signal."""
+    def _set_stored_row(self, row: int, signal) -> None:
+        """Populate one table row from a stored signal."""
         visible_item = QTableWidgetItem()
         visible_item.setFlags(
             Qt.ItemFlag.ItemIsEnabled
@@ -275,7 +289,7 @@ class SignalsManagerDialog(QDialog):
             current = live.color if live is not None else "#ffffff"
         else:
             current = next(
-                (s.color for s in self._store.imported_signals() if s.id == signal_id),
+                (s.color for s in self._store.stored_signals() if s.id == signal_id),
                 "#ffffff",
             )
 
@@ -291,12 +305,17 @@ class SignalsManagerDialog(QDialog):
         except Exception as exc:  # noqa: BLE001
             show_error(str(exc))
 
-    def _remove_selected(self) -> None:
-        """Remove the currently selected imported signal (live signals are skipped)."""
+    def _selected_stored_ids(self) -> list[str]:
+        """Return ids of the currently selected stored (non-live) rows.
+
+        Live rows are skipped: the manager only tracks their presentation
+        metadata, not the underlying data, so they can't be removed or exported
+        from here.
+        """
         signal_ids = []
         selection_model = self._table.selectionModel()
         if selection_model is None:
-            return
+            return signal_ids
         rows = [index.row() for index in selection_model.selectedRows()]
         if not rows and self._table.currentRow() >= 0:
             rows = [self._table.currentRow()]
@@ -307,7 +326,41 @@ class SignalsManagerDialog(QDialog):
             signal_id = item.data(Qt.ItemDataRole.UserRole)
             if isinstance(signal_id, str) and not self._is_live_id(signal_id):
                 signal_ids.append(signal_id)
-        self._store.remove_signals(signal_ids)
+        return signal_ids
+
+    def _remove_selected(self) -> None:
+        """Remove the currently selected stored signal (live signals are skipped)."""
+        self._store.remove_signals(self._selected_stored_ids())
+
+    def _export_selected(self) -> None:
+        """Export the currently selected stored signals to a CSV or TSV file."""
+        signal_ids = self._selected_stored_ids()
+        stored_by_id = {s.id: s for s in self._store.stored_signals()}
+        export_signals = [
+            ExportSignal(
+                stored_by_id[sid].name, stored_by_id[sid].x, stored_by_id[sid].y
+            )
+            for sid in signal_ids
+            if sid in stored_by_id
+        ]
+        if not export_signals:
+            show_error("Select one or more stored signals to export.")
+            return
+
+        export_selection = prompt_delimited_export_path(
+            self, "Export Signals", str(Path.home() / "signals.tsv")
+        )
+        if export_selection is None:
+            return
+        path, delimiter = export_selection
+
+        try:
+            write_delimited_signals(path, export_signals, delimiter=delimiter)
+        except Exception as exc:  # noqa: BLE001
+            show_error(str(exc))
+            return
+
+        show_info(f"Exported signals to {path}")
 
     def _import_file(self) -> None:
         """Import one or more CSV or TSV files into the shared store."""

--- a/src/confusius/_napari/_signals/_panel.py
+++ b/src/confusius/_napari/_signals/_panel.py
@@ -45,17 +45,26 @@ class SignalPanel(QWidget):
         The active napari viewer instance.
     event_store : EventStore, optional
         Shared store of temporal events whose intervals are shaded on the plot.
+    signal_store : SignalStore, optional
+        Shared store of stored/live signals. If not provided, a private store is
+        created. Pass the same instance used elsewhere (e.g. the QC panel) so
+        stored signals are available across panels.
     """
 
     def __init__(
-        self, viewer: napari.Viewer, event_store: EventStore | None = None
+        self,
+        viewer: napari.Viewer,
+        event_store: EventStore | None = None,
+        signal_store: SignalStore | None = None,
     ) -> None:
         super().__init__()
         self._viewer = viewer
         self._event_store = event_store
         self._plotter: SignalPlotter | None = None
         self._signals_manager: SignalsManagerDialog | None = None
-        self._signals_store = SignalStore(self)
+        self._signals_store = (
+            signal_store if signal_store is not None else SignalStore(self)
+        )
         self._cached_xaxis_dim_index: int | None = None
         self._setup_ui()
         viewer.events.theme.connect(self._on_theme_changed)

--- a/src/confusius/_napari/_signals/_panel.py
+++ b/src/confusius/_napari/_signals/_panel.py
@@ -47,8 +47,8 @@ class SignalPanel(QWidget):
         Shared store of temporal events whose intervals are shaded on the plot.
     signal_store : SignalStore, optional
         Shared store of stored/live signals. If not provided, a private store is
-        created. Pass the same instance used elsewhere (e.g. the QC panel) so
-        stored signals are available across panels.
+        created. Pass the same instance used elsewhere (e.g. the QC panel or the
+        Preprocessing panel) so stored signals are available across panels.
     """
 
     def __init__(
@@ -67,6 +67,12 @@ class SignalPanel(QWidget):
         )
         self._cached_xaxis_dim_index: int | None = None
         self._setup_ui()
+        # Construct (but don't dock) the plotter immediately: live-signal
+        # extraction/registration happens as part of its rendering, so e.g.
+        # painting a Labels layer must register/update live signals in the shared
+        # store even if "Show Signal Plot" was never clicked.
+        self._ensure_plotter_instance()
+        self._sync_source_to_plotter()
         viewer.events.theme.connect(self._on_theme_changed)
 
     def _setup_ui(self) -> None:
@@ -276,12 +282,12 @@ class SignalPanel(QWidget):
         self._ymax_spin.setEnabled(not checked)
         self._apply_settings()
 
-    def _ensure_plotter(self) -> SignalPlotter:
-        """Return the bottom-dock SignalPlotter.
+    def _ensure_plotter_instance(self) -> SignalPlotter:
+        """Return the SignalPlotter, constructing it (undocked) on first call.
 
-        Creates and docks the widget on first call. If the dock was closed (the
-        plotter's parent becomes None after napari removes it), re-docks it. When the
-        plotter is already in a live dock this is a no-op.
+        Separate from `_ensure_plotter` so live-signal extraction/registration
+        (which happens as part of rendering) works even before the plot dock has
+        ever been shown.
         """
         if self._plotter is None:
             self._plotter = SignalPlotter(
@@ -290,11 +296,21 @@ class SignalPanel(QWidget):
                 event_store=self._event_store,
             )
             self._plotter.frame_clicked.connect(self._on_frame_clicked)
+        return self._plotter
 
-        if self._plotter.parent() is None:
+    def _ensure_plotter(self) -> SignalPlotter:
+        """Return the bottom-dock SignalPlotter.
+
+        Creates and docks the widget on first call. If the dock was closed (the
+        plotter's parent becomes None after napari removes it), re-docks it. When the
+        plotter is already in a live dock this is a no-op.
+        """
+        plotter = self._ensure_plotter_instance()
+
+        if plotter.parent() is None:
             # Widget is not docked, create (or re-create) the dock.
             dock = self._viewer.window.add_dock_widget(
-                self._plotter, name="Signal Plot", area="bottom"
+                plotter, name="Signal Plot", area="bottom"
             )
 
             # Disable the button while the dock is visible; re-enable on hide/close.
@@ -345,9 +361,9 @@ class SignalPanel(QWidget):
         self._apply_settings()
         self._sync_source_to_plotter()
         if self._cursor_check.isChecked():
-            self._plotter.set_xaxis_cursor(self._current_xaxis_world())
+            plotter.set_xaxis_cursor(self._current_xaxis_world())
 
-        return self._plotter
+        return plotter
 
     def _show_plot(self) -> None:
         """Show or re-dock the signal plot widget."""
@@ -708,17 +724,22 @@ class SignalPanel(QWidget):
     def _spatial_info(
         self,
     ) -> tuple[
-        tuple[int, ...] | None, tuple[float, ...] | None, tuple[float, ...] | None
+        tuple[int, ...] | None,
+        tuple[float, ...] | None,
+        tuple[float, ...] | None,
+        tuple | None,
     ]:
-        """Return (shape, scale, translate) for the spatial axes of the first signal layer.
+        """Return (shape, scale, translate, units) for the spatial axes of the first signal layer.
 
         Spatial axes are those named `z`, `y`, or `x` in the xarray metadata.
         This always covers the full spatial volume regardless of which dims are
         currently displayed or used as sliders.
 
-        All three values come from the *same* layer so they are guaranteed to
-        be consistent.  Returns `(None, None, None)` when no suitable layer
-        is found.
+        All four values come from the *same* layer so they are guaranteed to be
+        consistent — in particular, `units` must match the reference image layer's
+        so a new Points/Labels layer doesn't trigger napari's "Inconsistent units
+        across layers" warning. Returns `(None, None, None, None)` when no suitable
+        layer is found.
         """
         for layer in self._viewer.layers:
             if layer._type_string != "image":
@@ -735,27 +756,29 @@ class SignalPanel(QWidget):
                 shape = tuple(da.shape[i] for i in spatial_indices)
                 scale = tuple(float(layer.scale[i]) for i in spatial_indices)
                 translate = tuple(float(layer.translate[i]) for i in spatial_indices)
-                return shape, scale, translate
+                units = tuple(layer.units[i] for i in spatial_indices)
+                return shape, scale, translate, units
             # Fallback: treat dim 0 as the signal axis for 4D+ layers without xarray.
             if layer.data.ndim >= 4:
                 return (
                     layer.data.shape[1:],
                     tuple(float(s) for s in layer.scale[1:]),
                     tuple(float(t) for t in layer.translate[1:]),
+                    tuple(layer.units[1:]),
                 )
-        return None, None, None
+        return None, None, None, None
 
     def _create_points_layer(self) -> None:
         """Add a new 3D Points layer (no time axis) to the viewer.
 
         The layer is initialised with no points and `out_of_slice_display` enabled so
-        that added points are always visible regardless of the current time step. Scale
-        and translate are copied from the reference image so the layer is aligned and
-        brush/point sizes match the data.
+        that added points are always visible regardless of the current time step. Scale,
+        translate, and units are copied from the reference image so the layer is
+        aligned and brush/point sizes match the data.
         """
         import numpy as np
 
-        shape, scale, translate = self._spatial_info()
+        shape, scale, translate, units = self._spatial_info()
         ndim = len(shape) if shape is not None else 3
         kwargs: dict = {}
         if scale is not None:
@@ -765,6 +788,8 @@ class SignalPanel(QWidget):
             kwargs["size"] = 2.0
         if translate is not None:
             kwargs["translate"] = translate
+        if units is not None:
+            kwargs["units"] = units
         layer = self._viewer.add_points(  # type: ignore
             np.empty((0, ndim)),
             name="Points (3D)",
@@ -776,19 +801,21 @@ class SignalPanel(QWidget):
     def _create_labels_layer(self) -> None:
         """Add a new 3D Labels layer (no time axis) to the viewer.
 
-        Shape, scale, and translate are derived from the first image layer with
-        xarray metadata so the labels are pixel-aligned with the image and the
+        Shape, scale, translate, and units are derived from the first image layer
+        with xarray metadata so the labels are pixel-aligned with the image and the
         paint brush maps to the correct voxel positions.
         """
         import numpy as np
 
-        shape, scale, translate = self._spatial_info()
+        shape, scale, translate, units = self._spatial_info()
         shape = shape or (64, 64, 64)
         kwargs: dict = {}
         if scale is not None:
             kwargs["scale"] = scale
         if translate is not None:
             kwargs["translate"] = translate
+        if units is not None:
+            kwargs["units"] = units
         self._viewer.add_labels(  # type: ignore
             np.zeros(shape, dtype=np.int32),
             name="Labels (3D)",

--- a/src/confusius/_napari/_signals/_plotter.py
+++ b/src/confusius/_napari/_signals/_plotter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, cast
 
@@ -14,6 +15,7 @@ from matplotlib.backends.backend_qtagg import NavigationToolbar2QT as Navigation
 from matplotlib.figure import Figure
 from napari.utils.colormaps import DirectLabelColormap
 from napari.utils.colormaps.standardize_color import transform_color
+from napari.utils.key_bindings import coerce_keybinding
 from napari.utils.notifications import show_error, show_info
 from qtpy.QtCore import QSize, QTimer, Signal
 from qtpy.QtWidgets import QSizePolicy, QVBoxLayout, QWidget
@@ -148,6 +150,21 @@ class SignalPlotter(QWidget):
         self._cursor_timer.setInterval(16)  # ms → ~60 fps
         self._cursor_timer.timeout.connect(self._flush_cursor)
 
+        # Throttle mouse-source updates to ~60 fps, leading-edge: process
+        # immediately when the last update was long enough ago (the common case,
+        # zero added latency), and otherwise schedule a single trailing update so
+        # the final cursor position still gets rendered once a fast burst of
+        # events (which would otherwise pile up faster than a redraw completes)
+        # subsides, rather than queuing every intermediate position.
+        self._mouse_update_min_interval_s = 1 / 60
+        self._last_mouse_update_time: float = 0.0
+        self._mouse_update_timer = QTimer(self)
+        self._mouse_update_timer.setSingleShot(True)
+        self._mouse_update_timer.timeout.connect(self._flush_mouse_update)
+
+        # Previous keymap handler displaced by binding Shift, restored on close.
+        self._displaced_shift_key = None
+
         self.setSizePolicy(
             QSizePolicy.Policy.Expanding,
             QSizePolicy.Policy.Expanding,
@@ -216,6 +233,61 @@ class SignalPlotter(QWidget):
         self._viewer.layers.events.inserted.connect(self._on_layer_change)
         self._viewer.layers.events.removed.connect(self._on_layer_change)
         self._viewer.layers.selection.events.active.connect(self._on_layer_change)
+        self._bind_shift_key()
+
+    def _bind_shift_key(self) -> None:
+        """Bind Shift in the napari keymap to plot the signal at the resting cursor.
+
+        Lets the user press Shift while the cursor is already stationary over an
+        image layer, instead of requiring mouse movement while Shift is held.
+        Any handler already bound to Shift is saved first so it can be restored
+        when the plotter closes.
+        """
+        keybinding = coerce_keybinding("Shift")
+        self._displaced_shift_key = self._viewer.keymap.get(keybinding)
+        self._viewer.bind_key("Shift", self._on_shift_pressed, overwrite=True)
+
+    def _unbind_shift_key(self) -> None:
+        """Restore the keymap entry displaced by `_bind_shift_key`."""
+        keybinding = coerce_keybinding("Shift")
+        if self._displaced_shift_key is not None:
+            self._viewer.keymap[keybinding] = self._displaced_shift_key
+        else:
+            self._viewer.keymap.pop(keybinding, None)
+        self._displaced_shift_key = None
+
+    def _on_shift_pressed(self, viewer: napari.Viewer) -> None:
+        """Plot the signal at the current cursor position when Shift is pressed."""
+        if self._source_mode != "mouse":
+            return
+        layer = self._active_layer()
+        if layer is None:
+            return
+        self._current_layer = layer
+        self._cursor_pos = np.array(viewer.cursor.position)
+        self._schedule_mouse_update()
+
+    def _schedule_mouse_update(self) -> None:
+        """Throttle mouse-source plot updates to ~60 updates per second.
+
+        Leading-edge: updates immediately if the minimum interval has already
+        elapsed, otherwise schedules exactly one trailing update for when it
+        will have elapsed, so a fast burst of events collapses to at most one
+        pending update instead of one call per event.
+        """
+        now = time.monotonic()
+        elapsed = now - self._last_mouse_update_time
+        if elapsed >= self._mouse_update_min_interval_s:
+            self._last_mouse_update_time = now
+            self._update_plot()
+        elif not self._mouse_update_timer.isActive():
+            remaining_ms = round((self._mouse_update_min_interval_s - elapsed) * 1000)
+            self._mouse_update_timer.start(max(remaining_ms, 0))
+
+    def _flush_mouse_update(self) -> None:
+        """Run the trailing update scheduled by `_schedule_mouse_update`."""
+        self._last_mouse_update_time = time.monotonic()
+        self._update_plot()
 
     def _get_colors(self) -> dict:
         """Get current theme colors."""
@@ -469,7 +541,7 @@ class SignalPlotter(QWidget):
         self._current_layer = layer
         # Store raw cursor position, rounding happens during data extraction.
         self._cursor_pos = np.array(viewer.cursor.position)
-        self._update_plot()
+        self._schedule_mouse_update()
 
     def _on_layer_change(self, event) -> None:
         """Handle layer insertion/removal or active-layer change events.
@@ -1379,6 +1451,26 @@ class SignalPlotter(QWidget):
         """
         return [ExportSignal(s.label, s.x_values, s.y_values) for s in signals]
 
+    def _set_ylim_from_data(
+        self, ts: np.ndarray, imported_signals: list[PlotSignal]
+    ) -> None:
+        """Autoscale the y-axis from already-extracted arrays.
+
+        Used by the mouse fast path instead of matplotlib's `relim()`/
+        `autoscale_view()`, which re-derive the data extent from every plotted
+        `Line2D` artist on every call — redundant work here since we already hold
+        the live and imported arrays as numpy arrays. Matches matplotlib's default
+        5% autoscale margin.
+        """
+        arrays = [ts, *(s.y_values for s in imported_signals)]
+        y = np.concatenate(arrays) if len(arrays) > 1 else arrays[0]
+        finite = y[np.isfinite(y)]
+        if finite.size == 0:
+            return
+        ymin, ymax = float(finite.min()), float(finite.max())
+        margin = (ymax - ymin) * 0.05 or (abs(ymin) * 0.05 or 0.5)
+        self._axes.set_ylim(ymin - margin, ymax + margin)
+
     def _try_fast_mouse_update(
         self,
         *,
@@ -1419,10 +1511,9 @@ class SignalPlotter(QWidget):
 
         self._update_legend_if_needed(colors, live_label, imported_signals)
 
-        self._axes.relim()
         self._restore_view(saved_xlim, saved_ylim)
         if self._autoscale:
-            self._axes.autoscale_view(scalex=False, scaley=True)
+            self._set_ylim_from_data(ts, imported_signals)
 
         self._has_plot = True
         self._prev_ts_valid = True
@@ -2021,6 +2112,7 @@ class SignalPlotter(QWidget):
         """
         if self._on_mouse_move in self._viewer.mouse_move_callbacks:
             self._viewer.mouse_move_callbacks.remove(self._on_mouse_move)
+        self._unbind_shift_key()
         if self._signals_store is not None:
             try:
                 self._signals_store.plot_data_changed.disconnect(

--- a/src/confusius/_napari/_signals/_plotter.py
+++ b/src/confusius/_napari/_signals/_plotter.py
@@ -39,6 +39,7 @@ from confusius._napari._theme import (
     style_export_button,
     style_plot_toolbar,
 )
+from confusius._napari._utils import extract_voxel_trace
 
 if TYPE_CHECKING:
     from confusius._napari._events._store import EventStore
@@ -981,22 +982,7 @@ class SignalPlotter(QWidget):
 
         Always uses the nearest voxel to the cursor position.
         """
-        data = layer.data
-        ind: list[int | slice] = [round(x) for x in layer.world_to_data(cursor_pos)]
-
-        xaxis_index = self._xaxis_dim_index(layer)
-        # Replace the x-axis index before bounds-checking: the injected x-axis world
-        # coordinate (typically 0) may fall outside the data range (e.g. when the
-        # coordinate starts at a non-zero offset), which would cause the check to
-        # reject valid spatial positions.
-        ind[xaxis_index] = slice(None)
-
-        if not all(
-            0 <= i < max_i for i, max_i in zip(ind, data.shape) if isinstance(i, int)
-        ):
-            return None
-
-        return data[tuple(ind)]
+        return extract_voxel_trace(layer, cursor_pos, self._xaxis_dim_index(layer))
 
     def _mouse_origin_key(self, layer, cursor_pos: np.ndarray) -> str:
         """Return a pin origin key identifying the voxel at the cursor.
@@ -1287,6 +1273,7 @@ class SignalPlotter(QWidget):
                     visible=True,
                     source_type="point",
                     source_id=point_index,
+                    layer_name=self._points_layer.name,
                 )
             )
         self._signals_store.register_live_signals(signals)
@@ -1299,7 +1286,7 @@ class SignalPlotter(QWidget):
         unique_labels : numpy.ndarray
             Array of nonzero label IDs found in the Labels layer.
         """
-        if self._signals_store is None:
+        if self._signals_store is None or self._labels_layer is None:
             return
         signals = []
         for lid in unique_labels:
@@ -1313,6 +1300,7 @@ class SignalPlotter(QWidget):
                     visible=True,
                     source_type="label",
                     source_id=lid_int,
+                    layer_name=self._labels_layer.name,
                 )
             )
         self._signals_store.register_live_signals(signals)

--- a/src/confusius/_napari/_signals/_plotter.py
+++ b/src/confusius/_napari/_signals/_plotter.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, cast
+from typing import TYPE_CHECKING, Literal, NamedTuple, cast
 
 import napari
 import numpy as np
@@ -29,9 +29,9 @@ from confusius._napari._export import (
     write_delimited_signals,
 )
 from confusius._napari._signals._store import (
-    ImportedSignal,
     LiveSignal,
     SignalStore,
+    StoredSignal,
 )
 from confusius._napari._theme import (
     create_export_button,
@@ -50,11 +50,36 @@ _LAYER_LINESTYLES = ["-", "--", "-.", ":"]
 """Line styles to cycle across reference layers for visual distinction when colors are the same."""
 
 
+class LivePlotSignal(NamedTuple):
+    """One currently plotted live signal, snapshotted for `_pin_current_signals`.
+
+    Attributes
+    ----------
+    origin : str
+        Identifier matching the source `LiveSignal.id`, used as the pinned
+        signal's `pin_origin` so re-pinning updates rather than duplicates.
+    name : str
+        Display name to pin.
+    x : numpy.ndarray
+        Time values.
+    y : numpy.ndarray
+        Signal values.
+    color : str
+        Hex color to pin.
+    """
+
+    origin: str
+    name: str
+    x: np.ndarray
+    y: np.ndarray
+    color: str
+
+
 class SignalPlotter(QWidget):
     """Bottom dock widget for live signals plotting.
 
     Supports three source modes: mouse hover (Shift + move), a Points layer, or a Labels
-    layer. Imported signals from a `SignalStore` are overlaid on every plot. The x-axis
+    layer. Stored signals from a `SignalStore` are overlaid on every plot. The x-axis
     dimension is resolved from xarray metadata when available, falling back to the first
     array dimension.
 
@@ -63,7 +88,7 @@ class SignalPlotter(QWidget):
     viewer : napari.Viewer
         The active napari viewer instance.
     store : SignalStore | None, optional
-        Shared store containing imported signals to overlay on the live plot.
+        Shared store containing stored signals to overlay on the live plot.
     event_store : EventStore | None, optional
         Shared store of temporal events whose intervals are shaded as background
         bands on the plot.
@@ -119,6 +144,11 @@ class SignalPlotter(QWidget):
         self._labels_layer = None
         self._ref_layers: list | None = None
 
+        # Currently plotted live signals, refreshed on every successful live plot
+        # update via _set_live_plot_signals. Consumed by _pin_current_signals to
+        # snapshot them into the store.
+        self._live_plot_signals: list[LivePlotSignal] = []
+
         # Debounce timer for labels data changes (painting is fast, replot is slow).
         self._labels_debounce = QTimer(self)
         self._labels_debounce.setSingleShot(True)
@@ -133,7 +163,7 @@ class SignalPlotter(QWidget):
         self._export_signals: list[ExportSignal] = []
         self._mouse_plot_dirty: bool = True
         self._mouse_live_line = None
-        self._mouse_imported_signature: tuple[str, ...] = ()
+        self._mouse_stored_signature: tuple[str, ...] = ()
         self._mouse_legend_signature: tuple[str, ...] = ()
         # Guard flag to prevent infinite color sync loops.
         self._syncing_color: bool = False
@@ -176,11 +206,11 @@ class SignalPlotter(QWidget):
             self._signals_store.plot_data_changed.connect(self._on_plot_data_changed)
             self._signals_store.changed.connect(self._refresh_plot)
             self._signals_store.changed.connect(self._sync_live_colors_to_layers)
-            # If there are already imported signals, plot them instead of showing
+            # If there are already stored signals, plot them instead of showing
             # instructions.
-            imported = self._signals_store.imported_signals()
-            if imported and self._render_imported_only():
-                pass  # Successfully plotted imported signal.
+            stored = self._signals_store.stored_signals()
+            if stored and self._render_stored_only():
+                pass  # Successfully plotted stored signal.
             else:
                 self._show_instructions()
         else:
@@ -218,6 +248,16 @@ class SignalPlotter(QWidget):
         )
         self._export_button.setEnabled(False)
         self._toolbar.addWidget(self._export_button)
+        self._pin_button = create_export_button(
+            self._toolbar,
+            "signalPinButton",
+            self._pin_current_signals,
+            text="Pin",
+            tooltip="Pin the currently plotted live signal(s) so they persist across "
+            "source-mode switches, as Stored signals.",
+        )
+        self._pin_button.setEnabled(False)
+        self._toolbar.addWidget(self._pin_button)
         layout.addWidget(self._toolbar)
         layout.addWidget(self._canvas)
 
@@ -303,6 +343,7 @@ class SignalPlotter(QWidget):
 
         style_plot_toolbar(self._toolbar, colors)
         style_export_button(self._export_button, colors)
+        style_export_button(self._pin_button, colors, icon_name="pin")
 
         for spine in self._axes.spines.values():
             spine.set_edgecolor(colors["fg"])
@@ -582,7 +623,7 @@ class SignalPlotter(QWidget):
     def _invalidate_mouse_cache(self) -> None:
         """Reset all mouse-plot cache state, forcing a full redraw on the next update."""
         self._mouse_live_line = None
-        self._mouse_imported_signature = ()
+        self._mouse_stored_signature = ()
         self._mouse_legend_signature = ()
         self._mouse_plot_dirty = True
 
@@ -590,6 +631,7 @@ class SignalPlotter(QWidget):
         """Show a centered message in the plot area with no axes or data."""
         self._clear_export_signals()
         self._invalidate_mouse_cache()
+        self._set_live_plot_signals([])
         self._axes.clear()
         colors = self._get_colors()
         self._axes.text(
@@ -637,7 +679,7 @@ class SignalPlotter(QWidget):
             self._update_plot()
 
     def _on_plot_data_changed(self) -> None:
-        """Reset auto x-range when plotted imported signal membership changes."""
+        """Reset auto x-range when plotted stored signal membership changes."""
         self._has_plot = False
         self._prev_ts_valid = False
         self._mouse_plot_dirty = True
@@ -645,7 +687,7 @@ class SignalPlotter(QWidget):
     def _update_plot(self) -> None:
         """Update the signals plot with current data."""
         if self._current_layer is None or self._cursor_pos is None:
-            self._render_imported_only()
+            self._render_stored_only()
             return
 
         # Preserve zoom state across voxel changes. X limits are always
@@ -700,8 +742,8 @@ class SignalPlotter(QWidget):
                 else None
             )
             if mouse_signal is not None and not mouse_signal.visible:
-                # Mouse signal hidden: only show imported.
-                self._render_imported_only(saved_xlim=saved_xlim, saved_ylim=saved_ylim)
+                # Mouse signal hidden: only show stored.
+                self._render_stored_only(saved_xlim=saved_xlim, saved_ylim=saved_ylim)
                 return
 
             live_label = (
@@ -713,7 +755,21 @@ class SignalPlotter(QWidget):
                 mouse_signal.color if mouse_signal is not None else colors["accent"]
             )
 
-            imported_signals = self._imported_plot_signals()
+            self._set_live_plot_signals(
+                [
+                    LivePlotSignal(
+                        origin=self._mouse_origin_key(
+                            self._current_layer, self._cursor_pos
+                        ),
+                        name=live_label,
+                        x=np.asarray(x_values),
+                        y=np.asarray(ts),
+                        color=live_color,
+                    )
+                ]
+            )
+
+            stored_signals = self._stored_plot_signals()
             coord_str = self._mouse_coord_string()
             title = f"{self._current_layer.name} — ({coord_str})"
 
@@ -726,7 +782,7 @@ class SignalPlotter(QWidget):
                 title=title,
                 saved_xlim=saved_xlim,
                 saved_ylim=saved_ylim,
-                imported_signals=imported_signals,
+                stored_signals=stored_signals,
                 colors=colors,
             ):
                 return
@@ -742,12 +798,12 @@ class SignalPlotter(QWidget):
             )
 
             self._mouse_live_line = self._axes.lines[-1]
-            self._plot_signal_lines(imported_signals, linewidth=1.4, alpha=0.95)
-            self._mouse_imported_signature = self._imported_signature(imported_signals)
-            export_imported = self._plot_signal_to_export(imported_signals)
+            self._plot_signal_lines(stored_signals, linewidth=1.4, alpha=0.95)
+            self._mouse_stored_signature = self._stored_signature(stored_signals)
+            export_stored = self._plot_signal_to_export(stored_signals)
             self._set_export_signals(
                 [ExportSignal(live_label, np.asarray(x_values), np.asarray(ts))]
-                + export_imported
+                + export_stored
             )
 
         if ts is not None:
@@ -764,10 +820,10 @@ class SignalPlotter(QWidget):
             self._prev_ts_valid = True
             self._mouse_plot_dirty = False
             self._mouse_legend_signature = self._legend_signature(
-                live_label, imported_signals
+                live_label, stored_signals
             )
         else:
-            if self._render_imported_only(saved_xlim=saved_xlim, saved_ylim=saved_ylim):
+            if self._render_stored_only(saved_xlim=saved_xlim, saved_ylim=saved_ylim):
                 return
             self._clear_export_signals()
             self._prev_ts_valid = False
@@ -931,6 +987,50 @@ class SignalPlotter(QWidget):
 
         return data[tuple(ind)]
 
+    def _mouse_origin_key(self, layer, cursor_pos: np.ndarray) -> str:
+        """Return a pin origin key identifying the voxel at the cursor.
+
+        Distinct per voxel (unlike the mouse `LiveSignal.id`, which is the fixed
+        `"mouse-0"`), so pinned voxels are never hidden by the live-signal dedup in
+        [_stored_plot_signals][confusius._napari._signals._plotter.SignalPlotter._stored_plot_signals]
+        while hovering — only re-pinning the exact same voxel updates it in place.
+        """
+        indices = [round(x) for x in layer.world_to_data(cursor_pos)]
+        xaxis_index = self._xaxis_dim_index(layer)
+        spatial = [v for i, v in enumerate(indices) if i != xaxis_index]
+        return "mouse-" + "-".join(str(v) for v in spatial)
+
+    def _set_live_plot_signals(self, signals: list[LivePlotSignal]) -> None:
+        """Update the currently-pinnable live signals and the Pin button state."""
+        self._live_plot_signals = signals
+        self._pin_button.setEnabled(bool(signals))
+
+    def _pin_current_signals(self) -> None:
+        """Pin every currently plotted live signal into the store as stored signals.
+
+        A pinned entry is hidden from the plot while a live signal with the same
+        origin is still active (see
+        [_stored_plot_signals][confusius._napari._signals._plotter.SignalPlotter._stored_plot_signals]),
+        so pinning without changing source mode or hiding the live signal has no
+        immediately visible effect on the plot itself — it will appear once you
+        switch away, hide the live signal, or the live source (e.g. a repainted
+        label) diverges from the snapshot. It always shows up in the Signal
+        Manager right away.
+        """
+        if self._signals_store is None or not self._live_plot_signals:
+            return
+        for signal in self._live_plot_signals:
+            self._signals_store.pin_signal(
+                origin=signal.origin,
+                # Distinct from the live signal's name so the two are never
+                # visually indistinguishable duplicates in the legend/manager.
+                name=f"{signal.name} (pinned)",
+                x=signal.x,
+                y=signal.y,
+                color=signal.color,
+                source_label=f"Pinned from {self._source_mode}",
+            )
+
     # ------------------------------------------------------------------
     # Source mode — public setters
     # ------------------------------------------------------------------
@@ -951,8 +1051,8 @@ class SignalPlotter(QWidget):
             # restore the [0, 1] xlim left by the cleared axes.
             self._has_plot = False
             self._prev_ts_valid = False
-            # Only show instructions if there are no imported signal to display.
-            if not self._render_imported_only():
+            # Only show instructions if there are no stored signal to display.
+            if not self._render_stored_only():
                 self._show_instructions()
         elif mode == "points":
             self._update_plot_from_points()
@@ -1334,11 +1434,11 @@ class SignalPlotter(QWidget):
         """Clear the currently exported signal."""
         self._set_export_signals([])
 
-    def _visible_imported_signals(self) -> list[ImportedSignal]:
-        """Return visible imported signals from the shared store."""
+    def _visible_stored_signals(self) -> list[StoredSignal]:
+        """Return visible stored signals from the shared store."""
         if self._signals_store is None:
             return []
-        return self._signals_store.visible_imported_signals()
+        return self._signals_store.visible_stored_signals()
 
     def _mouse_coord_string(self) -> str:
         """Return the current mouse coordinates formatted for the plot title.
@@ -1387,10 +1487,22 @@ class SignalPlotter(QWidget):
 
         return ", ".join(coord_parts)
 
-    def _imported_plot_signals(self) -> list[PlotSignal]:
-        """Return imported signals prepared for plotting and export."""
+    def _stored_plot_signals(self) -> list[PlotSignal]:
+        """Return stored signals prepared for plotting and export.
+
+        A pinned signal (`pin_origin` set) is skipped while a live signal with a
+        matching id is currently active, so pinning e.g. a label mean doesn't show
+        a duplicate line while that same label is live in the Labels source mode.
+        """
+        live_ids = (
+            {s.id for s in self._signals_store.live_signals()}
+            if self._signals_store is not None
+            else set()
+        )
         plotted = []
-        for signals in self._visible_imported_signals():
+        for signals in self._visible_stored_signals():
+            if signals.pin_origin is not None and signals.pin_origin in live_ids:
+                continue
             x_values = np.asarray(signals.x).copy()
             y_values = np.asarray(signals.y, dtype=float).copy()
             if self._zscore:
@@ -1425,15 +1537,15 @@ class SignalPlotter(QWidget):
                     label=s.label,
                 )
 
-    def _imported_signature(self, signals: list[PlotSignal]) -> tuple[str, ...]:
-        """Return a lightweight signature for imported signals already on the axes."""
+    def _stored_signature(self, signals: list[PlotSignal]) -> tuple[str, ...]:
+        """Return a lightweight signature for stored signals already on the axes."""
         return tuple(s.label for s in signals)
 
     def _legend_signature(
-        self, live_label: str, imported_signals: list[PlotSignal]
+        self, live_label: str, stored_signals: list[PlotSignal]
     ) -> tuple[str, ...]:
         """Return the legend content signature for the current mouse plot."""
-        return (live_label, *self._imported_signature(imported_signals))
+        return (live_label, *self._stored_signature(stored_signals))
 
     @staticmethod
     def _plot_signal_to_export(signals: list[PlotSignal]) -> list[ExportSignal]:
@@ -1452,17 +1564,17 @@ class SignalPlotter(QWidget):
         return [ExportSignal(s.label, s.x_values, s.y_values) for s in signals]
 
     def _set_ylim_from_data(
-        self, ts: np.ndarray, imported_signals: list[PlotSignal]
+        self, ts: np.ndarray, stored_signals: list[PlotSignal]
     ) -> None:
         """Autoscale the y-axis from already-extracted arrays.
 
         Used by the mouse fast path instead of matplotlib's `relim()`/
         `autoscale_view()`, which re-derive the data extent from every plotted
         `Line2D` artist on every call — redundant work here since we already hold
-        the live and imported arrays as numpy arrays. Matches matplotlib's default
+        the live and stored arrays as numpy arrays. Matches matplotlib's default
         5% autoscale margin.
         """
-        arrays = [ts, *(s.y_values for s in imported_signals)]
+        arrays = [ts, *(s.y_values for s in stored_signals)]
         y = np.concatenate(arrays) if len(arrays) > 1 else arrays[0]
         finite = y[np.isfinite(y)]
         if finite.size == 0:
@@ -1482,13 +1594,13 @@ class SignalPlotter(QWidget):
         title: str,
         saved_xlim,
         saved_ylim,
-        imported_signals: list[PlotSignal],
+        stored_signals: list[PlotSignal],
         colors: dict,
     ) -> bool:
-        """Update the mouse plot without rebuilding imported overlay lines."""
+        """Update the mouse plot without rebuilding stored overlay lines."""
         if self._mouse_plot_dirty or self._mouse_live_line is None:
             return False
-        if self._mouse_imported_signature != self._imported_signature(imported_signals):
+        if self._mouse_stored_signature != self._stored_signature(stored_signals):
             return False
 
         self._mouse_live_line.set_data(x_values, ts)
@@ -1496,7 +1608,7 @@ class SignalPlotter(QWidget):
         self._mouse_live_line.set_color(live_color)
         self._set_export_signals(
             [ExportSignal(live_label, x_values, ts)]
-            + self._plot_signal_to_export(imported_signals)
+            + self._plot_signal_to_export(stored_signals)
         )
 
         self._axes.set_xlabel(xlabel, color=colors["fg"], fontsize=9)
@@ -1509,11 +1621,11 @@ class SignalPlotter(QWidget):
         if self._show_grid:
             self._axes.grid(True, alpha=0.3, color=colors["fg"])
 
-        self._update_legend_if_needed(colors, live_label, imported_signals)
+        self._update_legend_if_needed(colors, live_label, stored_signals)
 
         self._restore_view(saved_xlim, saved_ylim)
         if self._autoscale:
-            self._set_ylim_from_data(ts, imported_signals)
+            self._set_ylim_from_data(ts, stored_signals)
 
         self._has_plot = True
         self._prev_ts_valid = True
@@ -1524,10 +1636,10 @@ class SignalPlotter(QWidget):
         return True
 
     def _update_legend_if_needed(
-        self, colors: dict, live_label: str, imported_signals: list[PlotSignal]
+        self, colors: dict, live_label: str, stored_signals: list[PlotSignal]
     ) -> None:
         """Update the legend only when its entries actually changed."""
-        signature = self._legend_signature(live_label, imported_signals)
+        signature = self._legend_signature(live_label, stored_signals)
         if signature == self._mouse_legend_signature:
             return
 
@@ -1545,24 +1657,25 @@ class SignalPlotter(QWidget):
             )
         self._mouse_legend_signature = signature
 
-    def _render_imported_only(self, saved_xlim=None, saved_ylim=None) -> bool:
-        """Render only imported signals when no live data can be drawn."""
-        imported_signals = self._imported_plot_signals()
-        if not imported_signals:
+    def _render_stored_only(self, saved_xlim=None, saved_ylim=None) -> bool:
+        """Render only stored signals when no live data can be drawn."""
+        self._set_live_plot_signals([])
+        stored_signals = self._stored_plot_signals()
+        if not stored_signals:
             return False
 
         colors = self._get_colors()
         self._axes.clear()
-        self._plot_signal_lines(imported_signals, linewidth=1.4, alpha=0.95)
-        self._set_export_signals(self._plot_signal_to_export(imported_signals))
+        self._plot_signal_lines(stored_signals, linewidth=1.4, alpha=0.95)
+        self._set_export_signals(self._plot_signal_to_export(stored_signals))
         self._mouse_live_line = None
-        self._mouse_imported_signature = self._imported_signature(imported_signals)
-        self._mouse_legend_signature = self._imported_signature(imported_signals)
+        self._mouse_stored_signature = self._stored_signature(stored_signals)
+        self._mouse_legend_signature = self._stored_signature(stored_signals)
         self._mouse_plot_dirty = True
         self._xaxis_coords = None
-        # Label from the active layer when one is present so the imported-only
+        # Label from the active layer when one is present so the stored-only
         # view stays consistent with the live plot; fall back to "Time" for
-        # standalone imported signals (typically a CSV time column).
+        # standalone stored signals (typically a CSV time column).
         xlabel = (
             self._get_xaxis_label(self._current_layer)
             if self._current_layer is not None
@@ -1572,8 +1685,8 @@ class SignalPlotter(QWidget):
             colors,
             xlabel,
             "Z-score" if self._zscore else "Value",
-            "Imported Signals",
-            with_legend=len(imported_signals) > 1,
+            "Stored Signals",
+            with_legend=len(stored_signals) > 1,
         )
         self._restore_view(saved_xlim, saved_ylim)
         self._has_plot = True
@@ -1582,15 +1695,15 @@ class SignalPlotter(QWidget):
         self._canvas.draw_idle()
         return True
 
-    def _show_message_or_imported(
+    def _show_message_or_stored(
         self,
         text: str,
         *,
         saved_xlim=None,
         saved_ylim=None,
     ) -> None:
-        """Show a message when no imported signals are visible, else plot imports only."""
-        if self._render_imported_only(saved_xlim=saved_xlim, saved_ylim=saved_ylim):
+        """Show a message when no stored signals are visible, else plot stored signals only."""
+        if self._render_stored_only(saved_xlim=saved_xlim, saved_ylim=saved_ylim):
             return
         self._show_message(text)
 
@@ -1748,7 +1861,7 @@ class SignalPlotter(QWidget):
             The reference image layers, or `None` if validation failed.
         """
         if source_layer is None:
-            self._show_message_or_imported(
+            self._show_message_or_stored(
                 f"No {source_name} layer selected.\n"
                 "Choose one in the Source section of the panel.",
                 saved_xlim=saved_xlim,
@@ -1757,7 +1870,7 @@ class SignalPlotter(QWidget):
             return None
         ref_layers = self._get_ref_image_layers()
         if not ref_layers:
-            self._show_message_or_imported(
+            self._show_message_or_stored(
                 "No reference image layer found.\nLoad a 4-D image layer first.",
                 saved_xlim=saved_xlim,
                 saved_ylim=saved_ylim,
@@ -1795,7 +1908,7 @@ class SignalPlotter(QWidget):
         saved_xlim,
         saved_ylim,
     ) -> None:
-        """Overlay imported signals, style the axes, and redraw after a multi-signals plot.
+        """Overlay stored signals, style the axes, and redraw after a multi-signals plot.
 
         Shared by `_update_plot_from_points` and `_update_plot_from_labels` once their
         per-signal loops have completed successfully.
@@ -1815,10 +1928,10 @@ class SignalPlotter(QWidget):
         saved_ylim : tuple or None
             Saved y-axis limits to restore.
         """
-        imported_signals = self._imported_plot_signals()
-        self._plot_signal_lines(imported_signals, linewidth=1.4, alpha=0.95)
+        stored_signals = self._stored_plot_signals()
+        self._plot_signal_lines(stored_signals, linewidth=1.4, alpha=0.95)
         self._set_export_signals(
-            export_signals + self._plot_signal_to_export(imported_signals)
+            export_signals + self._plot_signal_to_export(stored_signals)
         )
         xlabel = self._get_xaxis_label(ref_layers[0])
         ylabel = "Z-score" if self._zscore else "Intensity"
@@ -1855,7 +1968,7 @@ class SignalPlotter(QWidget):
 
             n_points = len(points_layer.data)
             if n_points == 0:
-                self._show_message_or_imported(
+                self._show_message_or_stored(
                     "The selected Points layer is empty.",
                     saved_xlim=saved_xlim,
                     saved_ylim=saved_ylim,
@@ -1872,6 +1985,7 @@ class SignalPlotter(QWidget):
             self._axes.clear()
             has_any = False
             export_signals: list[ExportSignal] = []
+            live_plot_signals: list[LivePlotSignal] = []
 
             for point_index in range(n_points):
                 # Check store for visibility/name/color overrides.
@@ -1945,7 +2059,24 @@ class SignalPlotter(QWidget):
                     # Keep x-axis coords from the last successful layer for cursor mapping.
                     self._xaxis_coords = xaxis_coords
                     self._current_layer = img_layer
+                    # Keep the last successful layer's data for pinning too, matching
+                    # the cursor-mapping choice above.
+                    live_plot_signals = [
+                        s
+                        for s in live_plot_signals
+                        if s.origin != f"point-{point_index}"
+                    ]
+                    live_plot_signals.append(
+                        LivePlotSignal(
+                            origin=f"point-{point_index}",
+                            name=pt_name,
+                            x=np.asarray(x),
+                            y=ts,
+                            color=pt_color,
+                        )
+                    )
 
+            self._set_live_plot_signals(live_plot_signals)
             if has_any:
                 self._finalize_multi_signals_plot(
                     export_signals,
@@ -1956,7 +2087,7 @@ class SignalPlotter(QWidget):
                     saved_ylim,
                 )
             else:
-                self._show_message_or_imported(
+                self._show_message_or_stored(
                     "No valid data at the point positions.\n",
                     saved_xlim=saved_xlim,
                     saved_ylim=saved_ylim,
@@ -1992,6 +2123,7 @@ class SignalPlotter(QWidget):
             has_any = False
             shape_mismatch = False
             export_signals: list[ExportSignal] = []
+            live_plot_signals: list[LivePlotSignal] = []
             # Collect all unique labels across layers for registration.
             all_unique_labels: set[int] = set()
 
@@ -2068,6 +2200,20 @@ class SignalPlotter(QWidget):
                         ExportSignal(label, np.asarray(x), np.asarray(ts))
                     )
                     has_any = True
+                    # Keep the last successful layer's data for pinning, matching the
+                    # cursor-mapping choice below.
+                    live_plot_signals = [
+                        s for s in live_plot_signals if s.origin != f"label-{lid_int}"
+                    ]
+                    live_plot_signals.append(
+                        LivePlotSignal(
+                            origin=f"label-{lid_int}",
+                            name=base_name,
+                            x=np.asarray(x),
+                            y=ts,
+                            color=lid_color,
+                        )
+                    )
 
                 # Keep time coords from the last successful layer for cursor mapping.
                 self._xaxis_coords = xaxis_coords
@@ -2077,6 +2223,7 @@ class SignalPlotter(QWidget):
             if all_unique_labels:
                 self._register_labels_live_signals(np.array(sorted(all_unique_labels)))
 
+            self._set_live_plot_signals(live_plot_signals)
             if has_any:
                 self._finalize_multi_signals_plot(
                     export_signals,
@@ -2087,14 +2234,14 @@ class SignalPlotter(QWidget):
                     saved_ylim,
                 )
             elif shape_mismatch:
-                self._show_message_or_imported(
+                self._show_message_or_stored(
                     "Spatial shape of the Labels layer does not match\n"
                     "the reference image. Make sure they share the same grid.",
                     saved_xlim=saved_xlim,
                     saved_ylim=saved_ylim,
                 )
             else:
-                self._show_message_or_imported(
+                self._show_message_or_stored(
                     "No valid data extracted from the Labels layer.",
                     saved_xlim=saved_xlim,
                     saved_ylim=saved_ylim,

--- a/src/confusius/_napari/_signals/_plotter.py
+++ b/src/confusius/_napari/_signals/_plotter.py
@@ -991,9 +991,9 @@ class SignalPlotter(QWidget):
         """Return a pin origin key identifying the voxel at the cursor.
 
         Distinct per voxel (unlike the mouse `LiveSignal.id`, which is the fixed
-        `"mouse-0"`), so pinned voxels are never hidden by the live-signal dedup in
-        [_stored_plot_signals][confusius._napari._signals._plotter.SignalPlotter._stored_plot_signals]
-        while hovering — only re-pinning the exact same voxel updates it in place.
+        `"mouse-0"`), so pinning two different voxels creates two separate stored
+        signals — only re-pinning the exact same voxel updates it in place (see
+        [SignalStore.pin_signal][confusius._napari._signals._store.SignalStore.pin_signal]).
         """
         indices = [round(x) for x in layer.world_to_data(cursor_pos)]
         xaxis_index = self._xaxis_dim_index(layer)
@@ -1006,17 +1006,7 @@ class SignalPlotter(QWidget):
         self._pin_button.setEnabled(bool(signals))
 
     def _pin_current_signals(self) -> None:
-        """Pin every currently plotted live signal into the store as stored signals.
-
-        A pinned entry is hidden from the plot while a live signal with the same
-        origin is still active (see
-        [_stored_plot_signals][confusius._napari._signals._plotter.SignalPlotter._stored_plot_signals]),
-        so pinning without changing source mode or hiding the live signal has no
-        immediately visible effect on the plot itself — it will appear once you
-        switch away, hide the live signal, or the live source (e.g. a repainted
-        label) diverges from the snapshot. It always shows up in the Signal
-        Manager right away.
-        """
+        """Pin every currently plotted live signal into the store as stored signals."""
         if self._signals_store is None or not self._live_plot_signals:
             return
         for signal in self._live_plot_signals:
@@ -1488,21 +1478,9 @@ class SignalPlotter(QWidget):
         return ", ".join(coord_parts)
 
     def _stored_plot_signals(self) -> list[PlotSignal]:
-        """Return stored signals prepared for plotting and export.
-
-        A pinned signal (`pin_origin` set) is skipped while a live signal with a
-        matching id is currently active, so pinning e.g. a label mean doesn't show
-        a duplicate line while that same label is live in the Labels source mode.
-        """
-        live_ids = (
-            {s.id for s in self._signals_store.live_signals()}
-            if self._signals_store is not None
-            else set()
-        )
+        """Return stored signals prepared for plotting and export."""
         plotted = []
         for signals in self._visible_stored_signals():
-            if signals.pin_origin is not None and signals.pin_origin in live_ids:
-                continue
             x_values = np.asarray(signals.x).copy()
             y_values = np.asarray(signals.y, dtype=float).copy()
             if self._zscore:
@@ -1686,7 +1664,9 @@ class SignalPlotter(QWidget):
             xlabel,
             "Z-score" if self._zscore else "Value",
             "Stored Signals",
-            with_legend=len(stored_signals) > 1,
+            # Unlike the mouse-hover title (which already names the voxel), this
+            # generic title doesn't identify a lone line, so always show the legend.
+            with_legend=bool(stored_signals),
         )
         self._restore_view(saved_xlim, saved_ylim)
         self._has_plot = True

--- a/src/confusius/_napari/_signals/_plotter.py
+++ b/src/confusius/_napari/_signals/_plotter.py
@@ -192,8 +192,10 @@ class SignalPlotter(QWidget):
         self._mouse_update_timer.setSingleShot(True)
         self._mouse_update_timer.timeout.connect(self._flush_mouse_update)
 
-        # Previous keymap handler displaced by binding Shift, restored on close.
+        # Previous keymap handler displaced by binding Shift, restored once Shift is
+        # unbound (leaving mouse source mode, or on close).
         self._displaced_shift_key = None
+        self._shift_bound: bool = False
 
         self.setSizePolicy(
             QSizePolicy.Policy.Expanding,
@@ -273,28 +275,37 @@ class SignalPlotter(QWidget):
         self._viewer.layers.events.inserted.connect(self._on_layer_change)
         self._viewer.layers.events.removed.connect(self._on_layer_change)
         self._viewer.layers.selection.events.active.connect(self._on_layer_change)
-        self._bind_shift_key()
+        if self._source_mode == "mouse":
+            self._bind_shift_key()
 
     def _bind_shift_key(self) -> None:
         """Bind Shift in the napari keymap to plot the signal at the resting cursor.
 
         Lets the user press Shift while the cursor is already stationary over an
-        image layer, instead of requiring mouse movement while Shift is held.
-        Any handler already bound to Shift is saved first so it can be restored
-        when the plotter closes.
+        image layer, instead of requiring mouse movement while Shift is held. Any
+        handler already bound to Shift is saved first so it can be restored once
+        Shift is unbound. Idempotent, and scoped to mouse source mode by
+        `set_source_mode` (rather than held for the plotter's whole lifetime) so
+        another binding on bare Shift is only displaced while actually in mouse mode.
         """
+        if self._shift_bound:
+            return
         keybinding = coerce_keybinding("Shift")
         self._displaced_shift_key = self._viewer.keymap.get(keybinding)
         self._viewer.bind_key("Shift", self._on_shift_pressed, overwrite=True)
+        self._shift_bound = True
 
     def _unbind_shift_key(self) -> None:
-        """Restore the keymap entry displaced by `_bind_shift_key`."""
+        """Restore the keymap entry displaced by `_bind_shift_key`. Idempotent."""
+        if not self._shift_bound:
+            return
         keybinding = coerce_keybinding("Shift")
         if self._displaced_shift_key is not None:
             self._viewer.keymap[keybinding] = self._displaced_shift_key
         else:
             self._viewer.keymap.pop(keybinding, None)
         self._displaced_shift_key = None
+        self._shift_bound = False
 
     def _on_shift_pressed(self, viewer: napari.Viewer) -> None:
         """Plot the signal at the current cursor position when Shift is pressed."""
@@ -1036,6 +1047,7 @@ class SignalPlotter(QWidget):
         self._source_mode = mode
         self._invalidate_mouse_cache()
         if mode == "mouse":
+            self._bind_shift_key()
             self._register_mouse_live_signal()
             # Invalidate the saved zoom state so the first mouse-hover plot does not
             # restore the [0, 1] xlim left by the cleared axes.
@@ -1045,8 +1057,10 @@ class SignalPlotter(QWidget):
             if not self._render_stored_only():
                 self._show_instructions()
         elif mode == "points":
+            self._unbind_shift_key()
             self._update_plot_from_points()
         else:
+            self._unbind_shift_key()
             self._update_plot_from_labels()
 
     def set_points_layer(self, layer) -> None:

--- a/src/confusius/_napari/_signals/_store.py
+++ b/src/confusius/_napari/_signals/_store.py
@@ -1,4 +1,4 @@
-"""Shared store for imported napari signals."""
+"""Shared store for stored (imported or pinned) napari signals."""
 
 from __future__ import annotations
 
@@ -14,13 +14,18 @@ from qtpy.QtCore import QObject, Signal
 from confusius._napari._utils import CATEGORICAL_COLORS
 from confusius.bids import load_physio
 
-_IMPORTED_SIGNAL_COLORS = CATEGORICAL_COLORS
-"""Palette cycled across imported signal columns."""
+_STORED_SIGNAL_COLORS = CATEGORICAL_COLORS
+"""Palette cycled across stored signal columns."""
 
 
 @dataclass(frozen=True, slots=True)
-class ImportedSignal:
-    """Imported signal stored for overlay in the plotter.
+class StoredSignal:
+    """Persistent signal stored for overlay in the plotter.
+
+    Unlike `LiveSignal`, a stored signal owns its data outright and survives
+    source-mode switches. It either comes from an imported file, or is a
+    snapshot pinned from a live signal (see
+    [`SignalStore.pin_signal`][confusius._napari._signals._store.SignalStore.pin_signal]).
 
     Attributes
     ----------
@@ -37,11 +42,17 @@ class ImportedSignal:
     color : str
         Hex color used for plotting.
     source_label : str
-        Human-readable source description, typically the file name.
-    file_path : pathlib.Path
-        Original imported file.
-    original_column_name : str
-        Column name from the imported file.
+        Human-readable source description (a file name, or e.g. `"Pinned voxel"`).
+    file_path : pathlib.Path | None
+        Original imported file, or `None` for a pinned signal.
+    original_column_name : str | None
+        Column name from the imported file, or `None` for a pinned signal.
+    pin_origin : str | None, optional
+        Identifier of the live signal this was pinned from (e.g. `"label-3"`,
+        `"mouse-12-34-56"`), or `None` for a signal imported from a file.
+        Re-pinning the same origin updates this entry in place instead of
+        creating a duplicate, and a pinned entry is hidden from the plot
+        whenever a live signal with a matching id is currently active.
     """
 
     id: str
@@ -51,17 +62,21 @@ class ImportedSignal:
     visible: bool
     color: str
     source_label: str
-    file_path: Path
-    original_column_name: str
+    file_path: Path | None
+    original_column_name: str | None
+    pin_origin: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
 class LiveSignal:
     """Live signal backed by a napari layer.
 
-    Unlike `ImportedSignal`, a live signal does not own its data: the plotter extracts
-    it from layers on each update. The store tracks only presentation metadata (name,
-    color, visibility) so the user can customise the plot.
+    Unlike `StoredSignal`, a live signal does not own its data: the plotter extracts
+    it from layers on each update, and it only exists while its source mode is active
+    — switching source modes replaces the whole live set. The store tracks only
+    presentation metadata (name, color, visibility) so the user can customise the
+    plot; to keep a live signal's current values around after switching modes, pin it
+    with [`SignalStore.pin_signal`][confusius._napari._signals._store.SignalStore.pin_signal].
 
     Attributes
     ----------
@@ -88,7 +103,7 @@ class LiveSignal:
 
 
 class SignalStore(QObject):
-    """Store imported and live signals shared between the panel and plotter.
+    """Store stored and live signals shared between the panel and plotter.
 
     The store is the single source of truth for signal presentation metadata (name,
     color, visibility). It is shared between the panel, plotter, and manager dialog.
@@ -104,29 +119,29 @@ class SignalStore(QObject):
 
     def __init__(self, parent: QObject | None = None) -> None:
         super().__init__(parent)
-        self._imported_signals: list[ImportedSignal] = []
+        self._stored_signals: list[StoredSignal] = []
         self._live_signals: dict[str, LiveSignal] = {}
         self._id_counter: int = 0
 
-    def imported_signals(self) -> list[ImportedSignal]:
-        """Return all imported signals.
+    def stored_signals(self) -> list[StoredSignal]:
+        """Return all stored signals.
 
         Returns
         -------
-        list[ImportedSignal]
-            Imported signals in insertion order.
+        list[StoredSignal]
+            Stored signals in insertion order.
         """
-        return list(self._imported_signals)
+        return list(self._stored_signals)
 
-    def visible_imported_signals(self) -> list[ImportedSignal]:
-        """Return only imported signals marked as visible.
+    def visible_stored_signals(self) -> list[StoredSignal]:
+        """Return only stored signals marked as visible.
 
         Returns
         -------
-        list[ImportedSignal]
-            Visible imported signals.
+        list[StoredSignal]
+            Visible stored signals.
         """
-        return [signal for signal in self._imported_signals if signal.visible]
+        return [signal for signal in self._stored_signals if signal.visible]
 
     def _emit_changed(self, *, plot_data: bool = False) -> None:
         """Emit changed signals.
@@ -141,14 +156,14 @@ class SignalStore(QObject):
         self.changed.emit()
 
     def clear(self) -> None:
-        """Remove all imported signals."""
-        if not self._imported_signals:
+        """Remove all stored signals."""
+        if not self._stored_signals:
             return
-        self._imported_signals.clear()
+        self._stored_signals.clear()
         self._emit_changed(plot_data=True)
 
     def rename_signal(self, signal_id: str, new_name: str) -> None:
-        """Rename one imported signal.
+        """Rename one stored signal.
 
         Parameters
         ----------
@@ -164,11 +179,11 @@ class SignalStore(QObject):
         """
         stripped = new_name.strip()
         if not stripped:
-            raise ValueError("Imported signal name cannot be empty.")
+            raise ValueError("Stored signal name cannot be empty.")
         self._replace_signal(signal_id, name=stripped)
 
     def set_signal_visible(self, signal_id: str, visible: bool) -> None:
-        """Update the visible flag for one imported signal.
+        """Update the visible flag for one stored signal.
 
         Parameters
         ----------
@@ -180,7 +195,7 @@ class SignalStore(QObject):
         self._replace_signal(signal_id, plot_data=True, visible=visible)
 
     def set_signal_color(self, signal_id: str, color: str) -> None:
-        """Update the plot color for one imported signal.
+        """Update the plot color for one stored signal.
 
         Parameters
         ----------
@@ -190,11 +205,11 @@ class SignalStore(QObject):
             Hex color string.
         """
         if not color:
-            raise ValueError("Imported signal color cannot be empty.")
+            raise ValueError("Stored signal color cannot be empty.")
         self._replace_signal(signal_id, color=color)
 
     def remove_signals(self, signal_ids: list[str]) -> None:
-        """Remove selected imported signals.
+        """Remove selected stored signals.
 
         Parameters
         ----------
@@ -205,13 +220,13 @@ class SignalStore(QObject):
             return
 
         ids = set(signal_ids)
-        kept = [signal for signal in self._imported_signals if signal.id not in ids]
-        if len(kept) == len(self._imported_signals):
+        kept = [signal for signal in self._stored_signals if signal.id not in ids]
+        if len(kept) == len(self._stored_signals):
             return
-        self._imported_signals = kept
+        self._stored_signals = kept
         self._emit_changed(plot_data=True)
 
-    def import_file(self, path: Path) -> list[ImportedSignal]:
+    def import_file(self, path: Path) -> list[StoredSignal]:
         """Import one CSV or TSV file into the store.
 
         Parameters
@@ -221,8 +236,8 @@ class SignalStore(QObject):
 
         Returns
         -------
-        list[ImportedSignal]
-            Imported signal created from the file.
+        list[StoredSignal]
+            Signals created from the file.
 
         Raises
         ------
@@ -231,9 +246,74 @@ class SignalStore(QObject):
         """
         frame = self._read_signals_table(path)
         imported = self._signal_from_frame(frame, path)
-        self._imported_signals.extend(imported)
+        self._stored_signals.extend(imported)
         self._emit_changed(plot_data=True)
         return imported
+
+    def pin_signal(
+        self,
+        origin: str,
+        name: str,
+        x: npt.NDArray[np.floating],
+        y: npt.NDArray[np.floating],
+        color: str,
+        source_label: str,
+    ) -> StoredSignal:
+        """Pin a live signal's current values as a persistent stored signal.
+
+        Re-pinning the same `origin` updates that entry's data in place rather than
+        creating a duplicate, so repeatedly pinning e.g. the same label id just
+        refreshes its snapshot (useful after repainting the label mask).
+
+        Parameters
+        ----------
+        origin : str
+            Identifier of the live signal being pinned (e.g. `"label-3"`,
+            `"mouse-12-34-56"`). Matches the corresponding `LiveSignal.id` so the
+            plotter can hide the pinned copy while that live signal is active.
+        name : str
+            Display name for the pinned signal.
+        x : numpy.ndarray
+            Time values.
+        y : numpy.ndarray
+            Signal values.
+        color : str
+            Hex color used for plotting.
+        source_label : str
+            Human-readable description of where this was pinned from.
+
+        Returns
+        -------
+        StoredSignal
+            The created or updated pinned signal.
+        """
+        x = np.asarray(x, dtype=float).copy()
+        y = np.asarray(y, dtype=float).copy()
+
+        for index, signal in enumerate(self._stored_signals):
+            if signal.pin_origin == origin:
+                updated = replace(signal, x=x, y=y)
+                self._stored_signals[index] = updated
+                self._emit_changed(plot_data=True)
+                return updated
+
+        signal_id = f"pinned-{self._id_counter}"
+        self._id_counter += 1
+        pinned = StoredSignal(
+            id=signal_id,
+            name=name,
+            x=x,
+            y=y,
+            visible=True,
+            color=color,
+            source_label=source_label,
+            file_path=None,
+            original_column_name=None,
+            pin_origin=origin,
+        )
+        self._stored_signals.append(pinned)
+        self._emit_changed(plot_data=True)
+        return pinned
 
     def _read_signals_table(self, path: Path) -> pd.DataFrame:
         """Read one CSV or TSV signals table from disk."""
@@ -257,10 +337,8 @@ class SignalStore(QObject):
             return path.suffixes[-2].lower()
         return path.suffix.lower()
 
-    def _signal_from_frame(
-        self, frame: pd.DataFrame, path: Path
-    ) -> list[ImportedSignal]:
-        """Convert a dataframe into imported signal entries."""
+    def _signal_from_frame(self, frame: pd.DataFrame, path: Path) -> list[StoredSignal]:
+        """Convert a dataframe into stored signal entries."""
         if "time" not in frame.columns:
             raise ValueError("Imported file must contain a 'time' column.")
 
@@ -283,12 +361,12 @@ class SignalStore(QObject):
         imported = []
 
         for offset, column in enumerate(value_columns):
-            color = _IMPORTED_SIGNAL_COLORS[
-                (self._id_counter + offset) % len(_IMPORTED_SIGNAL_COLORS)
+            color = _STORED_SIGNAL_COLORS[
+                (self._id_counter + offset) % len(_STORED_SIGNAL_COLORS)
             ]
             signal_id = f"imported-{self._id_counter + offset}"
             imported.append(
-                ImportedSignal(
+                StoredSignal(
                     id=signal_id,
                     name=str(column),
                     x=time_values.copy(),
@@ -447,12 +525,12 @@ class SignalStore(QObject):
         plot_data: bool = False,
         **changes,
     ) -> None:
-        """Replace one imported signal while preserving order."""
-        for index, signal in enumerate(self._imported_signals):
+        """Replace one stored signal while preserving order."""
+        for index, signal in enumerate(self._stored_signals):
             if signal.id != signal_id:
                 continue
-            self._imported_signals[index] = replace(signal, **changes)
+            self._stored_signals[index] = replace(signal, **changes)
             self._emit_changed(plot_data=plot_data)
             return
 
-        raise ValueError(f"Unknown imported signal id: {signal_id!r}.")
+        raise ValueError(f"Unknown stored signal id: {signal_id!r}.")

--- a/src/confusius/_napari/_signals/_store.py
+++ b/src/confusius/_napari/_signals/_store.py
@@ -51,8 +51,7 @@ class StoredSignal:
         Identifier of the live signal this was pinned from (e.g. `"label-3"`,
         `"mouse-12-34-56"`), or `None` for a signal imported from a file.
         Re-pinning the same origin updates this entry in place instead of
-        creating a duplicate, and a pinned entry is hidden from the plot
-        whenever a live signal with a matching id is currently active.
+        creating a duplicate.
     """
 
     id: str
@@ -269,8 +268,8 @@ class SignalStore(QObject):
         ----------
         origin : str
             Identifier of the live signal being pinned (e.g. `"label-3"`,
-            `"mouse-12-34-56"`). Matches the corresponding `LiveSignal.id` so the
-            plotter can hide the pinned copy while that live signal is active.
+            `"mouse-12-34-56"`), matching the corresponding `LiveSignal.id` where
+            applicable. Used only to detect re-pinning the same source.
         name : str
             Display name for the pinned signal.
         x : numpy.ndarray

--- a/src/confusius/_napari/_signals/_store.py
+++ b/src/confusius/_napari/_signals/_store.py
@@ -91,6 +91,11 @@ class LiveSignal:
         Kind of napari source that produces this signal.
     source_id : int | None
         `None` for mouse, point index for points, label integer for labels.
+    layer_name : str | None
+        Name of the Points or Labels layer `source_id` is defined on, so
+        consumers outside the plotter (e.g. the Preprocessing panel) can
+        re-extract this signal's trace against a different reference image.
+        `None` for mouse signals, which have no backing layer.
     """
 
     id: str
@@ -99,6 +104,7 @@ class LiveSignal:
     visible: bool
     source_type: Literal["mouse", "point", "label"]
     source_id: int | None
+    layer_name: str | None = None
 
 
 class SignalStore(QObject):

--- a/src/confusius/_napari/_theme.py
+++ b/src/confusius/_napari/_theme.py
@@ -230,9 +230,17 @@ def make_lucide_icon(name: str, color: str, size: int = 16) -> QIcon:
 
 
 def create_export_button(
-    toolbar: QWidget, object_name: str, on_export, text: str = "Export"
+    toolbar: QWidget,
+    object_name: str,
+    on_export,
+    text: str = "Export",
+    tooltip: str = "Export the plotted data.",
 ) -> QToolButton:
-    """Create an export button for a matplotlib toolbar.
+    """Create a themed toolbar button for a matplotlib toolbar.
+
+    Despite the name, this is a generic themed-button factory (icon set
+    separately via [`style_export_button`][confusius._napari._theme.style_export_button]);
+    reused for e.g. a "Pin" button alongside the export button.
 
     Parameters
     ----------
@@ -243,17 +251,19 @@ def create_export_button(
     on_export : callable
         Callback triggered when the button is clicked.
     text : str, default: "Export"
-        Button label shown next to the export icon.
+        Button label shown next to the icon.
+    tooltip : str, default: "Export the plotted data."
+        Tooltip shown on hover.
 
     Returns
     -------
     QToolButton
-        Configured export button.
+        Configured button.
     """
     button = QToolButton(toolbar)
     button.setObjectName(object_name)
     button.setText(text)
-    button.setToolTip("Export the plotted data.")
+    button.setToolTip(tooltip)
     button.setAutoRaise(True)
     button.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextBesideIcon)
     button.clicked.connect(on_export)
@@ -261,18 +271,23 @@ def create_export_button(
     return button
 
 
-def style_export_button(button: QToolButton, colors: dict) -> None:
-    """Apply themed styling to an export button.
+def style_export_button(
+    button: QToolButton, colors: dict, icon_name: str = "download"
+) -> None:
+    """Apply themed styling to a toolbar button built by `create_export_button`.
 
     Parameters
     ----------
     button : QToolButton
-        Export button to style.
+        Button to style.
     colors : dict
         Napari theme color mapping produced by
         [`get_napari_colors`][confusius._napari._theme.get_napari_colors].
+    icon_name : str, default: "download"
+        Stem of the Lucide SVG asset to render, passed to
+        [`make_lucide_icon`][confusius._napari._theme.make_lucide_icon].
     """
-    button.setIcon(make_lucide_icon("download", colors["accent"], size=22))
+    button.setIcon(make_lucide_icon(icon_name, colors["accent"], size=22))
     button.setIconSize(QSize(22, 22))
     button.setToolButtonStyle(
         Qt.ToolButtonStyle.ToolButtonTextBesideIcon

--- a/src/confusius/_napari/_utils.py
+++ b/src/confusius/_napari/_utils.py
@@ -1,5 +1,13 @@
 """Shared helpers for the ConfUSIus napari plugin."""
 
+from typing import TYPE_CHECKING
+
+import numpy as np
+import numpy.typing as npt
+
+if TYPE_CHECKING:
+    from napari.layers import Layer
+
 CATEGORICAL_COLORS = [
     "#4e79a7",
     "#f28e2b",
@@ -14,6 +22,84 @@ CATEGORICAL_COLORS = [
 ]
 """Qualitative palette cycled to assign distinct colors to categories.
 
-Shared by the signal store (per imported signal) and the event store (per trial
+Shared by the signal store (per stored signal) and the event store (per trial
 type) so the plugin uses one consistent set of distinguishable colors.
 """
+
+
+def extract_voxel_trace(
+    layer: "Layer", world_position: npt.NDArray[np.floating], xaxis_index: int
+) -> npt.NDArray[np.floating] | None:
+    """Extract the nearest-voxel trace along one axis at a world position.
+
+    Parameters
+    ----------
+    layer : napari.layers.Layer
+        Image layer to extract from.
+    world_position : numpy.ndarray
+        World-coordinate position, in `layer`'s number of dimensions.
+    xaxis_index : int
+        Data-axis index kept as a full slice (e.g. the `time` axis); all other axes
+        are collapsed to their nearest-voxel index.
+
+    Returns
+    -------
+    numpy.ndarray or None
+        1D trace along `xaxis_index`, or `None` if the rounded voxel position falls
+        outside the layer's data bounds.
+    """
+    data = layer.data
+    ind = [round(v) for v in layer.world_to_data(world_position)]
+    ind[xaxis_index] = slice(None)  # type: ignore[call-overload]
+
+    if not all(
+        0 <= i < max_i for i, max_i in zip(ind, data.shape) if isinstance(i, int)
+    ):
+        return None
+
+    return np.asarray(data[tuple(ind)], dtype=float)
+
+
+def extract_label_mean_trace(
+    layer: "Layer",
+    labels_data: npt.NDArray[np.integer],
+    label_id: int,
+    xaxis_index: int,
+) -> npt.NDArray[np.floating] | None:
+    """Extract the mean trace over voxels matching one label, along one axis.
+
+    Parameters
+    ----------
+    layer : napari.layers.Layer
+        Image layer to extract from.
+    labels_data : numpy.ndarray
+        Labels array, either the same shape as `layer.data` or its spatial shape
+        (i.e. `layer.data`'s shape with `xaxis_index` removed).
+    label_id : int
+        Label value to average over.
+    xaxis_index : int
+        Data-axis index kept as a full slice (e.g. the `time` axis); the mean is
+        taken over all other (spatial) axes.
+
+    Returns
+    -------
+    numpy.ndarray or None
+        1D mean trace along `xaxis_index`, or `None` if `labels_data`'s shape does
+        not match `layer.data` (directly or spatially) or no voxel matches `label_id`.
+    """
+    img_data = np.asarray(layer.data)
+    img_spatial = tuple(s for i, s in enumerate(img_data.shape) if i != xaxis_index)
+
+    if labels_data.shape == img_data.shape:
+        labels_spatial = np.max(labels_data, axis=xaxis_index)
+    elif labels_data.shape == img_spatial:
+        labels_spatial = labels_data
+    else:
+        return None
+
+    mask = labels_spatial == label_id
+    if not mask.any():
+        return None
+
+    img_arr = np.moveaxis(img_data, xaxis_index, -1)
+    return np.asarray(img_arr[mask].mean(axis=0), dtype=float)

--- a/src/confusius/_napari/_widget.py
+++ b/src/confusius/_napari/_widget.py
@@ -158,6 +158,20 @@ QComboBox {{
     border-radius: 3px;
     padding: 4px 6px;
 }}
+QListWidget {{
+    background: {input_bg};
+    color: {input_fg};
+    border: 1px solid {input_border};
+    border-radius: 3px;
+}}
+QListWidget::item:selected {{
+    background: {accent};
+    color: {accent_fg};
+}}
+QListWidget::item:selected:!active {{
+    background: {accent};
+    color: {accent_fg};
+}}
 
 /* ---- Buttons ---- */
 QPushButton {{
@@ -257,8 +271,9 @@ class ConfUSIusWidget(QWidget):
         # plotter (background shading) and the time overlay (active-event readout).
         self._event_store = EventStore(self)
         # Shared store of stored/live signals, used by the Signals panel (source of
-        # truth) and the QC panel (adds computed DVARS traces so they're selectable
-        # elsewhere, e.g. as a scrubbing sample mask).
+        # truth), the QC panel (adds computed DVARS traces so they're selectable
+        # elsewhere, e.g. as a scrubbing sample mask), and the Preprocessing panel
+        # (confounds/sample mask sourcing).
         self._signal_store = SignalStore(self)
         self._apply_theme()
         self._setup_ui()
@@ -526,6 +541,7 @@ class ConfUSIusWidget(QWidget):
         from confusius._napari._data._load_panel import DataPanel
         from confusius._napari._data._save_panel import SavePanel
         from confusius._napari._events._panel import EventPanel
+        from confusius._napari._preprocessing._panel import PreprocessingPanel
         from confusius._napari._qc._panel import QCPanel
         from confusius._napari._registration._panel import RegistrationPanel
         from confusius._napari._signals._panel import SignalPanel
@@ -554,6 +570,7 @@ class ConfUSIusWidget(QWidget):
             ("Video", "video"),
             ("Signals", "chart-line"),
             ("Registration", "images"),
+            ("Preprocessing", "brush-cleaning"),
             ("Events", "calendar-clock"),
             ("Quality Control", "clipboard-check"),
         ]
@@ -566,6 +583,7 @@ class ConfUSIusWidget(QWidget):
                 signal_store=self._signal_store,
             ),
             RegistrationPanel(self.viewer),
+            PreprocessingPanel(self.viewer, signal_store=self._signal_store),
             EventPanel(self.viewer, self._event_store),
             QCPanel(self.viewer, signal_store=self._signal_store),
         ]

--- a/src/confusius/_napari/_widget.py
+++ b/src/confusius/_napari/_widget.py
@@ -31,6 +31,7 @@ from qtpy.QtWidgets import (
 
 from confusius._napari._events._store import EventStore
 from confusius._napari._qt import install_no_scroll_wheel_filter
+from confusius._napari._signals._store import SignalStore
 from confusius._napari._theme import make_lucide_icon
 from confusius._napari._time_overlay import _TimeOverlay
 from confusius._utils.colors import RED, RED_DARK
@@ -255,6 +256,10 @@ class ConfUSIusWidget(QWidget):
         # Shared store of BIDS temporal events, used by the event panel, the signal
         # plotter (background shading) and the time overlay (active-event readout).
         self._event_store = EventStore(self)
+        # Shared store of stored/live signals, used by the Signals panel (source of
+        # truth) and the QC panel (adds computed DVARS traces so they're selectable
+        # elsewhere, e.g. as a scrubbing sample mask).
+        self._signal_store = SignalStore(self)
         self._apply_theme()
         self._setup_ui()
         self.viewer.events.theme.connect(self._on_theme_changed)
@@ -555,10 +560,14 @@ class ConfUSIusWidget(QWidget):
         panels = [
             data_panel,
             video_panel,
-            SignalPanel(self.viewer, event_store=self._event_store),
+            SignalPanel(
+                self.viewer,
+                event_store=self._event_store,
+                signal_store=self._signal_store,
+            ),
             RegistrationPanel(self.viewer),
             EventPanel(self.viewer, self._event_store),
-            QCPanel(self.viewer),
+            QCPanel(self.viewer, signal_store=self._signal_store),
         ]
         btns: list[QPushButton] = []
 

--- a/src/confusius/_napari/assets/brush-cleaning.svg
+++ b/src/confusius/_napari/assets/brush-cleaning.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m16 22-1-4M19 14a1 1 0 0 0 1-1v-1a2 2 0 0 0-2-2h-3a1 1 0 0 1-1-1V4a2 2 0 0 0-4 0v5a1 1 0 0 1-1 1H6a2 2 0 0 0-2 2v1a1 1 0 0 0 1 1" />
+  <path d="M19 14H5l-1.973 6.767A1 1 0 0 0 4 22h16a1 1 0 0 0 .973-1.233zM8 22l1-4" />
+</svg>

--- a/src/confusius/_napari/assets/pin.svg
+++ b/src/confusius/_napari/assets/pin.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 17v5" />
+  <path d="M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V16a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V7a1 1 0 0 1 1-1 2 2 0 0 0 0-4H8a2 2 0 0 0 0 4 1 1 0 0 1 1 1z" />
+</svg>

--- a/tests/unit/test_napari/test_preprocessing_panel.py
+++ b/tests/unit/test_napari/test_preprocessing_panel.py
@@ -1033,6 +1033,14 @@ class TestCompcorSubprocess:
 
 
 class TestComputeCompcor:
+    """Each test here waits on a real ProcessPoolExecutor(spawn) run.
+
+    Spawning a fresh interpreter and reimporting confusius' dependency stack (numpy,
+    scipy, sklearn, xarray, dask) can take several seconds on a loaded CI runner —
+    especially on Windows, where process creation is inherently slower than
+    fork — so these use a longer waitUntil timeout than the rest of the file.
+    """
+
     def test_matches_direct_compute_compcor_confounds_call(
         self, qtbot, viewer, panel, signals_store, sample_voxeldata_3dt
     ):
@@ -1054,7 +1062,7 @@ class TestComputeCompcor:
         panel._compcor_components_spin.setValue(2)
 
         panel._compute_compcor()
-        qtbot.waitUntil(lambda: len(signals_store.stored_signals()) == 2, timeout=5000)
+        qtbot.waitUntil(lambda: len(signals_store.stored_signals()) == 2, timeout=20000)
 
         noise_mask = xr.zeros_like(
             sample_voxeldata_3dt.isel(time=0, drop=True), dtype=bool
@@ -1094,11 +1102,11 @@ class TestComputeCompcor:
 
         panel._compcor_components_spin.setValue(4)
         panel._compute_compcor()
-        qtbot.waitUntil(lambda: len(signals_store.stored_signals()) == 4, timeout=5000)
+        qtbot.waitUntil(lambda: len(signals_store.stored_signals()) == 4, timeout=20000)
 
         panel._compcor_components_spin.setValue(2)
         panel._compute_compcor()
-        qtbot.waitUntil(lambda: len(signals_store.stored_signals()) == 2, timeout=5000)
+        qtbot.waitUntil(lambda: len(signals_store.stored_signals()) == 2, timeout=20000)
 
         stored_names = {s.name for s in signals_store.stored_signals()}
         assert stored_names == {
@@ -1127,7 +1135,7 @@ class TestComputeCompcor:
         assert panel._compcor_progress.isVisibleTo(panel)
         assert not panel._progress.isVisibleTo(panel)
 
-        qtbot.waitUntil(lambda: len(signals_store.stored_signals()) == 5, timeout=5000)
+        qtbot.waitUntil(lambda: len(signals_store.stored_signals()) == 5, timeout=20000)
         assert not panel._compcor_progress.isVisibleTo(panel)
 
     def test_recomputing_updates_signals_in_place(
@@ -1149,7 +1157,7 @@ class TestComputeCompcor:
         panel._compcor_components_spin.setValue(1)
 
         panel._compute_compcor()
-        qtbot.waitUntil(lambda: len(signals_store.stored_signals()) == 1, timeout=5000)
+        qtbot.waitUntil(lambda: len(signals_store.stored_signals()) == 1, timeout=20000)
         panel._compute_compcor()
         qtbot.wait(500)  # Give a second run a chance to (wrongly) duplicate.
 

--- a/tests/unit/test_napari/test_preprocessing_panel.py
+++ b/tests/unit/test_napari/test_preprocessing_panel.py
@@ -1003,6 +1003,7 @@ class TestCompcorSubprocess:
         # ProcessPoolExecutor needs to pickle both the callable and its
         # arguments/return value; a closure or an object carrying a Qt/napari
         # reference would fail here even though it works when called directly.
+        import multiprocessing
         from concurrent.futures import ProcessPoolExecutor
 
         from confusius._napari._preprocessing._panel import _compcor_subprocess
@@ -1010,7 +1011,13 @@ class TestCompcorSubprocess:
         values = rng.random((20, 3, 4, 5))
         time_values = np.arange(20, dtype=float) * 0.5
 
-        with ProcessPoolExecutor(max_workers=1) as pool:
+        # "spawn", not the platform-default "fork" on Linux: this test runs inside
+        # a pytest session that has already initialised Qt/napari (open X11/GL
+        # connections, GUI event loops), and forking a process with those resources
+        # already open can crash the child immediately (BrokenProcessPool) — the
+        # same hazard `_run_compcor` avoids in production for the same reason.
+        context = multiprocessing.get_context("spawn")
+        with ProcessPoolExecutor(max_workers=1, mp_context=context) as pool:
             result_time, result_values = pool.submit(
                 _compcor_subprocess,
                 values,

--- a/tests/unit/test_napari/test_preprocessing_panel.py
+++ b/tests/unit/test_napari/test_preprocessing_panel.py
@@ -1075,6 +1075,37 @@ class TestComputeCompcor:
             rtol=1e-5,
         )
 
+    def test_recomputing_with_fewer_components_drops_stale_signals(
+        self, qtbot, viewer, panel, signals_store, sample_voxeldata_3dt
+    ):
+        plot_napari(
+            sample_voxeldata_3dt,
+            viewer=viewer,
+            show_colorbar=False,
+            show_scale_bar=False,
+        )
+        labels = np.zeros(sample_voxeldata_3dt.shape[1:], dtype=np.int32)
+        labels[:2] = 1
+        viewer.add_labels(labels, name="wm")
+
+        panel._refresh_layer_combos()
+        panel._source_combo.setCurrentText("power_doppler")
+        panel._compcor_mask_combo.setCurrentText("wm")
+
+        panel._compcor_components_spin.setValue(4)
+        panel._compute_compcor()
+        qtbot.waitUntil(lambda: len(signals_store.stored_signals()) == 4, timeout=5000)
+
+        panel._compcor_components_spin.setValue(2)
+        panel._compute_compcor()
+        qtbot.waitUntil(lambda: len(signals_store.stored_signals()) == 2, timeout=5000)
+
+        stored_names = {s.name for s in signals_store.stored_signals()}
+        assert stored_names == {
+            "CompCor 0 (power_doppler)",
+            "CompCor 1 (power_doppler)",
+        }
+
     def test_shows_its_own_busy_indicator_not_the_shared_one(
         self, qtbot, viewer, panel, signals_store, sample_voxeldata_3dt
     ):

--- a/tests/unit/test_napari/test_preprocessing_panel.py
+++ b/tests/unit/test_napari/test_preprocessing_panel.py
@@ -1,0 +1,1139 @@
+"""Unit tests for the PreprocessingPanel widget.
+
+Covers source-layer/signal combo population (including live point/label signals from
+the signal store), pipeline keyword-argument building from UI state, raw signal
+alignment (confounds/sample mask), live-signal re-extraction, and end-to-end Apply
+runs (via `qtbot.waitUntil`) that compare the resulting layer against directly-chained
+calls to `confusius.timing`/`confusius.spatial`/`confusius.signal`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from confusius._napari._preprocessing._panel import (
+    _align_series,
+    _MaskSpec,
+    _threshold_mask,
+)
+from confusius._napari._signals._store import LiveSignal, StoredSignal
+from confusius.plotting import plot_napari
+from confusius.signal import clean
+from confusius.spatial import smooth_volume
+from confusius.timing import resample_to_uniform_time
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def viewer(make_napari_viewer):
+    return make_napari_viewer()
+
+
+@pytest.fixture
+def panel(viewer, signals_store):
+    from confusius._napari._preprocessing._panel import PreprocessingPanel
+
+    return PreprocessingPanel(viewer, signal_store=signals_store)
+
+
+def _imported_signal(name: str, x: np.ndarray, y: np.ndarray) -> StoredSignal:
+    return StoredSignal(
+        id=f"imported-{name}",
+        name=name,
+        x=x,
+        y=y,
+        visible=True,
+        color="#000000",
+        source_label="test.csv",
+        file_path=Path("test.csv"),
+        original_column_name=name,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Source / reference combos
+# ---------------------------------------------------------------------------
+
+
+class TestSourceCombo:
+    def test_lists_image_layers_with_time_dim(
+        self, viewer, panel, sample_voxeldata_3dt
+    ):
+        plot_napari(
+            sample_voxeldata_3dt,
+            viewer=viewer,
+            show_colorbar=False,
+            show_scale_bar=False,
+        )
+        panel._refresh_layer_combos()
+        items = [
+            panel._source_combo.itemText(i) for i in range(panel._source_combo.count())
+        ]
+        assert items == ["power_doppler"]
+
+    def test_excludes_layers_without_xarray_metadata(self, viewer, panel):
+        viewer.add_image(np.zeros((10, 4, 6, 8)))
+        panel._refresh_layer_combos()
+        assert panel._source_combo.count() == 0
+
+    def test_excludes_layers_with_singleton_time_dim(self, viewer, panel):
+        da = xr.DataArray(np.zeros((1, 4, 6, 8)), dims=["time", "z", "y", "x"])
+        viewer.add_image(da.values, name="static", metadata={"xarray": da})
+        panel._refresh_layer_combos()
+        assert panel._source_combo.count() == 0
+
+    def test_excludes_labels_layers(self, viewer, panel, sample_voxeldata_3dt):
+        labels = (sample_voxeldata_3dt.values > 0.5).astype(np.int32)
+        viewer.add_labels(
+            labels, name="mask", metadata={"xarray": sample_voxeldata_3dt}
+        )
+        panel._refresh_layer_combos()
+        assert panel._source_combo.count() == 0
+
+
+class TestReferenceCombo:
+    def test_shares_eligibility_with_source_combo(
+        self, viewer, panel, sample_voxeldata_3dt
+    ):
+        plot_napari(
+            sample_voxeldata_3dt,
+            viewer=viewer,
+            show_colorbar=False,
+            show_scale_bar=False,
+        )
+        panel._refresh_layer_combos()
+        items = [
+            panel._resample_reference_combo.itemText(i)
+            for i in range(panel._resample_reference_combo.count())
+        ]
+        assert items == ["power_doppler"]
+
+
+class TestPrefillResampleDefaults:
+    def test_prefills_step_from_source_time_coordinate(
+        self, viewer, panel, sample_voxeldata_3dt
+    ):
+        plot_napari(
+            sample_voxeldata_3dt,
+            viewer=viewer,
+            show_colorbar=False,
+            show_scale_bar=False,
+        )
+        panel._refresh_layer_combos()
+        panel._source_combo.setCurrentText("power_doppler")
+
+        # sample_voxeldata_3dt's time coordinate is 10.0 + arange(10) * 0.5.
+        assert panel._resample_step_spin.value() == pytest.approx(0.5)
+
+    def test_noop_without_time_coordinate(self, viewer, panel):
+        da = xr.DataArray(np.zeros((5, 4, 6, 8)), dims=["time", "z", "y", "x"])
+        viewer.add_image(da.values, name="raw", metadata={"xarray": da})
+        panel._refresh_layer_combos()
+        panel._source_combo.setCurrentText("raw")
+        # No time coordinate to prefill from: spin keeps its construction default.
+        assert panel._resample_step_spin.value() == pytest.approx(0.5)
+
+
+# ---------------------------------------------------------------------------
+# Resample mode / advanced-filter fold toggles
+# ---------------------------------------------------------------------------
+
+
+class TestResampleModeToggle:
+    def test_no_resampling_hides_everything(self, panel):
+        assert panel._resample_mode_combo.currentText() == "No resampling"
+        assert not panel._uniform_widget.isVisibleTo(panel)
+        assert not panel._reference_widget.isVisibleTo(panel)
+        assert not panel._resample_method_widget.isVisibleTo(panel)
+
+    def test_uniform_grid_shows_step_and_method(self, panel):
+        panel._resample_mode_combo.setCurrentText("Uniform grid")
+        assert panel._uniform_widget.isVisibleTo(panel)
+        assert panel._resample_method_widget.isVisibleTo(panel)
+        assert not panel._reference_widget.isVisibleTo(panel)
+
+    def test_match_reference_shows_reference_and_method(self, panel):
+        panel._resample_mode_combo.setCurrentText("Match reference layer")
+        assert panel._reference_widget.isVisibleTo(panel)
+        assert panel._resample_method_widget.isVisibleTo(panel)
+        assert not panel._uniform_widget.isVisibleTo(panel)
+
+
+class TestAdvancedFilterToggle:
+    def test_hidden_by_default(self, panel):
+        assert not panel._advanced_widget.isVisibleTo(panel)
+
+    def test_shown_when_checked(self, panel):
+        panel._advanced_toggle.setChecked(True)
+        assert panel._advanced_widget.isVisibleTo(panel)
+
+
+# ---------------------------------------------------------------------------
+# Signal (confounds/sample mask) combos
+# ---------------------------------------------------------------------------
+
+
+def _confounds_list_items(panel) -> list[str]:
+    return [
+        panel._confounds_list.item(i).text()
+        for i in range(panel._confounds_list.count())
+    ]
+
+
+def _check_confound(panel, name: str) -> None:
+    """Select the confounds-list item with the given name."""
+    for i in range(panel._confounds_list.count()):
+        item = panel._confounds_list.item(i)
+        if item.text() == name:
+            item.setSelected(True)
+            return
+    raise AssertionError(f"No confound item named {name!r}.")
+
+
+class TestSignalCombos:
+    def test_confounds_list_has_no_none_sentinel(
+        self, panel, signals_store, signals_csv
+    ):
+        signals_store.import_file(signals_csv)
+        panel._refresh_signal_combos()
+        assert _confounds_list_items(panel) == ["a", "b"]
+
+    def test_refreshes_on_store_change(self, panel, signals_store, signals_csv):
+        assert panel._mask_combo.count() == 1  # Just "None".
+        signals_store.import_file(signals_csv)
+        items = [
+            panel._mask_combo.itemText(i) for i in range(panel._mask_combo.count())
+        ]
+        assert items == ["None", "a", "b"]
+
+    def test_includes_point_and_label_live_signals(self, panel, signals_store):
+        signals_store.register_live_signals(
+            [
+                LiveSignal(
+                    id="point-0",
+                    name="Point 0",
+                    color="#000000",
+                    visible=True,
+                    source_type="point",
+                    source_id=0,
+                    layer_name="Points (3D)",
+                ),
+                LiveSignal(
+                    id="label-1",
+                    name="Label 1",
+                    color="#000000",
+                    visible=True,
+                    source_type="label",
+                    source_id=1,
+                    layer_name="Labels (3D)",
+                ),
+            ]
+        )
+        panel._refresh_signal_combos()
+        assert _confounds_list_items(panel) == ["Point 0", "Label 1"]
+
+    def test_excludes_mouse_live_signal(self, panel, signals_store):
+        signals_store.register_live_signals(
+            [
+                LiveSignal(
+                    id="mouse-0",
+                    name="Cursor",
+                    color="#000000",
+                    visible=True,
+                    source_type="mouse",
+                    source_id=None,
+                    layer_name=None,
+                ),
+            ]
+        )
+        panel._refresh_signal_combos()
+        assert _confounds_list_items(panel) == []
+
+    def test_selected_confounds_survive_a_refresh(
+        self, panel, signals_store, signals_csv
+    ):
+        signals_store.import_file(signals_csv)
+        panel._refresh_signal_combos()
+        panel._confounds_list.item(0).setSelected(True)
+
+        # Trigger another refresh (e.g. a new signal arriving).
+        signals_store.pin_signal(
+            origin="test",
+            name="c",
+            x=np.array([0.0]),
+            y=np.array([1.0]),
+            color="#000000",
+            source_label="test",
+        )
+
+        assert panel._selected_confound_names() == ["a"]
+
+    def test_selecting_a_range_yields_every_item_in_it(
+        self, panel, signals_store, tmp_path
+    ):
+        # Simulates a shift-click range select spanning several stored signals
+        # (e.g. a batch of CompCor components), not just single-item toggling.
+        for name in ["a", "b", "c", "d"]:
+            path = tmp_path / f"{name}.csv"
+            path.write_text(f"time,{name}\n0,1\n1,2\n")
+            signals_store.import_file(path)
+        panel._refresh_signal_combos()
+
+        selection_model = panel._confounds_list.selectionModel()
+        top = panel._confounds_list.model().index(1, 0)
+        bottom = panel._confounds_list.model().index(2, 0)
+        selection_model.select(
+            top,
+            selection_model.SelectionFlag.Select | selection_model.SelectionFlag.Rows,
+        )
+        selection_model.select(
+            bottom,
+            selection_model.SelectionFlag.Select | selection_model.SelectionFlag.Rows,
+        )
+
+        assert set(panel._selected_confound_names()) == {"b", "c"}
+
+
+# ---------------------------------------------------------------------------
+# _align_series
+# ---------------------------------------------------------------------------
+
+
+class TestAlignSeries:
+    def test_interpolates_onto_matching_time_grid(self):
+        reference = xr.DataArray(
+            np.zeros(4), dims="time", coords={"time": [0.0, 1.0, 2.0, 3.0]}
+        )
+        result = _align_series(
+            np.array([0.0, 1.0, 2.0, 3.0]),
+            np.array([10.0, 20.0, 30.0, 40.0]),
+            reference,
+        )
+        np.testing.assert_allclose(result.values, [10.0, 20.0, 30.0, 40.0])
+        np.testing.assert_allclose(result.coords["time"].values, reference["time"])
+
+    def test_uses_raw_values_without_x(self):
+        reference = xr.DataArray(np.zeros(3), dims="time")
+        result = _align_series(None, np.array([1.0, 2.0, 3.0]), reference)
+        np.testing.assert_allclose(result.values, [1.0, 2.0, 3.0])
+
+    def test_raises_on_length_mismatch_without_x(self):
+        reference = xr.DataArray(np.zeros(3), dims="time")
+        with pytest.raises(ValueError, match="no shared 'time' coordinate to align by"):
+            _align_series(None, np.array([1.0, 2.0]), reference)
+
+
+# ---------------------------------------------------------------------------
+# _threshold_mask
+# ---------------------------------------------------------------------------
+
+
+class TestThresholdMask:
+    def test_already_binary_uses_nonzero_as_keep(self):
+        aligned = xr.DataArray(np.array([0.0, 1.0, 0.0, 1.0]), dims="time")
+        result = _threshold_mask(
+            aligned,
+            _MaskSpec(x=None, y=aligned.values, threshold=None, keep_above=True),
+        )
+        assert result.dtype == bool
+        np.testing.assert_array_equal(result.values, [False, True, False, True])
+
+    def test_keep_above_threshold(self):
+        aligned = xr.DataArray(np.array([0.1, 0.4, 0.2, 0.6]), dims="time")
+        result = _threshold_mask(
+            aligned,
+            _MaskSpec(x=None, y=aligned.values, threshold=0.3, keep_above=True),
+        )
+        np.testing.assert_array_equal(result.values, [False, True, False, True])
+
+    def test_keep_below_threshold(self):
+        aligned = xr.DataArray(np.array([0.1, 0.4, 0.2, 0.6]), dims="time")
+        result = _threshold_mask(
+            aligned,
+            _MaskSpec(x=None, y=aligned.values, threshold=0.3, keep_above=False),
+        )
+        np.testing.assert_array_equal(result.values, [True, False, True, False])
+
+
+# ---------------------------------------------------------------------------
+# _resolve_raw_signal / _extract_live_series
+# ---------------------------------------------------------------------------
+
+
+class TestResolveRawSignal:
+    def test_none_selection_returns_none(self, viewer, panel, sample_voxeldata_3dt):
+        _, layer = plot_napari(
+            sample_voxeldata_3dt,
+            viewer=viewer,
+            show_colorbar=False,
+            show_scale_bar=False,
+        )
+        assert panel._resolve_raw_signal("None", layer) is None
+        assert panel._resolve_raw_signal("", layer) is None
+
+    def test_unknown_signal_raises(self, viewer, panel, sample_voxeldata_3dt):
+        _, layer = plot_napari(
+            sample_voxeldata_3dt,
+            viewer=viewer,
+            show_colorbar=False,
+            show_scale_bar=False,
+        )
+        with pytest.raises(ValueError, match="not found"):
+            panel._resolve_raw_signal("nope", layer)
+
+    def test_resolves_imported_signal_raw_xy(
+        self, viewer, panel, signals_store, signals_csv, sample_voxeldata_3dt
+    ):
+        signals_store.import_file(signals_csv)  # time=[0,1,2], a=[1,2,3], b=[4,5,6].
+        _, layer = plot_napari(
+            sample_voxeldata_3dt,
+            viewer=viewer,
+            show_colorbar=False,
+            show_scale_bar=False,
+        )
+        x, y = panel._resolve_raw_signal("a", layer)
+        np.testing.assert_allclose(x, [0.0, 1.0, 2.0])
+        np.testing.assert_allclose(y, [1.0, 2.0, 3.0])
+
+    def test_resolves_point_live_signal_by_voxel_position(
+        self, viewer, panel, signals_store, sample_voxeldata_3dt
+    ):
+        _, image_layer = plot_napari(
+            sample_voxeldata_3dt,
+            viewer=viewer,
+            show_colorbar=False,
+            show_scale_bar=False,
+        )
+        spatial_scale = np.asarray(image_layer.scale)[1:]
+        spatial_translate = np.asarray(image_layer.translate)[1:]
+        points_layer = viewer.add_points(
+            np.array([[1.0, 2.0, 3.0]]),
+            name="Points (3D)",
+            ndim=3,
+            scale=spatial_scale,
+            translate=spatial_translate,
+        )
+        signals_store.register_live_signals(
+            [
+                LiveSignal(
+                    id="point-0",
+                    name="Point 0",
+                    color="#000000",
+                    visible=True,
+                    source_type="point",
+                    source_id=0,
+                    layer_name=points_layer.name,
+                ),
+            ]
+        )
+
+        x, y = panel._resolve_raw_signal("Point 0", image_layer)
+        np.testing.assert_allclose(x, sample_voxeldata_3dt["time"].values)
+        np.testing.assert_allclose(y, sample_voxeldata_3dt.values[:, 1, 2, 3])
+
+    def test_resolves_label_live_signal_as_mean_trace(
+        self, viewer, panel, signals_store, sample_voxeldata_3dt
+    ):
+        _, image_layer = plot_napari(
+            sample_voxeldata_3dt,
+            viewer=viewer,
+            show_colorbar=False,
+            show_scale_bar=False,
+        )
+        labels_data = np.zeros(sample_voxeldata_3dt.shape[1:], dtype=np.int32)
+        labels_data[0, 0, :2] = 1
+        labels_layer = viewer.add_labels(labels_data, name="Labels (3D)")
+        signals_store.register_live_signals(
+            [
+                LiveSignal(
+                    id="label-1",
+                    name="Label 1",
+                    color="#000000",
+                    visible=True,
+                    source_type="label",
+                    source_id=1,
+                    layer_name=labels_layer.name,
+                ),
+            ]
+        )
+
+        x, y = panel._resolve_raw_signal("Label 1", image_layer)
+        expected = sample_voxeldata_3dt.values[:, 0, 0, :2].mean(axis=-1)
+        np.testing.assert_allclose(x, sample_voxeldata_3dt["time"].values)
+        np.testing.assert_allclose(y, expected)
+
+    def test_stale_live_signal_layer_raises(
+        self, viewer, panel, signals_store, sample_voxeldata_3dt
+    ):
+        _, image_layer = plot_napari(
+            sample_voxeldata_3dt,
+            viewer=viewer,
+            show_colorbar=False,
+            show_scale_bar=False,
+        )
+        signals_store.register_live_signals(
+            [
+                LiveSignal(
+                    id="point-0",
+                    name="Point 0",
+                    color="#000000",
+                    visible=True,
+                    source_type="point",
+                    source_id=0,
+                    layer_name="Nonexistent Points",
+                ),
+            ]
+        )
+        with pytest.raises(ValueError, match="Could not extract signal"):
+            panel._resolve_raw_signal("Point 0", image_layer)
+
+
+# ---------------------------------------------------------------------------
+# _build_clean_kwargs / _build_resample_spec / _build_smooth_kwargs
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCleanKwargs:
+    def test_defaults(self, panel):
+        kwargs = panel._build_clean_kwargs()
+        assert kwargs["detrend_order"] is None  # Detrending is off by default.
+        assert kwargs["standardize_method"] is None
+        assert kwargs["low_cutoff"] is None
+        assert kwargs["high_cutoff"] is None
+        assert kwargs["filter_kwargs"] == {
+            "order": 5,
+            "padtype": "odd",
+            "padlen": None,
+            "uniformity_tolerance": 1e-2,
+        }
+        assert kwargs["standardize_confounds"] is True
+        assert kwargs["ensure_finite"] is False
+        assert kwargs["interpolate_method"] == "linear"
+
+    def test_checked_detrend_uses_spin_value(self, panel):
+        panel._detrend_check.setChecked(True)
+        panel._detrend_order_spin.setValue(2)
+        assert panel._build_clean_kwargs()["detrend_order"] == 2
+
+    def test_standardize_combo_maps_to_clean_literal(self, panel):
+        panel._standardize_combo.setCurrentText("Z-score")
+        assert panel._build_clean_kwargs()["standardize_method"] == "zscore"
+        panel._standardize_combo.setCurrentText("Percent signal change")
+        assert panel._build_clean_kwargs()["standardize_method"] == "psc"
+
+    def test_cutoffs_only_applied_when_checked(self, panel):
+        panel._low_cutoff_check.setChecked(True)
+        panel._low_cutoff_spin.setValue(0.02)
+        panel._high_cutoff_check.setChecked(True)
+        panel._high_cutoff_spin.setValue(0.5)
+        kwargs = panel._build_clean_kwargs()
+        assert kwargs["low_cutoff"] == pytest.approx(0.02)
+        assert kwargs["high_cutoff"] == pytest.approx(0.5)
+
+    def test_padtype_none_option_maps_to_python_none(self, panel):
+        panel._padtype_combo.setCurrentText("None")
+        assert panel._build_clean_kwargs()["filter_kwargs"]["padtype"] is None
+
+    def test_nonzero_padlen_is_forwarded(self, panel):
+        panel._padlen_spin.setValue(64)
+        assert panel._build_clean_kwargs()["filter_kwargs"]["padlen"] == 64
+
+
+class TestBuildMaskSpec:
+    def test_no_signal_selected_returns_none(self, panel, viewer, sample_voxeldata_3dt):
+        _, layer = plot_napari(
+            sample_voxeldata_3dt,
+            viewer=viewer,
+            show_colorbar=False,
+            show_scale_bar=False,
+        )
+        assert panel._build_mask_spec(layer) is None
+
+    def test_already_binary_mode_ignores_threshold_spin(
+        self, panel, viewer, signals_store, sample_voxeldata_3dt
+    ):
+        _, layer = plot_napari(
+            sample_voxeldata_3dt,
+            viewer=viewer,
+            show_colorbar=False,
+            show_scale_bar=False,
+        )
+        signals_store.pin_signal(
+            origin="test-censor",
+            name="censor",
+            x=np.arange(10.0),
+            y=np.array([0, 1] * 5, dtype=float),
+            color="#000000",
+            source_label="test",
+        )
+        panel._refresh_signal_combos()
+        panel._mask_combo.setCurrentText("censor")
+        panel._mask_threshold_spin.setValue(999.0)  # must be ignored in this mode
+
+        spec = panel._build_mask_spec(layer)
+        assert spec is not None
+        assert spec.threshold is None
+
+    def test_threshold_mode_reads_spin_and_direction(
+        self, panel, viewer, signals_store, sample_voxeldata_3dt
+    ):
+        _, layer = plot_napari(
+            sample_voxeldata_3dt,
+            viewer=viewer,
+            show_colorbar=False,
+            show_scale_bar=False,
+        )
+        signals_store.pin_signal(
+            origin="test-fd",
+            name="fd",
+            x=np.arange(10.0),
+            y=np.linspace(0, 1, 10),
+            color="#000000",
+            source_label="test",
+        )
+        panel._refresh_signal_combos()
+        panel._mask_combo.setCurrentText("fd")
+        panel._mask_mode_combo.setCurrentText("Keep where value <")
+        panel._mask_threshold_spin.setValue(0.3)
+
+        spec = panel._build_mask_spec(layer)
+        assert spec is not None
+        assert spec.threshold == pytest.approx(0.3)
+        assert spec.keep_above is False
+
+
+class TestBuildResampleSpec:
+    def test_no_resampling_returns_none(self, panel):
+        assert panel._build_resample_spec() is None
+
+    def test_uniform_grid_spec_always_uses_recording_bounds(self, panel):
+        panel._resample_mode_combo.setCurrentText("Uniform grid")
+        panel._resample_step_spin.setValue(0.25)
+        mode, kwargs = panel._build_resample_spec()
+        assert mode == "Uniform grid"
+        assert kwargs == {
+            "start": None,
+            "stop": None,
+            "step": 0.25,
+            "method": "linear",
+        }
+
+    def test_match_reference_without_reference_raises(self, panel):
+        panel._resample_mode_combo.setCurrentText("Match reference layer")
+        panel._resample_reference_combo.clear()
+        with pytest.raises(ValueError, match="No reference layer selected"):
+            panel._build_resample_spec()
+
+    def test_match_reference_spec(self, viewer, panel, sample_voxeldata_3dt):
+        plot_napari(
+            sample_voxeldata_3dt,
+            viewer=viewer,
+            show_colorbar=False,
+            show_scale_bar=False,
+        )
+        panel._refresh_layer_combos()
+        panel._resample_mode_combo.setCurrentText("Match reference layer")
+        panel._resample_reference_combo.setCurrentText("power_doppler")
+        mode, kwargs = panel._build_resample_spec()
+        assert mode == "Match reference layer"
+        np.testing.assert_allclose(
+            kwargs["new_time"], sample_voxeldata_3dt["time"].values
+        )
+        assert kwargs["method"] == "linear"
+
+
+class TestBuildSmoothKwargs:
+    def test_disabled_returns_none(self, panel):
+        assert panel._build_smooth_kwargs() is None
+
+    def test_enabled_returns_kwargs(self, panel):
+        panel._smooth_enable_check.setChecked(True)
+        panel._smooth_fwhm_spin.setValue(0.4)
+        panel._smooth_ensure_finite_check.setChecked(True)
+        assert panel._build_smooth_kwargs() == {"fwhm": 0.4, "ensure_finite": True}
+
+
+# ---------------------------------------------------------------------------
+# Apply — validation
+# ---------------------------------------------------------------------------
+
+
+class TestApplyValidation:
+    def test_no_source_selected_shows_error(self, panel, monkeypatch):
+        calls = []
+        monkeypatch.setattr(
+            "confusius._napari._preprocessing._panel.show_error", calls.append
+        )
+        panel._apply()
+        assert calls == ["No source layer selected."]
+
+    def test_match_reference_without_reference_shows_error(
+        self, viewer, panel, monkeypatch, sample_voxeldata_3dt
+    ):
+        plot_napari(
+            sample_voxeldata_3dt,
+            viewer=viewer,
+            show_colorbar=False,
+            show_scale_bar=False,
+        )
+        panel._refresh_layer_combos()
+        panel._source_combo.setCurrentText("power_doppler")
+        panel._resample_mode_combo.setCurrentText("Match reference layer")
+        panel._resample_reference_combo.clear()
+
+        calls = []
+        monkeypatch.setattr(
+            "confusius._napari._preprocessing._panel.show_error", calls.append
+        )
+        panel._apply()
+        assert calls == ["No reference layer selected."]
+
+
+# ---------------------------------------------------------------------------
+# Apply — end to end
+# ---------------------------------------------------------------------------
+
+
+class TestApplyEndToEnd:
+    def test_clean_only_matches_direct_call(
+        self, qtbot, viewer, panel, sample_voxeldata_3dt
+    ):
+        plot_napari(
+            sample_voxeldata_3dt,
+            viewer=viewer,
+            show_colorbar=False,
+            show_scale_bar=False,
+        )
+        panel._refresh_layer_combos()
+        panel._source_combo.setCurrentText("power_doppler")
+        panel._standardize_combo.setCurrentText("Z-score")
+
+        panel._apply()
+        qtbot.waitUntil(lambda: len(viewer.layers) == 2, timeout=5000)
+
+        new_layer = viewer.layers["power_doppler — cleaned"]
+        expected = clean(
+            sample_voxeldata_3dt,
+            detrend_order=None,
+            standardize_method="zscore",
+            low_cutoff=None,
+            high_cutoff=None,
+            filter_method="butterworth",
+            filter_kwargs={
+                "order": 5,
+                "padtype": "odd",
+                "padlen": None,
+                "uniformity_tolerance": 1e-2,
+            },
+            confounds=None,
+            standardize_confounds=True,
+            ensure_finite=False,
+            sample_mask=None,
+            interpolate_method="linear",
+        )
+        np.testing.assert_allclose(
+            new_layer.data, expected.values, rtol=1e-5, atol=1e-8
+        )
+        # Z-scored output is centered on zero: expect a diverging colormap and a
+        # symmetric contrast range rather than the default sequential one.
+        assert new_layer.colormap.name == "twilight"
+        peak = float(np.nanmax(np.abs(expected.values)))
+        assert new_layer.contrast_limits == pytest.approx([-peak, peak], rel=1e-5)
+
+    def test_full_pipeline_order_matches_chained_direct_calls(
+        self, qtbot, viewer, panel, sample_voxeldata_3dt
+    ):
+        plot_napari(
+            sample_voxeldata_3dt,
+            viewer=viewer,
+            show_colorbar=False,
+            show_scale_bar=False,
+        )
+        panel._refresh_layer_combos()
+        panel._source_combo.setCurrentText("power_doppler")
+
+        panel._resample_mode_combo.setCurrentText("Uniform grid")
+        panel._resample_step_spin.setValue(0.25)
+
+        panel._smooth_enable_check.setChecked(True)
+        panel._smooth_fwhm_spin.setValue(0.4)
+
+        panel._detrend_check.setChecked(True)
+        panel._detrend_order_spin.setValue(1)
+
+        panel._apply()
+        qtbot.waitUntil(lambda: len(viewer.layers) == 2, timeout=5000)
+
+        new_layer = viewer.layers["power_doppler — cleaned"]
+        resampled = resample_to_uniform_time(
+            sample_voxeldata_3dt, start=None, stop=None, step=0.25, method="linear"
+        )
+        smoothed = smooth_volume(resampled, fwhm=0.4, ensure_finite=False)
+        expected = clean(
+            smoothed,
+            detrend_order=1,
+            standardize_method=None,
+            low_cutoff=None,
+            high_cutoff=None,
+            filter_method="butterworth",
+            filter_kwargs={
+                "order": 5,
+                "padtype": "odd",
+                "padlen": None,
+                "uniformity_tolerance": 1e-2,
+            },
+            confounds=None,
+            standardize_confounds=True,
+            ensure_finite=False,
+            sample_mask=None,
+            interpolate_method="linear",
+        )
+        np.testing.assert_allclose(
+            new_layer.data, expected.values, rtol=1e-5, atol=1e-8
+        )
+
+    def test_imported_confound_matches_direct_clean_call(
+        self, qtbot, viewer, panel, signals_store, sample_voxeldata_3dt
+    ):
+        # Aligned 1:1 with sample_voxeldata_3dt's time coordinate (10.0 + arange(10) * 0.5).
+        confound_signal = _imported_signal(
+            "motion",
+            10.0 + np.arange(10) * 0.5,
+            np.sin(np.arange(10) * 0.3),
+        )
+        signals_store._stored_signals.append(confound_signal)
+
+        plot_napari(
+            sample_voxeldata_3dt,
+            viewer=viewer,
+            show_colorbar=False,
+            show_scale_bar=False,
+        )
+        panel._refresh_layer_combos()
+        panel._refresh_signal_combos()
+        panel._source_combo.setCurrentText("power_doppler")
+        _check_confound(panel, "motion")
+
+        panel._apply()
+        qtbot.waitUntil(lambda: len(viewer.layers) == 2, timeout=5000)
+
+        new_layer = viewer.layers["power_doppler — cleaned"]
+        # The panel always stacks selected confounds along a "confound" dim (even
+        # for a single one), matching multi-confound selection.
+        expected_confounds = xr.concat(
+            [
+                xr.DataArray(
+                    confound_signal.y,
+                    dims="time",
+                    coords={"time": sample_voxeldata_3dt["time"]},
+                )
+            ],
+            dim="confound",
+        )
+        expected = clean(
+            sample_voxeldata_3dt,
+            detrend_order=None,
+            standardize_method=None,
+            low_cutoff=None,
+            high_cutoff=None,
+            filter_method="butterworth",
+            filter_kwargs={
+                "order": 5,
+                "padtype": "odd",
+                "padlen": None,
+                "uniformity_tolerance": 1e-2,
+            },
+            confounds=expected_confounds,
+            standardize_confounds=True,
+            ensure_finite=False,
+            sample_mask=None,
+            interpolate_method="linear",
+        )
+        np.testing.assert_allclose(
+            new_layer.data, expected.values, rtol=1e-5, atol=1e-8
+        )
+
+    def test_point_live_signal_confound_matches_direct_clean_call(
+        self, qtbot, viewer, panel, signals_store, sample_voxeldata_3dt
+    ):
+        _, image_layer = plot_napari(
+            sample_voxeldata_3dt,
+            viewer=viewer,
+            show_colorbar=False,
+            show_scale_bar=False,
+        )
+        spatial_scale = np.asarray(image_layer.scale)[1:]
+        spatial_translate = np.asarray(image_layer.translate)[1:]
+        points_layer = viewer.add_points(
+            np.array([[1.0, 2.0, 3.0]]),
+            name="Points (3D)",
+            ndim=3,
+            scale=spatial_scale,
+            translate=spatial_translate,
+        )
+        signals_store.register_live_signals(
+            [
+                LiveSignal(
+                    id="point-0",
+                    name="Point 0",
+                    color="#000000",
+                    visible=True,
+                    source_type="point",
+                    source_id=0,
+                    layer_name=points_layer.name,
+                ),
+            ]
+        )
+
+        panel._refresh_layer_combos()
+        panel._refresh_signal_combos()
+        panel._source_combo.setCurrentText("power_doppler")
+        _check_confound(panel, "Point 0")
+
+        panel._apply()
+        qtbot.waitUntil(lambda: len(viewer.layers) == 3, timeout=5000)
+
+        new_layer = viewer.layers["power_doppler — cleaned"]
+        expected_confounds = xr.concat(
+            [
+                xr.DataArray(
+                    sample_voxeldata_3dt.values[:, 1, 2, 3],
+                    dims="time",
+                    coords={"time": sample_voxeldata_3dt["time"]},
+                )
+            ],
+            dim="confound",
+        )
+        expected = clean(
+            sample_voxeldata_3dt,
+            detrend_order=None,
+            standardize_method=None,
+            low_cutoff=None,
+            high_cutoff=None,
+            filter_method="butterworth",
+            filter_kwargs={
+                "order": 5,
+                "padtype": "odd",
+                "padlen": None,
+                "uniformity_tolerance": 1e-2,
+            },
+            confounds=expected_confounds,
+            standardize_confounds=True,
+            ensure_finite=False,
+            sample_mask=None,
+            interpolate_method="linear",
+        )
+        np.testing.assert_allclose(
+            new_layer.data, expected.values, rtol=1e-5, atol=1e-8
+        )
+
+
+# ---------------------------------------------------------------------------
+# _build_noise_mask
+# ---------------------------------------------------------------------------
+
+
+class TestBuildNoiseMask:
+    def test_full_shape_labels_collapsed_over_time(self, sample_voxeldata_3dt):
+        from confusius._napari._preprocessing._panel import _build_noise_mask
+
+        labels = np.zeros(sample_voxeldata_3dt.shape, dtype=np.int32)
+        labels[:, 0, 0, 0] = 1  # One voxel marked across every timepoint.
+        mask = _build_noise_mask(sample_voxeldata_3dt, labels)
+        assert mask is not None
+        assert mask.shape == sample_voxeldata_3dt.shape[1:]
+        assert mask.values[0, 0, 0]
+        assert not mask.values[0, 0, 1]
+
+    def test_spatial_shape_labels_used_directly(self, sample_voxeldata_3dt):
+        from confusius._napari._preprocessing._panel import _build_noise_mask
+
+        labels = np.zeros(sample_voxeldata_3dt.shape[1:], dtype=np.int32)
+        labels[1, 2, 3] = 5
+        mask = _build_noise_mask(sample_voxeldata_3dt, labels)
+        assert mask is not None
+        assert mask.values[1, 2, 3]
+        assert mask.values.sum() == 1
+
+    def test_mismatched_shape_returns_none(self, sample_voxeldata_3dt):
+        from confusius._napari._preprocessing._panel import _build_noise_mask
+
+        labels = np.zeros((2, 2, 2), dtype=np.int32)
+        assert _build_noise_mask(sample_voxeldata_3dt, labels) is None
+
+
+# ---------------------------------------------------------------------------
+# CompCor
+# ---------------------------------------------------------------------------
+
+
+class TestCompcorSubprocess:
+    def test_matches_direct_call_on_plain_arrays(self, rng):
+        from confusius._napari._preprocessing._panel import _compcor_subprocess
+        from confusius.signal import compute_compcor_confounds
+
+        values = rng.random((20, 3, 4, 5))
+        time_values = np.arange(20, dtype=float) * 0.5
+        noise_mask_values = np.zeros((3, 4, 5), dtype=bool)
+        noise_mask_values[:2] = True
+
+        result_time, result_values = _compcor_subprocess(
+            values, ("time", "k", "j", "i"), time_values, noise_mask_values, None, 2
+        )
+
+        signals = xr.DataArray(
+            values, dims=("time", "k", "j", "i"), coords={"time": time_values}
+        )
+        noise_mask = xr.DataArray(noise_mask_values, dims=("k", "j", "i"))
+        expected = compute_compcor_confounds(
+            signals, noise_mask=noise_mask, n_components=2
+        )
+
+        np.testing.assert_allclose(result_time, expected.coords["time"].values)
+        np.testing.assert_allclose(result_values, expected.values, rtol=1e-5)
+
+    def test_picklable_for_process_pool_dispatch(self, rng):
+        # ProcessPoolExecutor needs to pickle both the callable and its
+        # arguments/return value; a closure or an object carrying a Qt/napari
+        # reference would fail here even though it works when called directly.
+        from concurrent.futures import ProcessPoolExecutor
+
+        from confusius._napari._preprocessing._panel import _compcor_subprocess
+
+        values = rng.random((20, 3, 4, 5))
+        time_values = np.arange(20, dtype=float) * 0.5
+
+        with ProcessPoolExecutor(max_workers=1) as pool:
+            result_time, result_values = pool.submit(
+                _compcor_subprocess,
+                values,
+                ("time", "k", "j", "i"),
+                time_values,
+                None,
+                0.5,
+                2,
+            ).result()
+
+        assert result_values.shape == (20, 2)
+        np.testing.assert_allclose(result_time, time_values)
+
+
+class TestComputeCompcor:
+    def test_matches_direct_compute_compcor_confounds_call(
+        self, qtbot, viewer, panel, signals_store, sample_voxeldata_3dt
+    ):
+        from confusius.signal import compute_compcor_confounds
+
+        plot_napari(
+            sample_voxeldata_3dt,
+            viewer=viewer,
+            show_colorbar=False,
+            show_scale_bar=False,
+        )
+        labels = np.zeros(sample_voxeldata_3dt.shape[1:], dtype=np.int32)
+        labels[:2] = 1
+        viewer.add_labels(labels, name="wm")
+
+        panel._refresh_layer_combos()
+        panel._source_combo.setCurrentText("power_doppler")
+        panel._compcor_mask_combo.setCurrentText("wm")
+        panel._compcor_components_spin.setValue(2)
+
+        panel._compute_compcor()
+        qtbot.waitUntil(lambda: len(signals_store.stored_signals()) == 2, timeout=5000)
+
+        noise_mask = xr.zeros_like(
+            sample_voxeldata_3dt.isel(time=0, drop=True), dtype=bool
+        )
+        noise_mask.values[:2] = True
+        expected = compute_compcor_confounds(
+            sample_voxeldata_3dt, noise_mask=noise_mask, n_components=2
+        )
+
+        stored = {s.name: s for s in signals_store.stored_signals()}
+        assert set(stored) == {
+            "CompCor 0 (power_doppler)",
+            "CompCor 1 (power_doppler)",
+        }
+        np.testing.assert_allclose(
+            stored["CompCor 0 (power_doppler)"].y,
+            expected.isel(component=0).values,
+            rtol=1e-5,
+        )
+
+    def test_shows_its_own_busy_indicator_not_the_shared_one(
+        self, qtbot, viewer, panel, signals_store, sample_voxeldata_3dt
+    ):
+        plot_napari(
+            sample_voxeldata_3dt,
+            viewer=viewer,
+            show_colorbar=False,
+            show_scale_bar=False,
+        )
+        labels = np.zeros(sample_voxeldata_3dt.shape[1:], dtype=np.int32)
+        labels[:2] = 1
+        viewer.add_labels(labels, name="wm")
+
+        panel._refresh_layer_combos()
+        panel._source_combo.setCurrentText("power_doppler")
+        panel._compcor_mask_combo.setCurrentText("wm")
+
+        panel._compute_compcor()
+        assert panel._compcor_progress.isVisibleTo(panel)
+        assert not panel._progress.isVisibleTo(panel)
+
+        qtbot.waitUntil(lambda: len(signals_store.stored_signals()) == 5, timeout=5000)
+        assert not panel._compcor_progress.isVisibleTo(panel)
+
+    def test_recomputing_updates_signals_in_place(
+        self, qtbot, viewer, panel, signals_store, sample_voxeldata_3dt
+    ):
+        plot_napari(
+            sample_voxeldata_3dt,
+            viewer=viewer,
+            show_colorbar=False,
+            show_scale_bar=False,
+        )
+        labels = np.zeros(sample_voxeldata_3dt.shape[1:], dtype=np.int32)
+        labels[:2] = 1
+        viewer.add_labels(labels, name="wm")
+
+        panel._refresh_layer_combos()
+        panel._source_combo.setCurrentText("power_doppler")
+        panel._compcor_mask_combo.setCurrentText("wm")
+        panel._compcor_components_spin.setValue(1)
+
+        panel._compute_compcor()
+        qtbot.waitUntil(lambda: len(signals_store.stored_signals()) == 1, timeout=5000)
+        panel._compute_compcor()
+        qtbot.wait(500)  # Give a second run a chance to (wrongly) duplicate.
+
+        assert len(signals_store.stored_signals()) == 1
+
+    def test_no_mask_or_variance_threshold_shows_error(
+        self, viewer, panel, monkeypatch, sample_voxeldata_3dt
+    ):
+        plot_napari(
+            sample_voxeldata_3dt,
+            viewer=viewer,
+            show_colorbar=False,
+            show_scale_bar=False,
+        )
+        panel._refresh_layer_combos()
+        panel._source_combo.setCurrentText("power_doppler")
+
+        errors = []
+        monkeypatch.setattr(
+            "confusius._napari._preprocessing._panel.show_error", errors.append
+        )
+        panel._compute_compcor()
+
+        assert len(errors) == 1
+        assert "noise mask" in errors[0]

--- a/tests/unit/test_napari/test_qc_panel.py
+++ b/tests/unit/test_napari/test_qc_panel.py
@@ -100,3 +100,49 @@ class TestRefreshLayers:
         layer = viewer.add_image(np.zeros((10, 4, 6, 8)), name="my_layer")
         viewer.layers.remove(layer)
         assert qc_panel._layer_combo.count() == 0
+
+
+# ---------------------------------------------------------------------------
+# _store_dvars_signal
+# ---------------------------------------------------------------------------
+
+
+class TestStoreDvarsSignal:
+    def test_noop_without_a_signal_store(self, viewer):
+        from confusius._napari._qc._panel import QCPanel
+
+        panel = QCPanel(viewer)
+        dvars = xr.DataArray([0.1, 0.2, 0.3], dims=["time"], coords={"time": [0, 1, 2]})
+        panel._store_dvars_signal(dvars, "my_layer")  # Must not raise.
+
+    def test_adds_dvars_to_the_signal_store(self, viewer):
+        from confusius._napari._qc._panel import QCPanel
+        from confusius._napari._signals._store import SignalStore
+
+        store = SignalStore()
+        panel = QCPanel(viewer, signal_store=store)
+        dvars = xr.DataArray([0.1, 0.2, 0.3], dims=["time"], coords={"time": [0, 1, 2]})
+
+        panel._store_dvars_signal(dvars, "my_layer")
+
+        stored = store.stored_signals()
+        assert len(stored) == 1
+        assert stored[0].name == "DVARS (my_layer)"
+        np.testing.assert_array_equal(stored[0].y, [0.1, 0.2, 0.3])
+        np.testing.assert_array_equal(stored[0].x, [0, 1, 2])
+
+    def test_recomputing_updates_in_place_instead_of_duplicating(self, viewer):
+        from confusius._napari._qc._panel import QCPanel
+        from confusius._napari._signals._store import SignalStore
+
+        store = SignalStore()
+        panel = QCPanel(viewer, signal_store=store)
+        first = xr.DataArray([0.1, 0.2], dims=["time"], coords={"time": [0, 1]})
+        second = xr.DataArray([0.9, 0.8], dims=["time"], coords={"time": [0, 1]})
+
+        panel._store_dvars_signal(first, "my_layer")
+        panel._store_dvars_signal(second, "my_layer")
+
+        stored = store.stored_signals()
+        assert len(stored) == 1
+        np.testing.assert_array_equal(stored[0].y, [0.9, 0.8])

--- a/tests/unit/test_napari/test_signal_manager.py
+++ b/tests/unit/test_napari/test_signal_manager.py
@@ -34,25 +34,25 @@ def test_manager_applies_store_mutations(
     name_item = dialog._table.item(0, 1)
     assert name_item is not None
     name_item.setText("baseline")
-    assert signals_store.imported_signals()[0].name == "baseline"
+    assert signals_store.stored_signals()[0].name == "baseline"
 
     visible_item = dialog._table.item(0, 0)
     assert visible_item is not None
     visible_item.setCheckState(Qt.CheckState.Unchecked)
-    assert signals_store.imported_signals()[0].visible is False
+    assert signals_store.stored_signals()[0].visible is False
 
     monkeypatch.setattr(
         "confusius._napari._signals._manager.QColorDialog.getColor",
         lambda *args, **kwargs: QColor("#123456"),
     )
     dialog._choose_color(imported[0].id)
-    assert signals_store.imported_signals()[0].color == "#123456"
+    assert signals_store.stored_signals()[0].color == "#123456"
 
     dialog._table.selectRow(0)
     dialog._remove_selected()
     # Should have removed only the first signal, leaving the second.
-    assert len(signals_store.imported_signals()) == 1
-    assert signals_store.imported_signals()[0].name == "b"
+    assert len(signals_store.stored_signals()) == 1
+    assert signals_store.stored_signals()[0].name == "b"
 
 
 def test_manager_updates_on_store_change(qtbot, signals_store, signals_csv):
@@ -77,7 +77,7 @@ def test_manager_clear_all_button(qtbot, signals_store, signals_csv):
 
     dialog._clear_btn.click()
 
-    assert signals_store.imported_signals() == []
+    assert signals_store.stored_signals() == []
     assert dialog._table.rowCount() == 0
 
 
@@ -87,12 +87,49 @@ def test_manager_handles_multiple_selection(qtbot, signals_store, signals_csv):
     dialog = SignalsManagerDialog(signals_store)
     qtbot.addWidget(dialog)
 
-    assert len(signals_store.imported_signals()) == 2
+    assert len(signals_store.stored_signals()) == 2
 
     dialog._table.selectAll()
     dialog._remove_selected()
 
-    assert signals_store.imported_signals() == []
+    assert signals_store.stored_signals() == []
+
+
+def test_manager_export_selected_writes_only_selected_signals(
+    qtbot, signals_store, signals_csv, monkeypatch, tmp_path
+):
+    signals_store.import_file(signals_csv)
+    dialog = SignalsManagerDialog(signals_store)
+    qtbot.addWidget(dialog)
+
+    out_path = tmp_path / "selected.csv"
+    monkeypatch.setattr(
+        "confusius._napari._signals._manager.prompt_delimited_export_path",
+        lambda *args, **kwargs: (out_path, ","),
+    )
+
+    dialog._table.selectRow(0)
+    dialog._export_selected()
+
+    content = out_path.read_text()
+    assert "a" in content
+    assert "b" not in content.split("\n")[0]
+
+
+def test_manager_export_selected_shows_error_when_nothing_selected(
+    qtbot, signals_store, signals_csv, monkeypatch
+):
+    signals_store.import_file(signals_csv)
+    dialog = SignalsManagerDialog(signals_store)
+    qtbot.addWidget(dialog)
+    dialog._table.clearSelection()
+
+    errors = []
+    monkeypatch.setattr("confusius._napari._signals._manager.show_error", errors.append)
+
+    dialog._export_selected()
+
+    assert errors == ["Select one or more stored signals to export."]
 
 
 def test_manager_imports_multiple_files(qtbot, signals_store, monkeypatch, tmp_path):
@@ -111,7 +148,7 @@ def test_manager_imports_multiple_files(qtbot, signals_store, monkeypatch, tmp_p
 
     dialog._import_file()
 
-    assert [signal.name for signal in signals_store.imported_signals()] == ["a", "b"]
+    assert [signal.name for signal in signals_store.stored_signals()] == ["a", "b"]
 
 
 def test_manager_import_dialog_filters_supported_formats(

--- a/tests/unit/test_napari/test_signal_plotter.py
+++ b/tests/unit/test_napari/test_signal_plotter.py
@@ -15,7 +15,7 @@ import pytest
 import xarray as xr
 
 from confusius._napari._export import format_export_value
-from confusius._napari._signals._store import SignalStore
+from confusius._napari._signals._store import LiveSignal, SignalStore
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -780,8 +780,8 @@ class TestTsvExport:
         assert not plotter._export_button.isEnabled()
 
 
-class TestImportedSignalIntegration:
-    def test_overlays_imported_signals_with_live_mouse_plot(
+class TestStoredSignalIntegration:
+    def test_overlays_stored_signals_with_live_mouse_plot(
         self, plotter_with_store, store, tmp_path
     ):
         path = tmp_path / "imported.csv"
@@ -805,7 +805,7 @@ class TestImportedSignalIntegration:
             ["2", "23", "22"],
         ]
 
-    def test_plots_imported_signals_without_live_data(
+    def test_plots_stored_signals_without_live_data(
         self, plotter_with_store, store, tmp_path
     ):
         path = tmp_path / "imported.tsv"
@@ -986,7 +986,7 @@ class TestImportedSignalIntegration:
         store.import_file(path)
 
         plotter_with_store.set_zscore(True)
-        result = plotter_with_store._render_imported_only()
+        result = plotter_with_store._render_stored_only()
 
         assert result is True
         assert len(plotter_with_store._axes.lines) == 1
@@ -1002,7 +1002,7 @@ class TestImportedSignalIntegration:
         store.import_file(path)
 
         plotter_with_store.set_zscore(True)
-        result = plotter_with_store._render_imported_only()
+        result = plotter_with_store._render_stored_only()
 
         assert result is True
         assert len(plotter_with_store._axes.lines) == 1
@@ -1040,3 +1040,146 @@ class TestImportedSignalIntegration:
         store.import_file(path2)
 
         assert call_count["n"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Pinning and the live-signal dedup in _stored_plot_signals
+# ---------------------------------------------------------------------------
+
+
+class TestPinnedSignalDedup:
+    def test_pinned_signal_hidden_while_its_live_origin_is_active(
+        self, plotter_with_store, store
+    ):
+        store.pin_signal(
+            origin="label-3",
+            name="Label 3",
+            x=np.array([0.0, 1.0]),
+            y=np.array([1.0, 2.0]),
+            color="#123456",
+            source_label="Pinned from labels",
+        )
+        store.register_live_signals(
+            [
+                LiveSignal(
+                    id="label-3",
+                    name="Label 3",
+                    color="#123456",
+                    visible=True,
+                    source_type="label",
+                    source_id=3,
+                )
+            ]
+        )
+
+        names = [s.label for s in plotter_with_store._stored_plot_signals()]
+        assert "Label 3" not in names
+
+    def test_pinned_signal_shown_once_its_live_origin_is_no_longer_active(
+        self, plotter_with_store, store
+    ):
+        store.pin_signal(
+            origin="label-3",
+            name="Label 3",
+            x=np.array([0.0, 1.0]),
+            y=np.array([1.0, 2.0]),
+            color="#123456",
+            source_label="Pinned from labels",
+        )
+        # Switching to mouse mode replaces the live set entirely.
+        store.register_live_signals(
+            [
+                LiveSignal(
+                    id="mouse-0",
+                    name="Cursor",
+                    color="#abcdef",
+                    visible=True,
+                    source_type="mouse",
+                    source_id=None,
+                )
+            ]
+        )
+
+        names = [s.label for s in plotter_with_store._stored_plot_signals()]
+        assert "Label 3" in names
+
+    def test_pinned_mouse_voxel_is_never_hidden_by_the_fixed_mouse_id(
+        self, plotter_with_store, store
+    ):
+        # The live mouse signal always has the fixed id "mouse-0", not a per-voxel
+        # id, so a pinned voxel (a distinct "mouse-k-j-i" origin) must stay visible
+        # while hovering elsewhere.
+        store.pin_signal(
+            origin="mouse-1-2-3",
+            name="Pinned voxel",
+            x=np.array([0.0, 1.0]),
+            y=np.array([1.0, 2.0]),
+            color="#123456",
+            source_label="Pinned from mouse",
+        )
+        store.register_live_signals(
+            [
+                LiveSignal(
+                    id="mouse-0",
+                    name="Cursor",
+                    color="#abcdef",
+                    visible=True,
+                    source_type="mouse",
+                    source_id=None,
+                )
+            ]
+        )
+
+        names = [s.label for s in plotter_with_store._stored_plot_signals()]
+        assert "Pinned voxel" in names
+
+
+class TestPinCurrentSignals:
+    def test_pins_every_currently_plotted_live_signal(self, plotter_with_store, store):
+        from confusius._napari._signals._plotter import LivePlotSignal
+
+        plotter_with_store._set_live_plot_signals(
+            [
+                LivePlotSignal(
+                    origin="label-1",
+                    name="Label 1",
+                    x=np.array([0.0, 1.0]),
+                    y=np.array([1.0, 2.0]),
+                    color="#111111",
+                ),
+                LivePlotSignal(
+                    origin="label-2",
+                    name="Label 2",
+                    x=np.array([0.0, 1.0]),
+                    y=np.array([3.0, 4.0]),
+                    color="#222222",
+                ),
+            ]
+        )
+
+        plotter_with_store._pin_current_signals()
+
+        origins = {s.pin_origin for s in store.stored_signals()}
+        assert origins == {"label-1", "label-2"}
+
+    def test_pin_button_disabled_when_no_live_signal_is_plotted(
+        self, plotter_with_store
+    ):
+        plotter_with_store._set_live_plot_signals([])
+        assert plotter_with_store._pin_button.isEnabled() is False
+
+    def test_pin_button_enabled_when_a_live_signal_is_plotted(self, plotter_with_store):
+        from confusius._napari._signals._plotter import LivePlotSignal
+
+        plotter_with_store._set_live_plot_signals(
+            [
+                LivePlotSignal(
+                    origin="label-1",
+                    name="Label 1",
+                    x=np.array([0.0]),
+                    y=np.array([1.0]),
+                    color="#111111",
+                )
+            ]
+        )
+        assert plotter_with_store._pin_button.isEnabled() is True

--- a/tests/unit/test_napari/test_signal_plotter.py
+++ b/tests/unit/test_napari/test_signal_plotter.py
@@ -1047,13 +1047,17 @@ class TestStoredSignalIntegration:
 # ---------------------------------------------------------------------------
 
 
-class TestPinnedSignalDedup:
-    def test_pinned_signal_hidden_while_its_live_origin_is_active(
+class TestPinnedSignalAlwaysVisible:
+    def test_pinned_signal_stays_visible_while_its_live_origin_is_active(
         self, plotter_with_store, store
     ):
+        # A pinned signal is a distinct stored entry (see the "(pinned)" name
+        # suffix applied by _pin_current_signals) and must always render — it
+        # must not be silently hidden just because its live origin is still
+        # active, which previously made pinning look like it had no effect.
         store.pin_signal(
             origin="label-3",
-            name="Label 3",
+            name="Label 3 (pinned)",
             x=np.array([0.0, 1.0]),
             y=np.array([1.0, 2.0]),
             color="#123456",
@@ -1073,65 +1077,22 @@ class TestPinnedSignalDedup:
         )
 
         names = [s.label for s in plotter_with_store._stored_plot_signals()]
-        assert "Label 3" not in names
+        assert "Label 3 (pinned)" in names
 
-    def test_pinned_signal_shown_once_its_live_origin_is_no_longer_active(
-        self, plotter_with_store, store
+    def test_legend_shown_for_a_single_stored_signal(
+        self, plotter_with_store, store, tmp_path
     ):
-        store.pin_signal(
-            origin="label-3",
-            name="Label 3",
-            x=np.array([0.0, 1.0]),
-            y=np.array([1.0, 2.0]),
-            color="#123456",
-            source_label="Pinned from labels",
-        )
-        # Switching to mouse mode replaces the live set entirely.
-        store.register_live_signals(
-            [
-                LiveSignal(
-                    id="mouse-0",
-                    name="Cursor",
-                    color="#abcdef",
-                    visible=True,
-                    source_type="mouse",
-                    source_id=None,
-                )
-            ]
-        )
+        # _render_stored_only's title is generic ("Stored Signals"), unlike the
+        # mouse-hover title which already names the voxel, so even a lone line
+        # needs its own legend entry to be identifiable.
+        path = tmp_path / "single.csv"
+        path.write_text("time,a\n0,1\n1,2\n")
+        store.import_file(path)
 
-        names = [s.label for s in plotter_with_store._stored_plot_signals()]
-        assert "Label 3" in names
+        result = plotter_with_store._render_stored_only()
 
-    def test_pinned_mouse_voxel_is_never_hidden_by_the_fixed_mouse_id(
-        self, plotter_with_store, store
-    ):
-        # The live mouse signal always has the fixed id "mouse-0", not a per-voxel
-        # id, so a pinned voxel (a distinct "mouse-k-j-i" origin) must stay visible
-        # while hovering elsewhere.
-        store.pin_signal(
-            origin="mouse-1-2-3",
-            name="Pinned voxel",
-            x=np.array([0.0, 1.0]),
-            y=np.array([1.0, 2.0]),
-            color="#123456",
-            source_label="Pinned from mouse",
-        )
-        store.register_live_signals(
-            [
-                LiveSignal(
-                    id="mouse-0",
-                    name="Cursor",
-                    color="#abcdef",
-                    visible=True,
-                    source_type="mouse",
-                    source_id=None,
-                )
-            ]
-        )
-
-        names = [s.label for s in plotter_with_store._stored_plot_signals()]
-        assert "Pinned voxel" in names
+        assert result is True
+        assert plotter_with_store._axes.get_legend() is not None
 
 
 class TestPinCurrentSignals:

--- a/tests/unit/test_napari/test_signal_plotter.py
+++ b/tests/unit/test_napari/test_signal_plotter.py
@@ -180,6 +180,47 @@ class TestOnMouseMove:
 
 
 # ---------------------------------------------------------------------------
+# Shift keybinding scoped to mouse source mode
+# ---------------------------------------------------------------------------
+
+
+def _bound_shift_handler(viewer):
+    from napari.utils.key_bindings import coerce_keybinding
+
+    return viewer.keymap.get(coerce_keybinding("Shift"))
+
+
+class TestShiftKeyBinding:
+    def test_bound_by_default_in_mouse_mode(self, viewer, plotter):
+        assert _bound_shift_handler(viewer) == plotter._on_shift_pressed
+
+    def test_unbound_when_leaving_mouse_mode(self, viewer, plotter):
+        plotter.set_source_mode("labels")
+        assert _bound_shift_handler(viewer) is None
+
+    def test_rebound_when_returning_to_mouse_mode(self, viewer, plotter):
+        plotter.set_source_mode("labels")
+        plotter.set_source_mode("mouse")
+        assert _bound_shift_handler(viewer) == plotter._on_shift_pressed
+
+    def test_preserves_a_pre_existing_shift_binding_while_in_other_modes(
+        self, viewer, plotter
+    ):
+        def other_handler(viewer):
+            pass
+
+        # Simulate another binding claiming Shift while this widget isn't using it.
+        plotter.set_source_mode("labels")
+        viewer.bind_key("Shift", other_handler, overwrite=True)
+
+        plotter.set_source_mode("mouse")
+        assert _bound_shift_handler(viewer) == plotter._on_shift_pressed
+
+        plotter.set_source_mode("labels")
+        assert _bound_shift_handler(viewer) is other_handler
+
+
+# ---------------------------------------------------------------------------
 # _get_xaxis_coords
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_napari/test_signal_store.py
+++ b/tests/unit/test_napari/test_signal_store.py
@@ -97,13 +97,13 @@ def test_store_can_rename_toggle_recolor_and_remove_signals(signals_store, signa
     signals_store.set_signal_visible(imported[1].id, False)
     signals_store.set_signal_color(imported[1].id, "#123456")
 
-    updated = signals_store.imported_signals()
+    updated = signals_store.stored_signals()
     assert updated[0].name == "baseline"
     assert updated[1].visible is False
     assert updated[1].color == "#123456"
 
     signals_store.remove_signals([imported[0].id])
-    remaining = signals_store.imported_signals()
+    remaining = signals_store.stored_signals()
     assert len(remaining) == 1
     assert remaining[0].id == imported[1].id
 
@@ -139,10 +139,70 @@ def test_store_generates_unique_ids_after_removal(signals_store, signals_csv, tm
 
 def test_store_clear_removes_all_signals(signals_store, signals_csv):
     signals_store.import_file(signals_csv)
-    assert len(signals_store.imported_signals()) == 2
+    assert len(signals_store.stored_signals()) == 2
 
     signals_store.clear()
-    assert signals_store.imported_signals() == []
+    assert signals_store.stored_signals() == []
+
+
+def test_pin_signal_creates_a_stored_signal_with_matching_origin(signals_store):
+    pinned = signals_store.pin_signal(
+        origin="label-3",
+        name="Label 3",
+        x=np.array([0.0, 1.0]),
+        y=np.array([1.0, 2.0]),
+        color="#123456",
+        source_label="Pinned from labels",
+    )
+
+    assert pinned.pin_origin == "label-3"
+    assert signals_store.stored_signals() == [pinned]
+
+
+def test_repinning_the_same_origin_updates_in_place_instead_of_duplicating(
+    signals_store,
+):
+    signals_store.pin_signal(
+        origin="label-3",
+        name="Label 3",
+        x=np.array([0.0, 1.0]),
+        y=np.array([1.0, 2.0]),
+        color="#123456",
+        source_label="Pinned from labels",
+    )
+    signals_store.pin_signal(
+        origin="label-3",
+        name="Label 3",
+        x=np.array([0.0, 1.0]),
+        y=np.array([9.0, 9.0]),
+        color="#123456",
+        source_label="Pinned from labels",
+    )
+
+    stored = signals_store.stored_signals()
+    assert len(stored) == 1
+    npt.assert_array_equal(stored[0].y, np.array([9.0, 9.0]))
+
+
+def test_pinning_different_origins_creates_separate_signals(signals_store):
+    signals_store.pin_signal(
+        origin="label-1",
+        name="Label 1",
+        x=np.array([0.0]),
+        y=np.array([1.0]),
+        color="#123456",
+        source_label="Pinned from labels",
+    )
+    signals_store.pin_signal(
+        origin="label-2",
+        name="Label 2",
+        x=np.array([0.0]),
+        y=np.array([2.0]),
+        color="#123456",
+        source_label="Pinned from labels",
+    )
+
+    assert len(signals_store.stored_signals()) == 2
 
 
 class TestStoreSignals:


### PR DESCRIPTION
Adds a Preprocessing panel (resampling, spatial smoothing, detrending, temporal filtering, standardization, confound regression, scrubbing) operating on VoxelData layers, with CompCor confound extraction and sample masks/confounds sourced from stored signals.