### PR TITLE
feat(napari): register within-scan frames to a fixed layer

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -42,6 +42,9 @@ Current development version for the next ConfUSIus release.
 
 ### :frame_photo: Napari plugin
 
+- The registration panel's within-scan mode can register every frame to a fixed
+  layer, with its own intensity scaling, as an alternative to the reference volume
+  index ([#376](https://github.com/confusius-tools/confusius/issues/376)).
 - Scrolling the sidebar with the mouse wheel no longer gets hijacked by whichever
   combo box or spin box the cursor happens to be over
   ([#431](https://github.com/confusius-tools/confusius/pull/431)).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -43,8 +43,8 @@ Current development version for the next ConfUSIus release.
 ### :frame_photo: Napari plugin
 
 - The registration panel's within-scan mode can register every frame to a fixed
-  layer, with its own intensity scaling, as an alternative to the reference volume
-  index ([#376](https://github.com/confusius-tools/confusius/issues/376)).
+  layer, with its own intensity scaling, as an alternative to a reference time index
+  ([#376](https://github.com/confusius-tools/confusius/issues/376)).
 - Scrolling the sidebar with the mouse wheel no longer gets hijacked by whichever
   combo box or spin box the cursor happens to be over
   ([#431](https://github.com/confusius-tools/confusius/pull/431)).

--- a/docs/examples/03_registration/02_volumewise_motion_correction.py
+++ b/docs/examples/03_registration/02_volumewise_motion_correction.py
@@ -68,12 +68,15 @@ data
 # any spatial-only volume on the same grid as `fixed`, for example the mean of a few
 # low-motion frames. Here, we're trying to correct for rigid motion, that is,
 # translation and rotations. The default learning rate is conservative; for this
-# recording, `1.0` recovers the inter-frame shifts better.
+# recording, `1.0` recovers the inter-frame shifts better. Depending on the recording,
+# the dynamic range of the data can be quite large, here we use decibel scaling to help
+# the optimizer find the correct alignment.
 
 # %%
 registered = cf.registration.register_volumewise(
     data,
     transform="rigid",
+    moving_intensity_scaling="db",
     metric="correlation",
     learning_rate=1.0,
 )

--- a/docs/gui/plugin.md
+++ b/docs/gui/plugin.md
@@ -369,7 +369,9 @@ Use **Within-scan** for motion correction inside a single time series.
 
 1. Switch **Mode** to **Within-scan**.
 2. Select the time-series **Moving layer**.
-3. Choose the **Reference volume** index used as the registration target.
+3. Choose the **Reference volume** index used as the registration target, or check
+   **Use a fixed layer** and select a spatial-only layer on the same grid instead
+   (for example the mean of a few low-motion frames).
 4. Pick a transform model (`translation`, `rigid`, or `affine`).
 5. Click **Run registration**.
 
@@ -378,9 +380,10 @@ Use **Within-scan** for motion correction inside a single time series.
 | Parameter | What it does | When it is useful |
 |---|---|---|
 | **Reference volume** | Chooses the volume index used as the motion-correction target. | Pick a representative, sharp frame with little motion. |
+| **Use a fixed layer** / **Fixed layer** | Registers every frame to the selected spatial-only layer on the same grid instead of a volume index. | Use a more stable target than any single frame, for example the mean of a few low-motion frames. |
 | **Transform** | Chooses the volume-wise motion model. | `rigid` is the safest starting point; `affine` is available when motion is more complex. |
 | **Metric** | Chooses the volume-to-reference similarity criterion. | `correlation` is usually a good default for within-recording motion correction. |
-| **Intensity scaling** | Applies optional intensity scaling (`decibel`, `square root`, or `none`) to the reference and every frame, only for the optimizer. | Useful when an intensity transform makes anatomy more stable across time for the optimizer. |
+| **Fixed / Moving intensity scaling** | Applies optional intensity scaling (`decibel`, `square root`, or `none`) to the fixed layer and to every frame, only for the optimizer. The fixed scaling only appears with **Use a fixed layer**; the reference frame uses the moving scaling. | Useful when an intensity transform makes anatomy more stable across time for the optimizer, or when the fixed layer is on a different intensity scale than the recording. |
 | **Initialization** | Sets the initial volume-wise centering transform. | Most runs can use no initialization. |
 | **Learning rate** | Sets the optimizer step size for each frame. | Within-scan uses a fixed value here; the default is `0.01`. Reduce it if updates look unstable; increase it if frames are already close and convergence is too slow. |
 | **Iterations** | Maximum optimizer steps per frame. | Increase it for harder motion or more flexible transforms. |

--- a/docs/gui/plugin.md
+++ b/docs/gui/plugin.md
@@ -369,9 +369,9 @@ Use **Within-scan** for motion correction inside a single time series.
 
 1. Switch **Mode** to **Within-scan**.
 2. Select the time-series **Moving layer**.
-3. Choose the **Reference volume** index used as the registration target, or check
-   **Use a fixed layer** and select a spatial-only layer on the same grid instead
-   (for example the mean of a few low-motion frames).
+3. Choose the **Reference time index (moving layer)** used as the registration target,
+   or check **Use a fixed layer** and select a spatial-only layer on the same grid in
+   **Fixed layer** instead (for example the mean of a few low-motion frames).
 4. Pick a transform model (`translation`, `rigid`, or `affine`).
 5. Click **Run registration**.
 
@@ -379,8 +379,8 @@ Use **Within-scan** for motion correction inside a single time series.
 
 | Parameter | What it does | When it is useful |
 |---|---|---|
-| **Reference volume** | Chooses the volume index used as the motion-correction target. | Pick a representative, sharp frame with little motion. |
-| **Use a fixed layer** / **Fixed layer** | Registers every frame to the selected spatial-only layer on the same grid instead of a volume index. | Use a more stable target than any single frame, for example the mean of a few low-motion frames. |
+| **Reference time index (moving layer)** | Chooses the time index of the moving layer used as the motion-correction target. Inactive while **Use a fixed layer** is checked. | Pick a representative, sharp frame with little motion. |
+| **Use a fixed layer** / **Fixed layer** | Registers every frame to the selected spatial-only layer on the same grid instead of a time index. The **Fixed layer** selector is inactive until the box is checked. | Use a more stable target than any single frame, for example the mean of a few low-motion frames. |
 | **Transform** | Chooses the volume-wise motion model. | `rigid` is the safest starting point; `affine` is available when motion is more complex. |
 | **Metric** | Chooses the volume-to-reference similarity criterion. | `correlation` is usually a good default for within-recording motion correction. |
 | **Fixed / Moving intensity scaling** | Applies optional intensity scaling (`decibel`, `square root`, or `none`) to the fixed layer and to every frame, only for the optimizer. The fixed scaling only appears with **Use a fixed layer**; the reference frame uses the moving scaling. | Useful when an intensity transform makes anatomy more stable across time for the optimizer, or when the fixed layer is on a different intensity scale than the recording. |

--- a/docs/gui/plugin.md
+++ b/docs/gui/plugin.md
@@ -369,9 +369,9 @@ Use **Within-scan** for motion correction inside a single time series.
 
 1. Switch **Mode** to **Within-scan**.
 2. Select the time-series **Moving layer**.
-3. Choose the **Reference time index (moving layer)** used as the registration target,
-   or check **Use a fixed layer** and select a spatial-only layer on the same grid in
-   **Fixed layer** instead (for example the mean of a few low-motion frames).
+3. Choose the moving layer's **Reference time** index used as the registration target,
+   or tick **Fixed layer** and select a spatial-only layer on the same grid instead
+   (for example the mean of a few low-motion frames).
 4. Pick a transform model (`translation`, `rigid`, or `affine`).
 5. Click **Run registration**.
 
@@ -379,11 +379,11 @@ Use **Within-scan** for motion correction inside a single time series.
 
 | Parameter | What it does | When it is useful |
 |---|---|---|
-| **Reference time index (moving layer)** | Chooses the time index of the moving layer used as the motion-correction target. Inactive while **Use a fixed layer** is checked. | Pick a representative, sharp frame with little motion. |
-| **Use a fixed layer** / **Fixed layer** | Registers every frame to the selected spatial-only layer on the same grid instead of a time index. The **Fixed layer** selector is inactive until the box is checked. | Use a more stable target than any single frame, for example the mean of a few low-motion frames. |
+| **Reference time** | Chooses the moving layer's time index used as the motion-correction target. Inactive while **Fixed layer** is ticked. | Pick a representative, sharp frame with little motion. |
+| **Fixed layer** | Registers every frame to the selected spatial-only layer on the same grid instead of a time index. Its selector is inactive until the box is ticked. | Use a more stable target than any single frame, for example the mean of a few low-motion frames. |
 | **Transform** | Chooses the volume-wise motion model. | `rigid` is the safest starting point; `affine` is available when motion is more complex. |
 | **Metric** | Chooses the volume-to-reference similarity criterion. | `correlation` is usually a good default for within-recording motion correction. |
-| **Fixed / Moving intensity scaling** | Applies optional intensity scaling (`decibel`, `square root`, or `none`) to the fixed layer and to every frame, only for the optimizer. The fixed scaling only appears with **Use a fixed layer**; the reference frame uses the moving scaling. | Useful when an intensity transform makes anatomy more stable across time for the optimizer, or when the fixed layer is on a different intensity scale than the recording. |
+| **Fixed / Moving intensity scaling** | Applies optional intensity scaling (`decibel`, `square root`, or `none`) to the fixed layer and to every frame, only for the optimizer. The fixed scaling is only active with **Fixed layer** ticked; the reference frame uses the moving scaling. | Useful when an intensity transform makes anatomy more stable across time for the optimizer, or when the fixed layer is on a different intensity scale than the recording. |
 | **Initialization** | Sets the initial volume-wise centering transform. | Most runs can use no initialization. |
 | **Learning rate** | Sets the optimizer step size for each frame. | Within-scan uses a fixed value here; the default is `0.01`. Reduce it if updates look unstable; increase it if frames are already close and convergence is too slow. |
 | **Iterations** | Maximum optimizer steps per frame. | Increase it for harder motion or more flexible transforms. |

--- a/docs/gui/plugin.md
+++ b/docs/gui/plugin.md
@@ -369,8 +369,8 @@ Use **Within-scan** for motion correction inside a single time series.
 
 1. Switch **Mode** to **Within-scan**.
 2. Select the time-series **Moving layer**.
-3. Choose the moving layer's **Reference time** index used as the registration target,
-   or tick **Fixed layer** and select a spatial-only layer on the same grid instead
+3. Pick the registration target: either **Reference time**, a time index of the moving
+   layer, or **Fixed layer**, another layer on the same grid without a time dimension
    (for example the mean of a few low-motion frames).
 4. Pick a transform model (`translation`, `rigid`, or `affine`).
 5. Click **Run registration**.
@@ -379,11 +379,11 @@ Use **Within-scan** for motion correction inside a single time series.
 
 | Parameter | What it does | When it is useful |
 |---|---|---|
-| **Reference time** | Chooses the moving layer's time index used as the motion-correction target. Inactive while **Fixed layer** is ticked. | Pick a representative, sharp frame with little motion. |
-| **Fixed layer** | Registers every frame to the selected spatial-only layer on the same grid instead of a time index. Its selector is inactive until the box is ticked. | Use a more stable target than any single frame, for example the mean of a few low-motion frames. |
+| **Reference time** | Registers every frame to the moving layer's frame at this time index. | Pick a representative, sharp frame with little motion. |
+| **Fixed layer** | Registers every frame to another layer on the same grid instead. The layer must have no time dimension. | Use a more stable target than any single frame, for example the mean of a few low-motion frames. |
 | **Transform** | Chooses the volume-wise motion model. | `rigid` is the safest starting point; `affine` is available when motion is more complex. |
 | **Metric** | Chooses the volume-to-reference similarity criterion. | `correlation` is usually a good default for within-recording motion correction. |
-| **Fixed / Moving intensity scaling** | Applies optional intensity scaling (`decibel`, `square root`, or `none`) to the fixed layer and to every frame, only for the optimizer. The fixed scaling is only active with **Fixed layer** ticked; the reference frame uses the moving scaling. | Useful when an intensity transform makes anatomy more stable across time for the optimizer, or when the fixed layer is on a different intensity scale than the recording. |
+| **Fixed / Moving intensity scaling** | Applies optional intensity scaling (`decibel`, `square root`, or `none`) to the fixed layer and to every frame, only for the optimizer. The fixed scaling is only active with **Fixed layer** selected; the reference frame uses the moving scaling. | Useful when an intensity transform makes anatomy more stable across time for the optimizer, or when the fixed layer is on a different intensity scale than the recording. |
 | **Initialization** | Sets the initial volume-wise centering transform. | Most runs can use no initialization. |
 | **Learning rate** | Sets the optimizer step size for each frame. | Within-scan uses a fixed value here; the default is `0.01`. Reduce it if updates look unstable; increase it if frames are already close and convergence is too slow. |
 | **Iterations** | Maximum optimizer steps per frame. | Increase it for harder motion or more flexible transforms. |

--- a/src/confusius/_napari/_registration/_panel.py
+++ b/src/confusius/_napari/_registration/_panel.py
@@ -500,7 +500,9 @@ class RegistrationPanel(QWidget):
         )
         operation_layout.addRow(self._moving_label, self._moving_combo)
 
-        self._reference_time_label = QLabel("Reference time index (moving layer)")
+        # Kept short: QFormLayout sizes its label column to the widest label, so a
+        # long one here widens the whole panel and wraps the Mode row's radio pair.
+        self._reference_time_label = QLabel("Reference time")
         self._reference_time_spin = QSpinBox()
         self._reference_time_spin.setMinimum(0)
         self._reference_time_spin.setMaximumWidth(64)
@@ -508,16 +510,6 @@ class RegistrationPanel(QWidget):
             "Time index of the moving layer used as the registration target for within-scan motion correction."
         )
         operation_layout.addRow(self._reference_time_label, self._reference_time_spin)
-
-        self._volumewise_use_fixed_check = QCheckBox("Use a fixed layer")
-        self._volumewise_use_fixed_check.setToolTip(
-            "Register every frame to the Fixed layer below instead of a time index of "
-            "the moving layer."
-        )
-        self._volumewise_use_fixed_check.toggled.connect(
-            self._on_volumewise_fixed_toggled
-        )
-        operation_layout.addRow(self._volumewise_use_fixed_check)
 
         self._moving_mask_combo = QComboBox()
         self._moving_mask_combo.setSizeAdjustPolicy(
@@ -564,7 +556,24 @@ class RegistrationPanel(QWidget):
         self._fixed_label.setToolTip(
             "Reference layer that defines the registration target grid."
         )
-        operation_layout.addRow(self._fixed_label, self._fixed_combo)
+        # Within-scan makes the fixed layer optional, so the checkbox takes the
+        # label's place there; only one of the two is ever visible.
+        self._volumewise_use_fixed_check = QCheckBox("Fixed layer")
+        self._volumewise_use_fixed_check.setToolTip(
+            "Register every frame to this layer instead of a time index of the "
+            "moving layer."
+        )
+        self._volumewise_use_fixed_check.toggled.connect(
+            self._on_volumewise_fixed_toggled
+        )
+        fixed_label_row = QHBoxLayout()
+        fixed_label_row.setContentsMargins(0, 0, 0, 0)
+        fixed_label_row.setSpacing(0)
+        fixed_label_row.addWidget(self._fixed_label)
+        fixed_label_row.addWidget(self._volumewise_use_fixed_check)
+        self._fixed_label_row = QWidget()
+        self._fixed_label_row.setLayout(fixed_label_row)
+        operation_layout.addRow(self._fixed_label_row, self._fixed_combo)
 
         self._fixed_mask_combo = QComboBox()
         self._fixed_mask_combo.setSizeAdjustPolicy(
@@ -1540,11 +1549,11 @@ class RegistrationPanel(QWidget):
         is_volumewise = self._operation() == "register_volumewise"
         use_fixed = is_volumewise and self._volumewise_use_fixed_check.isChecked()
         fixed_enabled = not is_volumewise or use_fixed
-        self._fixed_label.setEnabled(fixed_enabled)
+        self._fixed_label.setVisible(not is_volumewise)
+        self._volumewise_use_fixed_check.setVisible(is_volumewise)
         self._fixed_combo.setEnabled(fixed_enabled)
         self._fixed_scale_label.setEnabled(fixed_enabled)
         self._fixed_scale_combo.setEnabled(fixed_enabled)
-        self._volumewise_use_fixed_check.setVisible(is_volumewise)
         self._reference_time_label.setVisible(is_volumewise)
         self._reference_time_spin.setVisible(is_volumewise)
         self._reference_time_label.setEnabled(not use_fixed)

--- a/src/confusius/_napari/_registration/_panel.py
+++ b/src/confusius/_napari/_registration/_panel.py
@@ -153,6 +153,7 @@ class ModeParameters(TypedDict):
     fill_value_auto: bool
     fill_value: float
     reference_time: int
+    volumewise_use_fixed: bool
     n_jobs: int
     sitk_threads: int
     optimizer_weights_enabled: bool
@@ -202,7 +203,9 @@ class VolumewiseRegistrationRunPayload(RegistrationRunPayloadBase):
     operation: Literal["register_volumewise"]
     transform: VolumewiseTransformType
     mesh_size: tuple[int, int, int]
-    reference_time: int
+    reference_time: int | None
+    fixed_layer_name: str | None
+    fixed_scale: ScaleMode | None
     n_jobs: int
 
 
@@ -578,6 +581,16 @@ class RegistrationPanel(QWidget):
         )
         operation_layout.addRow(self._fixed_mask_label, fixed_mask_container)
 
+        self._volumewise_use_fixed_check = QCheckBox("Use a fixed layer")
+        self._volumewise_use_fixed_check.setToolTip(
+            "Register every frame to the Fixed layer above instead of a volume index "
+            "of the moving layer."
+        )
+        self._volumewise_use_fixed_check.toggled.connect(
+            self._on_volumewise_fixed_toggled
+        )
+        operation_layout.addRow(self._volumewise_use_fixed_check)
+
         self._reference_time_label = QLabel("Reference volume")
         self._reference_time_spin = QSpinBox()
         self._reference_time_spin.setMinimum(0)
@@ -690,10 +703,8 @@ class RegistrationPanel(QWidget):
         )
         params_layout.addRow(self._fixed_scale_label, self._fixed_scale_combo)
 
-        # Labelled "Moving intensity scaling" between scans and "Intensity scaling"
-        # within-scan, where it applies to the reference and every frame.
         self._scale_combo = self._make_scale_combo(
-            "Intensity scaling applied to the moving layer (within-scan: to the reference and every frame), only by the registration optimizer; result layers keep original intensities."
+            "Intensity scaling applied to the moving layer (within-scan: to every frame, and to the reference unless a separate fixed scaling applies), only by the registration optimizer; result layers keep original intensities."
         )
         self._scale_label = self._make_form_label(
             "Moving intensity scaling", tooltip=self._scale_combo.toolTip()
@@ -1524,6 +1535,26 @@ class RegistrationPanel(QWidget):
         if is_bspline:
             self._optimizer_weights_fields.hide()
 
+    def _update_volumewise_fixed_visibility(self) -> None:
+        """Show either the fixed-layer or the reference-volume target widgets."""
+        is_volumewise = self._operation() == "register_volumewise"
+        use_fixed = is_volumewise and self._volumewise_use_fixed_check.isChecked()
+        show_fixed = not is_volumewise or use_fixed
+        self._fixed_label.setVisible(show_fixed)
+        self._fixed_combo.setVisible(show_fixed)
+        self._fixed_combo.setEnabled(show_fixed)
+        self._fixed_scale_label.setVisible(show_fixed)
+        self._fixed_scale_combo.setVisible(show_fixed)
+        self._volumewise_use_fixed_check.setVisible(is_volumewise)
+        self._reference_time_label.setVisible(is_volumewise and not use_fixed)
+        self._reference_time_spin.setVisible(is_volumewise and not use_fixed)
+
+    def _on_volumewise_fixed_toggled(self, checked: bool) -> None:
+        """Swap the within-scan target widgets when the fixed toggle changes."""
+        del checked
+        self._update_volumewise_fixed_visibility()
+        self._validate_registration_selection()
+
     def _on_mode_changed(self) -> None:
         """Update the panel when the registration mode changes."""
         new_mode = self._operation()
@@ -1535,20 +1566,10 @@ class RegistrationPanel(QWidget):
                 get_registration_parameters(self)
             )
 
-        self._fixed_label.setVisible(not is_volumewise)
-        self._fixed_combo.setVisible(not is_volumewise)
-        self._fixed_combo.setEnabled(not is_volumewise)
         self._fixed_mask_label.setVisible(not is_volumewise)
         self._fixed_mask_row.setVisible(not is_volumewise)
         self._moving_mask_label.setVisible(not is_volumewise)
         self._moving_mask_row.setVisible(not is_volumewise)
-        self._fixed_scale_label.setVisible(not is_volumewise)
-        self._fixed_scale_combo.setVisible(not is_volumewise)
-        self._scale_label.setText(
-            "Intensity scaling" if is_volumewise else "Moving intensity scaling"
-        )
-        self._reference_time_label.setVisible(is_volumewise)
-        self._reference_time_spin.setVisible(is_volumewise)
         self._n_jobs_row.setVisible(is_volumewise)
         self._sitk_threads_row.setVisible(not is_volumewise)
 
@@ -1563,6 +1584,7 @@ class RegistrationPanel(QWidget):
         )
         self._active_operation = new_mode
 
+        self._update_volumewise_fixed_visibility()
         self._update_reference_time_bounds()
         self._validate_registration_selection()
 
@@ -1817,6 +1839,22 @@ class RegistrationPanel(QWidget):
                 self._set_error(f"Unknown transform model: {transform!r}.")
                 return
 
+            use_fixed = self._volumewise_use_fixed_check.isChecked()
+            fixed_dataarray = None
+            fixed_layer_name = None
+            fixed_scale_mode = None
+            if use_fixed:
+                if fixed_layer is None:
+                    self._set_error("Select a fixed layer.")
+                    return
+                try:
+                    fixed_dataarray = _get_source_dataarray(fixed_layer)
+                except Exception as exc:  # noqa: BLE001
+                    self._set_error(str(exc))
+                    return
+                fixed_layer_name = fixed_layer.name
+                fixed_scale_mode = self._current_scale_mode(fixed=True)
+
             volumewise_payload: VolumewiseRegistrationRunPayload = {
                 "operation": "register_volumewise",
                 "moving_layer_name": moving_layer.name,
@@ -1843,7 +1881,11 @@ class RegistrationPanel(QWidget):
                     self._mesh_size_y_spin.value(),
                     self._mesh_size_x_spin.value(),
                 ),
-                "reference_time": self._reference_time_spin.value(),
+                "reference_time": None
+                if use_fixed
+                else self._reference_time_spin.value(),
+                "fixed_layer_name": fixed_layer_name,
+                "fixed_scale": fixed_scale_mode,
                 "n_jobs": self._n_jobs_spin.value(),
             }
             progress_reporter = setup_volumewise_progress(
@@ -1860,6 +1902,7 @@ class RegistrationPanel(QWidget):
             worker = thread_worker(register_volumewise)(
                 moving,
                 reference_time=volumewise_payload["reference_time"],
+                fixed=fixed_dataarray,
                 n_jobs=volumewise_payload["n_jobs"],
                 transform=volumewise_payload["transform"],
                 metric=volumewise_payload["metric"],
@@ -1868,6 +1911,7 @@ class RegistrationPanel(QWidget):
                 use_multi_resolution=volumewise_payload["use_multi_resolution"],
                 resample_interpolation=volumewise_payload["resample_interpolation"],
                 number_of_histogram_bins=volumewise_payload["number_of_histogram_bins"],
+                fixed_intensity_scaling=volumewise_payload["fixed_scale"],
                 moving_intensity_scaling=volumewise_payload["scale"],
                 convergence_minimum_value=volumewise_payload[
                     "convergence_minimum_value"

--- a/src/confusius/_napari/_registration/_panel.py
+++ b/src/confusius/_napari/_registration/_panel.py
@@ -471,20 +471,27 @@ class RegistrationPanel(QWidget):
 
         self._mode_group = QButtonGroup(self)
         mode_row = QHBoxLayout()
+        mode_row.setContentsMargins(0, 0, 0, 0)
         self._single_volume_radio = QRadioButton("Between scans")
         self._time_series_radio = QRadioButton("Within-scan")
         self._single_volume_radio.setChecked(True)
         self._mode_group.addButton(self._single_volume_radio)
         self._mode_group.addButton(self._time_series_radio)
-        mode_row.addWidget(self._single_volume_radio)
-        mode_row.addWidget(self._time_series_radio)
-        operation_layout.addRow(
+        mode_row.addWidget(
             self._make_form_label(
                 "Mode",
                 tooltip="Registration workflow. Use 'Between scans' for moving/fixed registration and 'Within-scan' for frame-to-reference motion correction.",
-            ),
-            mode_row,
+            )
         )
+        mode_row.addWidget(self._single_volume_radio)
+        mode_row.addWidget(self._time_series_radio)
+        mode_row.addStretch()
+        # Spanning row: keeping the mode radios out of the form's shared label
+        # column stops a wide label further down from wrapping them onto their
+        # own line.
+        mode_container = QWidget()
+        mode_container.setLayout(mode_row)
+        operation_layout.addRow(mode_container)
 
         self._moving_label = QLabel("Moving layer")
         self._moving_combo = QComboBox()
@@ -502,14 +509,14 @@ class RegistrationPanel(QWidget):
 
         # Kept short: QFormLayout sizes its label column to the widest label, so a
         # long one here widens the whole panel and wraps the Mode row's radio pair.
-        self._reference_time_label = QLabel("Reference time")
+        self._reference_time_radio = QRadioButton("Reference time")
         self._reference_time_spin = QSpinBox()
         self._reference_time_spin.setMinimum(0)
         self._reference_time_spin.setMaximumWidth(64)
-        self._reference_time_label.setToolTip(
+        self._reference_time_radio.setToolTip(
             "Time index of the moving layer used as the registration target for within-scan motion correction."
         )
-        operation_layout.addRow(self._reference_time_label, self._reference_time_spin)
+        operation_layout.addRow(self._reference_time_radio, self._reference_time_spin)
 
         self._moving_mask_combo = QComboBox()
         self._moving_mask_combo.setSizeAdjustPolicy(
@@ -556,21 +563,25 @@ class RegistrationPanel(QWidget):
         self._fixed_label.setToolTip(
             "Reference layer that defines the registration target grid."
         )
-        # Within-scan makes the fixed layer optional, so the checkbox takes the
-        # label's place there; only one of the two is ever visible.
-        self._volumewise_use_fixed_check = QCheckBox("Fixed layer")
-        self._volumewise_use_fixed_check.setToolTip(
+        # Within-scan picks one of two targets, so a radio button takes the label's
+        # place there; only one of the two is ever visible.
+        self._fixed_layer_radio = QRadioButton("Fixed layer")
+        self._fixed_layer_radio.setToolTip(
             "Register every frame to this layer instead of a time index of the "
             "moving layer."
         )
-        self._volumewise_use_fixed_check.toggled.connect(
-            self._on_volumewise_fixed_toggled
-        )
+        # An explicit group: the two target radios have different parent widgets,
+        # so Qt's sibling auto-exclusivity would not pair them.
+        self._volumewise_target_group = QButtonGroup(self)
+        self._volumewise_target_group.addButton(self._reference_time_radio)
+        self._volumewise_target_group.addButton(self._fixed_layer_radio)
+        self._reference_time_radio.setChecked(True)
+        self._fixed_layer_radio.toggled.connect(self._on_volumewise_fixed_toggled)
         fixed_label_row = QHBoxLayout()
         fixed_label_row.setContentsMargins(0, 0, 0, 0)
         fixed_label_row.setSpacing(0)
         fixed_label_row.addWidget(self._fixed_label)
-        fixed_label_row.addWidget(self._volumewise_use_fixed_check)
+        fixed_label_row.addWidget(self._fixed_layer_radio)
         self._fixed_label_row = QWidget()
         self._fixed_label_row.setLayout(fixed_label_row)
         operation_layout.addRow(self._fixed_label_row, self._fixed_combo)
@@ -1547,16 +1558,15 @@ class RegistrationPanel(QWidget):
     def _update_volumewise_target_state(self) -> None:
         """Enable the fixed-layer or the reference-time target widgets, not both."""
         is_volumewise = self._operation() == "register_volumewise"
-        use_fixed = is_volumewise and self._volumewise_use_fixed_check.isChecked()
+        use_fixed = is_volumewise and self._fixed_layer_radio.isChecked()
         fixed_enabled = not is_volumewise or use_fixed
         self._fixed_label.setVisible(not is_volumewise)
-        self._volumewise_use_fixed_check.setVisible(is_volumewise)
+        self._fixed_layer_radio.setVisible(is_volumewise)
         self._fixed_combo.setEnabled(fixed_enabled)
         self._fixed_scale_label.setEnabled(fixed_enabled)
         self._fixed_scale_combo.setEnabled(fixed_enabled)
-        self._reference_time_label.setVisible(is_volumewise)
+        self._reference_time_radio.setVisible(is_volumewise)
         self._reference_time_spin.setVisible(is_volumewise)
-        self._reference_time_label.setEnabled(not use_fixed)
         self._reference_time_spin.setEnabled(not use_fixed)
 
     def _on_volumewise_fixed_toggled(self, checked: bool) -> None:
@@ -1849,7 +1859,7 @@ class RegistrationPanel(QWidget):
                 self._set_error(f"Unknown transform model: {transform!r}.")
                 return
 
-            use_fixed = self._volumewise_use_fixed_check.isChecked()
+            use_fixed = self._fixed_layer_radio.isChecked()
             fixed_dataarray = None
             fixed_layer_name = None
             fixed_scale_mode = None

--- a/src/confusius/_napari/_registration/_panel.py
+++ b/src/confusius/_napari/_registration/_panel.py
@@ -500,6 +500,25 @@ class RegistrationPanel(QWidget):
         )
         operation_layout.addRow(self._moving_label, self._moving_combo)
 
+        self._reference_time_label = QLabel("Reference time index (moving layer)")
+        self._reference_time_spin = QSpinBox()
+        self._reference_time_spin.setMinimum(0)
+        self._reference_time_spin.setMaximumWidth(64)
+        self._reference_time_label.setToolTip(
+            "Time index of the moving layer used as the registration target for within-scan motion correction."
+        )
+        operation_layout.addRow(self._reference_time_label, self._reference_time_spin)
+
+        self._volumewise_use_fixed_check = QCheckBox("Use a fixed layer")
+        self._volumewise_use_fixed_check.setToolTip(
+            "Register every frame to the Fixed layer below instead of a time index of "
+            "the moving layer."
+        )
+        self._volumewise_use_fixed_check.toggled.connect(
+            self._on_volumewise_fixed_toggled
+        )
+        operation_layout.addRow(self._volumewise_use_fixed_check)
+
         self._moving_mask_combo = QComboBox()
         self._moving_mask_combo.setSizeAdjustPolicy(
             QComboBox.SizeAdjustPolicy.AdjustToMinimumContentsLengthWithIcon
@@ -580,25 +599,6 @@ class RegistrationPanel(QWidget):
             tooltip="Optional Labels layer used as the fixed-image metric mask. Nonzero labels are treated as True.",
         )
         operation_layout.addRow(self._fixed_mask_label, fixed_mask_container)
-
-        self._volumewise_use_fixed_check = QCheckBox("Use a fixed layer")
-        self._volumewise_use_fixed_check.setToolTip(
-            "Register every frame to the Fixed layer above instead of a volume index "
-            "of the moving layer."
-        )
-        self._volumewise_use_fixed_check.toggled.connect(
-            self._on_volumewise_fixed_toggled
-        )
-        operation_layout.addRow(self._volumewise_use_fixed_check)
-
-        self._reference_time_label = QLabel("Reference volume")
-        self._reference_time_spin = QSpinBox()
-        self._reference_time_spin.setMinimum(0)
-        self._reference_time_spin.setMaximumWidth(64)
-        self._reference_time_label.setToolTip(
-            "Volume index used as the registration target for within-scan motion correction."
-        )
-        operation_layout.addRow(self._reference_time_label, self._reference_time_spin)
 
         self._n_jobs_spin = QSpinBox()
         # Expanding: QFormLayout's ExpandingFieldsGrow only grows fields whose
@@ -1535,24 +1535,25 @@ class RegistrationPanel(QWidget):
         if is_bspline:
             self._optimizer_weights_fields.hide()
 
-    def _update_volumewise_fixed_visibility(self) -> None:
-        """Show either the fixed-layer or the reference-volume target widgets."""
+    def _update_volumewise_target_state(self) -> None:
+        """Enable the fixed-layer or the reference-time target widgets, not both."""
         is_volumewise = self._operation() == "register_volumewise"
         use_fixed = is_volumewise and self._volumewise_use_fixed_check.isChecked()
-        show_fixed = not is_volumewise or use_fixed
-        self._fixed_label.setVisible(show_fixed)
-        self._fixed_combo.setVisible(show_fixed)
-        self._fixed_combo.setEnabled(show_fixed)
-        self._fixed_scale_label.setVisible(show_fixed)
-        self._fixed_scale_combo.setVisible(show_fixed)
+        fixed_enabled = not is_volumewise or use_fixed
+        self._fixed_label.setEnabled(fixed_enabled)
+        self._fixed_combo.setEnabled(fixed_enabled)
+        self._fixed_scale_label.setEnabled(fixed_enabled)
+        self._fixed_scale_combo.setEnabled(fixed_enabled)
         self._volumewise_use_fixed_check.setVisible(is_volumewise)
-        self._reference_time_label.setVisible(is_volumewise and not use_fixed)
-        self._reference_time_spin.setVisible(is_volumewise and not use_fixed)
+        self._reference_time_label.setVisible(is_volumewise)
+        self._reference_time_spin.setVisible(is_volumewise)
+        self._reference_time_label.setEnabled(not use_fixed)
+        self._reference_time_spin.setEnabled(not use_fixed)
 
     def _on_volumewise_fixed_toggled(self, checked: bool) -> None:
-        """Swap the within-scan target widgets when the fixed toggle changes."""
+        """Swap the active within-scan target widget when the fixed toggle changes."""
         del checked
-        self._update_volumewise_fixed_visibility()
+        self._update_volumewise_target_state()
         self._validate_registration_selection()
 
     def _on_mode_changed(self) -> None:
@@ -1584,7 +1585,7 @@ class RegistrationPanel(QWidget):
         )
         self._active_operation = new_mode
 
-        self._update_volumewise_fixed_visibility()
+        self._update_volumewise_target_state()
         self._update_reference_time_bounds()
         self._validate_registration_selection()
 

--- a/src/confusius/_napari/_registration/_panel_parameters.py
+++ b/src/confusius/_napari/_registration/_panel_parameters.py
@@ -95,7 +95,7 @@ def get_registration_parameters(panel: RegistrationPanel) -> ModeParameters:
         "fill_value_auto": panel._fill_value_auto_check.isChecked(),
         "fill_value": panel._fill_value_spin.value(),
         "reference_time": panel._reference_time_spin.value(),
-        "volumewise_use_fixed": panel._volumewise_use_fixed_check.isChecked(),
+        "volumewise_use_fixed": panel._fixed_layer_radio.isChecked(),
         "n_jobs": panel._n_jobs_spin.value(),
         "sitk_threads": panel._sitk_threads_spin.value(),
         "optimizer_weights_enabled": panel._optimizer_weights_check.isChecked(),
@@ -169,7 +169,12 @@ def set_registration_parameters(
     panel._fill_value_auto_check.setChecked(params["fill_value_auto"])
     panel._fill_value_spin.setValue(params["fill_value"])
     panel._reference_time_spin.setValue(params["reference_time"])
-    panel._volumewise_use_fixed_check.setChecked(params["volumewise_use_fixed"])
+    # The two target radios are exclusive, so the unwanted one cannot just be
+    # unchecked: check the wanted one and Qt clears the other.
+    if params["volumewise_use_fixed"]:
+        panel._fixed_layer_radio.setChecked(True)
+    else:
+        panel._reference_time_radio.setChecked(True)
     panel._n_jobs_spin.setValue(params["n_jobs"])
     panel._sitk_threads_spin.setValue(params["sitk_threads"])
     panel._keep_diagnostics_check.setChecked(params["keep_diagnostics"])

--- a/src/confusius/_napari/_registration/_panel_parameters.py
+++ b/src/confusius/_napari/_registration/_panel_parameters.py
@@ -48,6 +48,7 @@ def get_default_registration_parameters(
         "fill_value_auto": True,
         "fill_value": 0.0,
         "reference_time": 0,
+        "volumewise_use_fixed": False,
         "n_jobs": -1,
         "sitk_threads": -1,
         "optimizer_weights_enabled": False,
@@ -94,6 +95,7 @@ def get_registration_parameters(panel: RegistrationPanel) -> ModeParameters:
         "fill_value_auto": panel._fill_value_auto_check.isChecked(),
         "fill_value": panel._fill_value_spin.value(),
         "reference_time": panel._reference_time_spin.value(),
+        "volumewise_use_fixed": panel._volumewise_use_fixed_check.isChecked(),
         "n_jobs": panel._n_jobs_spin.value(),
         "sitk_threads": panel._sitk_threads_spin.value(),
         "optimizer_weights_enabled": panel._optimizer_weights_check.isChecked(),
@@ -167,6 +169,7 @@ def set_registration_parameters(
     panel._fill_value_auto_check.setChecked(params["fill_value_auto"])
     panel._fill_value_spin.setValue(params["fill_value"])
     panel._reference_time_spin.setValue(params["reference_time"])
+    panel._volumewise_use_fixed_check.setChecked(params["volumewise_use_fixed"])
     panel._n_jobs_spin.setValue(params["n_jobs"])
     panel._sitk_threads_spin.setValue(params["sitk_threads"])
     panel._keep_diagnostics_check.setChecked(params["keep_diagnostics"])

--- a/src/confusius/_napari/_registration/_panel_results.py
+++ b/src/confusius/_napari/_registration/_panel_results.py
@@ -322,6 +322,7 @@ def on_volumewise_registration_finished(
         metadata={
             "motion_params": motion_params,
             "reference_time": payload["reference_time"],
+            "fixed_layer_name": payload.get("fixed_layer_name"),
         },
         registration_status=registration_status,
     )

--- a/src/confusius/_napari/_registration/_panel_selection.py
+++ b/src/confusius/_napari/_registration/_panel_selection.py
@@ -311,6 +311,11 @@ def set_layer_validation_style(
     panel._fixed_combo.setStyleSheet(error_style if fixed_invalid else normal_style)
     panel._moving_label.setStyleSheet("color: #e05555;" if moving_invalid else "")
     panel._fixed_label.setStyleSheet("color: #e05555;" if fixed_invalid else "")
+    # The checkbox stands in for the fixed label within-scan, so it carries the
+    # same invalid styling there.
+    panel._volumewise_use_fixed_check.setStyleSheet(
+        "color: #e05555;" if fixed_invalid else ""
+    )
     panel._reference_time_label.setStyleSheet("")
     if message:
         panel._layer_validation.setText(message)

--- a/src/confusius/_napari/_registration/_panel_selection.py
+++ b/src/confusius/_napari/_registration/_panel_selection.py
@@ -414,7 +414,7 @@ def validate_registration_selection(panel: RegistrationPanel) -> bool:
                 set_layer_validation_style(
                     panel,
                     fixed_invalid=True,
-                    message="Within-scan registration requires a fixed layer without a time dimension.",
+                    message="Fixed layer must not have a time dimension.",
                 )
                 set_run_btn_enabled(panel, False)
                 return False

--- a/src/confusius/_napari/_registration/_panel_selection.py
+++ b/src/confusius/_napari/_registration/_panel_selection.py
@@ -388,6 +388,14 @@ def validate_registration_selection(panel: RegistrationPanel) -> bool:
             )
             set_run_btn_enabled(panel, False)
             return False
+        if panel._volumewise_use_fixed_check.isChecked() and fixed_layer is None:
+            set_layer_validation_style(
+                panel,
+                fixed_invalid=True,
+                message="Select a fixed layer, or uncheck 'Use a fixed layer'.",
+            )
+            set_run_btn_enabled(panel, False)
+            return False
         init_message = validate_initial_transform_selection(
             panel,
             operation=operation,

--- a/src/confusius/_napari/_registration/_panel_selection.py
+++ b/src/confusius/_napari/_registration/_panel_selection.py
@@ -311,12 +311,10 @@ def set_layer_validation_style(
     panel._fixed_combo.setStyleSheet(error_style if fixed_invalid else normal_style)
     panel._moving_label.setStyleSheet("color: #e05555;" if moving_invalid else "")
     panel._fixed_label.setStyleSheet("color: #e05555;" if fixed_invalid else "")
-    # The checkbox stands in for the fixed label within-scan, so it carries the
-    # same invalid styling there.
-    panel._volumewise_use_fixed_check.setStyleSheet(
-        "color: #e05555;" if fixed_invalid else ""
-    )
-    panel._reference_time_label.setStyleSheet("")
+    # The radio button stands in for the fixed label within-scan, so it carries
+    # the same invalid styling there.
+    panel._fixed_layer_radio.setStyleSheet("color: #e05555;" if fixed_invalid else "")
+    panel._reference_time_radio.setStyleSheet("")
     if message:
         panel._layer_validation.setText(message)
         panel._layer_validation.show()
@@ -393,14 +391,33 @@ def validate_registration_selection(panel: RegistrationPanel) -> bool:
             )
             set_run_btn_enabled(panel, False)
             return False
-        if panel._volumewise_use_fixed_check.isChecked() and fixed_layer is None:
-            set_layer_validation_style(
-                panel,
-                fixed_invalid=True,
-                message="Select a fixed layer, or uncheck 'Use a fixed layer'.",
-            )
-            set_run_btn_enabled(panel, False)
-            return False
+        if panel._fixed_layer_radio.isChecked():
+            if fixed_layer is None:
+                set_layer_validation_style(
+                    panel,
+                    fixed_invalid=True,
+                    message="Select a fixed layer, or register to a reference time.",
+                )
+                set_run_btn_enabled(panel, False)
+                return False
+            try:
+                fixed = _get_source_dataarray(fixed_layer)
+            except TypeError:
+                set_layer_validation_style(
+                    panel,
+                    fixed_invalid=True,
+                    message="Could not read the selected fixed layer.",
+                )
+                set_run_btn_enabled(panel, False)
+                return False
+            if TIME_DIM in fixed.dims:
+                set_layer_validation_style(
+                    panel,
+                    fixed_invalid=True,
+                    message="Within-scan registration requires a fixed layer without a time dimension.",
+                )
+                set_run_btn_enabled(panel, False)
+                return False
         init_message = validate_initial_transform_selection(
             panel,
             operation=operation,

--- a/src/confusius/_napari/_tour.py
+++ b/src/confusius/_napari/_tour.py
@@ -1103,8 +1103,8 @@ def build_default_tour(
             title="Within-scan Inputs",
             body=(
                 "For <b>Within-scan</b>, choose one layer with a time dimension, then "
-                "pick the <b>Reference time</b> index that every frame should align "
-                "to, or tick <b>Fixed layer</b> to align them to another layer "
+                "pick <b>Reference time</b> to align every frame to one of its own "
+                "frames, or <b>Fixed layer</b> to align them to another layer "
                 "instead."
             ),
             anchor="left",
@@ -1114,7 +1114,7 @@ def build_default_tour(
                 "_time_series_radio",
                 "_moving_label",
                 "_moving_combo",
-                "_reference_time_label",
+                "_reference_time_radio",
                 "_reference_time_spin",
             ),
             tooltip_target=_dock_widget,

--- a/src/confusius/_napari/_tour.py
+++ b/src/confusius/_napari/_tour.py
@@ -1103,8 +1103,8 @@ def build_default_tour(
             title="Within-scan Inputs",
             body=(
                 "For <b>Within-scan</b>, choose one layer with a time dimension, then "
-                "pick the <b>Reference time index</b> that every frame should align "
-                "to, or check <b>Use a fixed layer</b> to align them to another layer "
+                "pick the <b>Reference time</b> index that every frame should align "
+                "to, or tick <b>Fixed layer</b> to align them to another layer "
                 "instead."
             ),
             anchor="left",

--- a/src/confusius/_napari/_tour.py
+++ b/src/confusius/_napari/_tour.py
@@ -995,7 +995,7 @@ def build_default_tour(
             body=(
                 "Pick <b>Between scans</b> to align one layer to another, or "
                 "<b>Within-scan</b> to motion-correct a time series against one "
-                "reference volume."
+                "reference frame or fixed layer."
             ),
             anchor="left",
             spotlight_rect=lambda: _united_rect(
@@ -1103,7 +1103,9 @@ def build_default_tour(
             title="Within-scan Inputs",
             body=(
                 "For <b>Within-scan</b>, choose one layer with a time dimension, then "
-                "pick the <b>Reference volume</b> that every frame should align to."
+                "pick the <b>Reference time index</b> that every frame should align "
+                "to, or check <b>Use a fixed layer</b> to align them to another layer "
+                "instead."
             ),
             anchor="left",
             spotlight_rect=_panel_attr_rect(

--- a/tests/unit/test_napari/test_registration_panel.py
+++ b/tests/unit/test_napari/test_registration_panel.py
@@ -242,7 +242,7 @@ class TestOperationMode:
     def test_volumewise_target_rows_are_ordered_under_moving_layer(
         self, registration_panel
     ):
-        """Within-scan rows read moving layer, reference time, toggle, fixed layer."""
+        """Within-scan rows read moving layer, reference time, then fixed layer."""
         registration_panel._time_series_radio.setChecked(True)
         operation_group = registration_panel._reference_time_label.parentWidget()
         operation_layout = operation_group.layout()
@@ -255,9 +255,30 @@ class TestOperationMode:
         assert (
             _row(registration_panel._moving_label)
             < _row(registration_panel._reference_time_label)
-            < _row(registration_panel._volumewise_use_fixed_check)
-            < _row(registration_panel._fixed_label)
+            < _row(registration_panel._fixed_label_row)
         )
+        # The fixed toggle labels its own combo box instead of taking a row.
+        assert _row(registration_panel._fixed_label_row) == _row(
+            registration_panel._fixed_combo
+        )
+        assert (
+            registration_panel._volumewise_use_fixed_check.parentWidget()
+            is registration_panel._fixed_label_row
+        )
+
+    def test_switching_to_within_scan_does_not_widen_panel(self, registration_panel):
+        # Regression test: a label wider than the between-scan ones grows
+        # QFormLayout's label column, which wraps the Mode row's radio pair.
+        registration_panel.show()
+        QApplication.processEvents()
+        between_scan_width = registration_panel.sizeHint().width()
+
+        registration_panel._time_series_radio.setChecked(True)
+        QApplication.processEvents()
+
+        # A long within-scan label widens QFormLayout's shared label column: at
+        # ~130px extra it pushed the Mode row's radio buttons onto their own line.
+        assert registration_panel.sizeHint().width() <= between_scan_width + 16
 
     def test_volumewise_fixed_choice_survives_mode_switch(self, registration_panel):
         registration_panel._time_series_radio.setChecked(True)

--- a/tests/unit/test_napari/test_registration_panel.py
+++ b/tests/unit/test_napari/test_registration_panel.py
@@ -1070,7 +1070,8 @@ class TestValidation:
         assert not registration_panel._validate_registration_selection()
         assert not registration_panel._run_btn.isEnabled()
         assert (
-            "without a time dimension" in registration_panel._layer_validation.text()
+            registration_panel._layer_validation.text()
+            == "Fixed layer must not have a time dimension."
         )
         assert "border" in registration_panel._fixed_combo.styleSheet()
 

--- a/tests/unit/test_napari/test_registration_panel.py
+++ b/tests/unit/test_napari/test_registration_panel.py
@@ -281,6 +281,14 @@ class TestOperationMode:
         Regression test: the mode radios used to sit in the form's shared label
         column, so a wider within-scan label pushed them onto their own line.
         """
+
+        def _shares_a_line(first, second):
+            # Top edges differ across platforms because a label and a radio have
+            # different heights, so compare the spans instead of the y offsets.
+            return max(first.y(), second.y()) <= min(
+                first.geometry().bottom(), second.geometry().bottom()
+            )
+
         registration_panel.show()
         registration_panel.resize(registration_panel.minimumSizeHint().width(), 900)
         QApplication.processEvents()
@@ -289,12 +297,12 @@ class TestOperationMode:
         ).widget()
         assert mode_label.text() == "Mode"
 
-        assert mode_label.y() == registration_panel._single_volume_radio.y()
+        assert _shares_a_line(mode_label, registration_panel._single_volume_radio)
 
         registration_panel._time_series_radio.setChecked(True)
         QApplication.processEvents()
 
-        assert mode_label.y() == registration_panel._single_volume_radio.y()
+        assert _shares_a_line(mode_label, registration_panel._single_volume_radio)
 
     def test_volumewise_fixed_choice_survives_mode_switch(self, registration_panel):
         registration_panel._time_series_radio.setChecked(True)

--- a/tests/unit/test_napari/test_registration_panel.py
+++ b/tests/unit/test_napari/test_registration_panel.py
@@ -8,7 +8,7 @@ from typing import Any, cast
 import numpy as np
 import pytest
 import xarray as xr
-from qtpy.QtWidgets import QApplication
+from qtpy.QtWidgets import QApplication, QFormLayout
 
 from confusius._dims import VOXEL_DIMS, WORLD_DIMS
 from confusius._napari._registration._panel_progress import (
@@ -205,34 +205,59 @@ class TestOperationMode:
         assert registration_panel._register_panel.isHidden()
         assert not registration_panel._transforms_panel.isHidden()
 
-    def test_volumewise_hides_fixed_selector(self, registration_panel):
+    def test_volumewise_disables_fixed_selector(self, registration_panel):
         registration_panel._time_series_radio.setChecked(True)
-        assert registration_panel._fixed_combo.isHidden()
+        assert not registration_panel._fixed_combo.isHidden()
+        assert not registration_panel._fixed_combo.isEnabled()
         assert not registration_panel._reference_time_spin.isHidden()
+        assert registration_panel._reference_time_spin.isEnabled()
         assert not registration_panel._n_jobs_row.isHidden()
 
-    def test_volumewise_fixed_toggle_swaps_target_widgets(self, registration_panel):
+    def test_volumewise_fixed_toggle_swaps_active_target(self, registration_panel):
         assert registration_panel._volumewise_use_fixed_check.isHidden()
 
         registration_panel._time_series_radio.setChecked(True)
 
         assert not registration_panel._volumewise_use_fixed_check.isHidden()
-        assert registration_panel._fixed_combo.isHidden()
-        assert registration_panel._fixed_scale_combo.isHidden()
-        assert not registration_panel._reference_time_spin.isHidden()
+        assert not registration_panel._fixed_combo.isEnabled()
+        assert not registration_panel._fixed_scale_combo.isEnabled()
+        assert registration_panel._reference_time_spin.isEnabled()
 
         registration_panel._volumewise_use_fixed_check.setChecked(True)
 
+        assert registration_panel._fixed_combo.isEnabled()
+        assert registration_panel._fixed_scale_combo.isEnabled()
+        assert not registration_panel._reference_time_spin.isEnabled()
+        assert not registration_panel._reference_time_label.isEnabled()
+        # Both targets stay on screen; only one of them is active.
         assert not registration_panel._fixed_combo.isHidden()
-        assert not registration_panel._fixed_scale_combo.isHidden()
-        assert registration_panel._reference_time_spin.isHidden()
-        assert registration_panel._reference_time_label.isHidden()
+        assert not registration_panel._reference_time_spin.isHidden()
 
         registration_panel._volumewise_use_fixed_check.setChecked(False)
 
-        assert registration_panel._fixed_combo.isHidden()
-        assert registration_panel._fixed_scale_combo.isHidden()
-        assert not registration_panel._reference_time_spin.isHidden()
+        assert not registration_panel._fixed_combo.isEnabled()
+        assert not registration_panel._fixed_scale_combo.isEnabled()
+        assert registration_panel._reference_time_spin.isEnabled()
+
+    def test_volumewise_target_rows_are_ordered_under_moving_layer(
+        self, registration_panel
+    ):
+        """Within-scan rows read moving layer, reference time, toggle, fixed layer."""
+        registration_panel._time_series_radio.setChecked(True)
+        operation_group = registration_panel._reference_time_label.parentWidget()
+        operation_layout = operation_group.layout()
+        assert isinstance(operation_layout, QFormLayout)
+
+        def _row(widget):
+            row, _role = operation_layout.getWidgetPosition(widget)
+            return row
+
+        assert (
+            _row(registration_panel._moving_label)
+            < _row(registration_panel._reference_time_label)
+            < _row(registration_panel._volumewise_use_fixed_check)
+            < _row(registration_panel._fixed_label)
+        )
 
     def test_volumewise_fixed_choice_survives_mode_switch(self, registration_panel):
         registration_panel._time_series_radio.setChecked(True)
@@ -241,13 +266,14 @@ class TestOperationMode:
         registration_panel._single_volume_radio.setChecked(True)
 
         assert registration_panel._volumewise_use_fixed_check.isHidden()
-        assert not registration_panel._fixed_combo.isHidden()
+        assert registration_panel._reference_time_spin.isHidden()
+        assert registration_panel._fixed_combo.isEnabled()
 
         registration_panel._time_series_radio.setChecked(True)
 
         assert registration_panel._volumewise_use_fixed_check.isChecked()
-        assert not registration_panel._fixed_combo.isHidden()
-        assert registration_panel._reference_time_spin.isHidden()
+        assert registration_panel._fixed_combo.isEnabled()
+        assert not registration_panel._reference_time_spin.isEnabled()
 
     def test_between_scan_shows_masks_and_sitk_threads(self, registration_panel):
         registration_panel._advanced_toggle.setChecked(True)
@@ -307,13 +333,15 @@ class TestOperationMode:
         assert registration_panel._scale_combo.currentText() == "none"
         assert registration_panel._fixed_scale_combo.currentText() == "square root"
 
-    def test_fixed_scale_combo_hidden_within_scan_by_default(self, registration_panel):
-        assert not registration_panel._fixed_scale_combo.isHidden()
+    def test_fixed_scale_combo_disabled_within_scan_by_default(
+        self, registration_panel
+    ):
+        assert registration_panel._fixed_scale_combo.isEnabled()
         assert registration_panel._scale_label.text() == "Moving intensity scaling"
 
         registration_panel._time_series_radio.setChecked(True)
 
-        assert registration_panel._fixed_scale_combo.isHidden()
+        assert not registration_panel._fixed_scale_combo.isEnabled()
         assert registration_panel._scale_label.text() == "Moving intensity scaling"
 
     def test_advanced_group_is_collapsed_by_default(self, registration_panel):

--- a/tests/unit/test_napari/test_registration_panel.py
+++ b/tests/unit/test_napari/test_registration_panel.py
@@ -211,6 +211,44 @@ class TestOperationMode:
         assert not registration_panel._reference_time_spin.isHidden()
         assert not registration_panel._n_jobs_row.isHidden()
 
+    def test_volumewise_fixed_toggle_swaps_target_widgets(self, registration_panel):
+        assert registration_panel._volumewise_use_fixed_check.isHidden()
+
+        registration_panel._time_series_radio.setChecked(True)
+
+        assert not registration_panel._volumewise_use_fixed_check.isHidden()
+        assert registration_panel._fixed_combo.isHidden()
+        assert registration_panel._fixed_scale_combo.isHidden()
+        assert not registration_panel._reference_time_spin.isHidden()
+
+        registration_panel._volumewise_use_fixed_check.setChecked(True)
+
+        assert not registration_panel._fixed_combo.isHidden()
+        assert not registration_panel._fixed_scale_combo.isHidden()
+        assert registration_panel._reference_time_spin.isHidden()
+        assert registration_panel._reference_time_label.isHidden()
+
+        registration_panel._volumewise_use_fixed_check.setChecked(False)
+
+        assert registration_panel._fixed_combo.isHidden()
+        assert registration_panel._fixed_scale_combo.isHidden()
+        assert not registration_panel._reference_time_spin.isHidden()
+
+    def test_volumewise_fixed_choice_survives_mode_switch(self, registration_panel):
+        registration_panel._time_series_radio.setChecked(True)
+        registration_panel._volumewise_use_fixed_check.setChecked(True)
+
+        registration_panel._single_volume_radio.setChecked(True)
+
+        assert registration_panel._volumewise_use_fixed_check.isHidden()
+        assert not registration_panel._fixed_combo.isHidden()
+
+        registration_panel._time_series_radio.setChecked(True)
+
+        assert registration_panel._volumewise_use_fixed_check.isChecked()
+        assert not registration_panel._fixed_combo.isHidden()
+        assert registration_panel._reference_time_spin.isHidden()
+
     def test_between_scan_shows_masks_and_sitk_threads(self, registration_panel):
         registration_panel._advanced_toggle.setChecked(True)
 
@@ -269,14 +307,14 @@ class TestOperationMode:
         assert registration_panel._scale_combo.currentText() == "none"
         assert registration_panel._fixed_scale_combo.currentText() == "square root"
 
-    def test_fixed_scale_combo_only_between_scans(self, registration_panel):
+    def test_fixed_scale_combo_hidden_within_scan_by_default(self, registration_panel):
         assert not registration_panel._fixed_scale_combo.isHidden()
         assert registration_panel._scale_label.text() == "Moving intensity scaling"
 
         registration_panel._time_series_radio.setChecked(True)
 
         assert registration_panel._fixed_scale_combo.isHidden()
-        assert registration_panel._scale_label.text() == "Intensity scaling"
+        assert registration_panel._scale_label.text() == "Moving intensity scaling"
 
     def test_advanced_group_is_collapsed_by_default(self, registration_panel):
         assert not registration_panel._advanced_toggle.isChecked()
@@ -802,10 +840,77 @@ class TestRunRegistration:
         assert kwargs["optimizer_weights"] == weights
         if within_scan:
             assert kwargs["reference_time"] == 0
+            assert kwargs["fixed"] is None
+            assert kwargs["fixed_intensity_scaling"] is None
         else:
             assert kwargs["sitk_threads"] == 3
             assert kwargs["fixed_mask"].dtype == bool
             assert kwargs["moving_mask"].dtype == bool
+        assert registration_panel._worker is not None
+
+    def test_within_scan_run_passes_fixed_layer(
+        self, viewer, registration_panel, monkeypatch
+    ):
+        moving = create_voxeldata(
+            np.zeros((2, 4, 6, 8), dtype=np.float32),
+            dims=("time", "k", "j", "i"),
+            time=np.arange(2),
+            spacing=(0.3, 0.2, 0.1),
+        )
+        fixed = create_voxeldata(
+            np.ones((4, 6, 8), dtype=np.float32),
+            dims=("k", "j", "i"),
+            spacing=(0.3, 0.2, 0.1),
+        )
+        viewer.add_image(moving.values, name="moving", metadata={"xarray": moving})
+        viewer.add_image(fixed.values, name="target", metadata={"xarray": fixed})
+        registration_panel._refresh_layers()
+        registration_panel._time_series_radio.setChecked(True)
+        registration_panel._moving_combo.setCurrentText("moving")
+        registration_panel._volumewise_use_fixed_check.setChecked(True)
+        registration_panel._fixed_combo.setCurrentText("target")
+        registration_panel._scale_combo.setCurrentText("square root")
+        registration_panel._fixed_scale_combo.setCurrentText("none")
+
+        captured: dict[str, object] = {}
+
+        class _FakeSignal:
+            def connect(self, _slot):
+                return None
+
+        class _FakeWorker:
+            def __init__(self) -> None:
+                self.returned = _FakeSignal()
+                self.errored = _FakeSignal()
+                self.finished = _FakeSignal()
+
+            def start(self) -> None:
+                return None
+
+        def _fake_thread_worker(func):
+            def _runner(*args, **kwargs):
+                captured["args"] = args
+                captured["kwargs"] = kwargs
+                return _FakeWorker()
+
+            return _runner
+
+        monkeypatch.setattr(
+            "confusius._napari._registration._panel.thread_worker",
+            _fake_thread_worker,
+        )
+        monkeypatch.setattr(
+            "confusius._napari._registration._panel.setup_volumewise_progress",
+            lambda *_args, **_kwargs: None,
+        )
+
+        registration_panel._run_registration()
+
+        kwargs = cast("dict[str, Any]", captured["kwargs"])
+        assert kwargs["reference_time"] is None
+        np.testing.assert_array_equal(kwargs["fixed"].values, fixed.values)
+        assert kwargs["fixed_intensity_scaling"] == "none"
+        assert kwargs["moving_intensity_scaling"] == "sqrt"
         assert registration_panel._worker is not None
 
 
@@ -849,6 +954,29 @@ class TestValidation:
             "Within-scan registration requires"
             in registration_panel._layer_validation.text()
         )
+
+    def test_within_scan_fixed_toggle_requires_fixed_layer(
+        self, viewer, registration_panel, sample_voxeldata_3dt
+    ):
+        viewer.add_image(
+            sample_voxeldata_3dt.values,
+            name="moving",
+            metadata={"xarray": sample_voxeldata_3dt},
+        )
+        registration_panel._refresh_layers()
+        registration_panel._time_series_radio.setChecked(True)
+        registration_panel._moving_combo.setCurrentText("moving")
+        registration_panel._volumewise_use_fixed_check.setChecked(True)
+        registration_panel._fixed_combo.setCurrentIndex(-1)
+
+        assert not registration_panel._validate_registration_selection()
+        assert not registration_panel._run_btn.isEnabled()
+        assert "Select a fixed layer" in registration_panel._layer_validation.text()
+
+        registration_panel._fixed_combo.setCurrentText("moving")
+
+        assert registration_panel._validate_registration_selection()
+        assert registration_panel._run_btn.isEnabled()
 
     def test_between_scans_accepts_time_series_by_averaging(
         self, viewer, registration_panel, sample_voxeldata_3dt
@@ -1574,14 +1702,16 @@ class TestFinishedCallbacks:
             "number_of_iterations": 100,
             "use_multi_resolution": False,
             "resample_interpolation": "linear",
-            "reference_time": 1,
+            "reference_time": None,
+            "fixed_layer_name": "target",
         }
 
         on_registration_finished(registration_panel, payload, registered)
 
         layer = viewer.layers["Motion corrected"]
         np.testing.assert_array_equal(np.asarray(layer.data), registered.values)
-        assert layer.metadata["reference_time"] == 1
+        assert layer.metadata["reference_time"] is None
+        assert layer.metadata["fixed_layer_name"] == "target"
         assert layer.metadata["registration_operation"] == "register_volumewise"
         assert {"Moving", "Motion corrected"}.issubset(
             {existing.name for existing in viewer.layers}

--- a/tests/unit/test_napari/test_registration_panel.py
+++ b/tests/unit/test_napari/test_registration_panel.py
@@ -213,28 +213,32 @@ class TestOperationMode:
         assert registration_panel._reference_time_spin.isEnabled()
         assert not registration_panel._n_jobs_row.isHidden()
 
-    def test_volumewise_fixed_toggle_swaps_active_target(self, registration_panel):
-        assert registration_panel._volumewise_use_fixed_check.isHidden()
+    def test_volumewise_target_radios_swap_active_input(self, registration_panel):
+        assert registration_panel._fixed_layer_radio.isHidden()
 
         registration_panel._time_series_radio.setChecked(True)
 
-        assert not registration_panel._volumewise_use_fixed_check.isHidden()
+        assert not registration_panel._fixed_layer_radio.isHidden()
+        assert registration_panel._reference_time_radio.isChecked()
         assert not registration_panel._fixed_combo.isEnabled()
         assert not registration_panel._fixed_scale_combo.isEnabled()
         assert registration_panel._reference_time_spin.isEnabled()
 
-        registration_panel._volumewise_use_fixed_check.setChecked(True)
+        registration_panel._fixed_layer_radio.setChecked(True)
 
+        # Selecting one target clears the other, and only its input stays active.
+        assert not registration_panel._reference_time_radio.isChecked()
         assert registration_panel._fixed_combo.isEnabled()
         assert registration_panel._fixed_scale_combo.isEnabled()
         assert not registration_panel._reference_time_spin.isEnabled()
-        assert not registration_panel._reference_time_label.isEnabled()
-        # Both targets stay on screen; only one of them is active.
+        # Both radios stay on screen and usable, so either target can be picked.
+        assert registration_panel._reference_time_radio.isEnabled()
         assert not registration_panel._fixed_combo.isHidden()
         assert not registration_panel._reference_time_spin.isHidden()
 
-        registration_panel._volumewise_use_fixed_check.setChecked(False)
+        registration_panel._reference_time_radio.setChecked(True)
 
+        assert not registration_panel._fixed_layer_radio.isChecked()
         assert not registration_panel._fixed_combo.isEnabled()
         assert not registration_panel._fixed_scale_combo.isEnabled()
         assert registration_panel._reference_time_spin.isEnabled()
@@ -244,7 +248,7 @@ class TestOperationMode:
     ):
         """Within-scan rows read moving layer, reference time, then fixed layer."""
         registration_panel._time_series_radio.setChecked(True)
-        operation_group = registration_panel._reference_time_label.parentWidget()
+        operation_group = registration_panel._reference_time_radio.parentWidget()
         operation_layout = operation_group.layout()
         assert isinstance(operation_layout, QFormLayout)
 
@@ -254,45 +258,57 @@ class TestOperationMode:
 
         assert (
             _row(registration_panel._moving_label)
-            < _row(registration_panel._reference_time_label)
+            < _row(registration_panel._reference_time_radio)
             < _row(registration_panel._fixed_label_row)
         )
-        # The fixed toggle labels its own combo box instead of taking a row.
+        # Each target radio labels its own input instead of taking a row.
+        assert _row(registration_panel._reference_time_radio) == _row(
+            registration_panel._reference_time_spin
+        )
         assert _row(registration_panel._fixed_label_row) == _row(
             registration_panel._fixed_combo
         )
         assert (
-            registration_panel._volumewise_use_fixed_check.parentWidget()
+            registration_panel._fixed_layer_radio.parentWidget()
             is registration_panel._fixed_label_row
         )
 
-    def test_switching_to_within_scan_does_not_widen_panel(self, registration_panel):
-        # Regression test: a label wider than the between-scan ones grows
-        # QFormLayout's label column, which wraps the Mode row's radio pair.
+    def test_mode_radios_stay_beside_their_label_in_both_modes(
+        self, registration_panel
+    ):
+        """The Mode row never wraps, whatever the active mode's labels are.
+
+        Regression test: the mode radios used to sit in the form's shared label
+        column, so a wider within-scan label pushed them onto their own line.
+        """
         registration_panel.show()
+        registration_panel.resize(registration_panel.minimumSizeHint().width(), 900)
         QApplication.processEvents()
-        between_scan_width = registration_panel.sizeHint().width()
+        mode_label = (
+            registration_panel._single_volume_radio.parentWidget().layout().itemAt(0)
+        ).widget()
+        assert mode_label.text() == "Mode"
+
+        assert mode_label.y() == registration_panel._single_volume_radio.y()
 
         registration_panel._time_series_radio.setChecked(True)
         QApplication.processEvents()
 
-        # A long within-scan label widens QFormLayout's shared label column: at
-        # ~130px extra it pushed the Mode row's radio buttons onto their own line.
-        assert registration_panel.sizeHint().width() <= between_scan_width + 16
+        assert mode_label.y() == registration_panel._single_volume_radio.y()
 
     def test_volumewise_fixed_choice_survives_mode_switch(self, registration_panel):
         registration_panel._time_series_radio.setChecked(True)
-        registration_panel._volumewise_use_fixed_check.setChecked(True)
+        registration_panel._fixed_layer_radio.setChecked(True)
 
         registration_panel._single_volume_radio.setChecked(True)
 
-        assert registration_panel._volumewise_use_fixed_check.isHidden()
+        assert registration_panel._fixed_layer_radio.isHidden()
         assert registration_panel._reference_time_spin.isHidden()
         assert registration_panel._fixed_combo.isEnabled()
 
         registration_panel._time_series_radio.setChecked(True)
 
-        assert registration_panel._volumewise_use_fixed_check.isChecked()
+        assert registration_panel._fixed_layer_radio.isChecked()
         assert registration_panel._fixed_combo.isEnabled()
         assert not registration_panel._reference_time_spin.isEnabled()
 
@@ -916,7 +932,7 @@ class TestRunRegistration:
         registration_panel._refresh_layers()
         registration_panel._time_series_radio.setChecked(True)
         registration_panel._moving_combo.setCurrentText("moving")
-        registration_panel._volumewise_use_fixed_check.setChecked(True)
+        registration_panel._fixed_layer_radio.setChecked(True)
         registration_panel._fixed_combo.setCurrentText("target")
         registration_panel._scale_combo.setCurrentText("square root")
         registration_panel._fixed_scale_combo.setCurrentText("none")
@@ -1004,7 +1020,35 @@ class TestValidation:
             in registration_panel._layer_validation.text()
         )
 
-    def test_within_scan_fixed_toggle_requires_fixed_layer(
+    def test_within_scan_fixed_target_requires_fixed_layer(
+        self, viewer, registration_panel, sample_voxeldata_3dt, sample_voxeldata_3d
+    ):
+        viewer.add_image(
+            sample_voxeldata_3dt.values,
+            name="moving",
+            metadata={"xarray": sample_voxeldata_3dt},
+        )
+        viewer.add_image(
+            sample_voxeldata_3d.values,
+            name="target",
+            metadata={"xarray": sample_voxeldata_3d},
+        )
+        registration_panel._refresh_layers()
+        registration_panel._time_series_radio.setChecked(True)
+        registration_panel._moving_combo.setCurrentText("moving")
+        registration_panel._fixed_layer_radio.setChecked(True)
+        registration_panel._fixed_combo.setCurrentIndex(-1)
+
+        assert not registration_panel._validate_registration_selection()
+        assert not registration_panel._run_btn.isEnabled()
+        assert "Select a fixed layer" in registration_panel._layer_validation.text()
+
+        registration_panel._fixed_combo.setCurrentText("target")
+
+        assert registration_panel._validate_registration_selection()
+        assert registration_panel._run_btn.isEnabled()
+
+    def test_within_scan_rejects_fixed_layer_with_time_dimension(
         self, viewer, registration_panel, sample_voxeldata_3dt
     ):
         viewer.add_image(
@@ -1012,20 +1056,29 @@ class TestValidation:
             name="moving",
             metadata={"xarray": sample_voxeldata_3dt},
         )
+        viewer.add_image(
+            sample_voxeldata_3dt.values,
+            name="other series",
+            metadata={"xarray": sample_voxeldata_3dt},
+        )
         registration_panel._refresh_layers()
         registration_panel._time_series_radio.setChecked(True)
         registration_panel._moving_combo.setCurrentText("moving")
-        registration_panel._volumewise_use_fixed_check.setChecked(True)
-        registration_panel._fixed_combo.setCurrentIndex(-1)
+        registration_panel._fixed_layer_radio.setChecked(True)
+        registration_panel._fixed_combo.setCurrentText("other series")
 
         assert not registration_panel._validate_registration_selection()
         assert not registration_panel._run_btn.isEnabled()
-        assert "Select a fixed layer" in registration_panel._layer_validation.text()
+        assert (
+            "without a time dimension" in registration_panel._layer_validation.text()
+        )
+        assert "border" in registration_panel._fixed_combo.styleSheet()
 
-        registration_panel._fixed_combo.setCurrentText("moving")
+        # The reference-time target has no such restriction.
+        registration_panel._reference_time_radio.setChecked(True)
 
         assert registration_panel._validate_registration_selection()
-        assert registration_panel._run_btn.isEnabled()
+        assert registration_panel._fixed_combo.styleSheet() == ""
 
     def test_between_scans_accepts_time_series_by_averaging(
         self, viewer, registration_panel, sample_voxeldata_3dt

--- a/tests/unit/test_signal/test_detrend.py
+++ b/tests/unit/test_signal/test_detrend.py
@@ -231,7 +231,7 @@ def test_detrend_polynomial_order4(rng):
     # Compare against naive reference implementation.
     naive_result = _naive_polynomial_detrend(signals.values, order=4, axis=0)
     # Higher-order polynomials have slightly worse numerical precision.
-    assert_allclose(result.values, naive_result, rtol=1e-7)
+    assert_allclose(result.values, naive_result, rtol=1e-5)
 
 
 def test_detrend_no_time_dimension(rng):


### PR DESCRIPTION
## Summary

The registration panel's within-scan mode gains a **Use a fixed layer** toggle: instead of a reference volume index, every frame can be registered to a spatial-only layer on the same grid (for example the mean of a few low-motion frames), with its own **Fixed intensity scaling**. This reuses the between-scan mode's existing fixed-layer picker and fixed-scale combo, wiring them to `register_volumewise`'s new `fixed`/`fixed_intensity_scaling` parameters.

The result layer's metadata records `fixed_layer_name`, and `reference_time` is `None` when a fixed layer was used. The moving scaling label now always reads "Moving intensity scaling" in both modes.

Stacked on #436 (the `register_volumewise` API change); this PR's own diff is the napari UI only.

Part of #376.

## Test plan
- [x] `uv run pytest tests/unit/test_napari/test_registration_panel.py`
- [x] `just pre-commit`