### PR TITLE
docs(io): note gzip NIfTI lazy-read costs

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,12 @@ Current development version for the next ConfUSIus release.
   large recordings or broad noise masks
   ([#434](https://github.com/confusius-tools/confusius/pull/434)).
 
+### :books: Documentation
+
+- Clarified when to use `.compute()` or `.persist()` before repeated partial reads from
+  gzip-compressed NIfTI files
+  ([#441](https://github.com/confusius-tools/confusius/pull/441)).
+
 ### :frame_photo: Napari plugin
 
 - Scrolling the sidebar with the mouse wheel no longer gets hijacked by whichever

--- a/docs/user-guide/io.md
+++ b/docs/user-guide/io.md
@@ -127,6 +127,17 @@ an operation requires it.
     da = cf.load("sub-01_task-awake_pwd.nii.gz").compute()
     ```
 
+    For gzip-compressed NIfTI files (`.nii.gz`), repeated lazy partial reads such as
+    per-frame loops may decompress the file again for each independent Dask computation.
+    Use `.compute()` for ordinary eager processing, or `.persist()` before many
+    downstream Dask operations that should stay chunked and parallel:
+
+    ```python
+    da = cf.load("sub-01_task-awake_pwd.nii.gz").persist()
+    ```
+
+    For larger repeated random-access workloads, prefer Zarr or uncompressed `.nii`.
+
 ### Loading Zarr Files
 
 Xarray treats Zarr stores as multi-variable datasets. ConfUSIus'

--- a/src/confusius/io/loadsave.py
+++ b/src/confusius/io/loadsave.py
@@ -75,6 +75,14 @@ def load(path: str | Path, variable: str | None = None, **kwargs: Any) -> xr.Dat
     ValueError
         If the file extension is not supported, or the Zarr store at `path` wasn't
         written by [`save`][confusius.io.save] (no `attrs["voxel_to_world"]`).
+
+    Notes
+    -----
+    Gzip-compressed NIfTI files (`.nii.gz`) do not support true random access. Repeated
+    lazy partial reads, such as per-frame loops, may decompress the file again for each
+    independent Dask computation. If the file fits in memory, use `.compute()` for eager
+    processing, or `.persist()` before many downstream Dask operations. For larger
+    repeated random-access workloads, prefer Zarr or uncompressed `.nii`.
     """
     path = check_path(path)
     name = path.name

--- a/src/confusius/io/nifti.py
+++ b/src/confusius/io/nifti.py
@@ -1219,6 +1219,13 @@ def load_nifti(
     `i` and derived world coordinates `z`, `y`, `x`. `coordinate_affine` controls which
     NIfTI header affine defines that voxel-to-world mapping.
 
+    Gzip-compressed `.nii.gz` files do not support true random access. Repeated lazy
+    partial reads, such as per-frame loops, may decompress the file again for each
+    independent Dask computation. If the file fits in memory, use `.compute()` for
+    ordinary eager processing, or `.persist()` before many downstream Dask operations
+    that should stay chunked and parallel. For larger repeated random-access workloads,
+    prefer Zarr or uncompressed `.nii`.
+
     World-to-world affines are stored in `da.attrs["affines"]`, a dict keyed by
     affine name. Each value is a 4×4 affine in ConfUSIus `(z, y, x)` convention that
     maps **world coordinates** (as stored in `da.coords`) to world-space


### PR DESCRIPTION
Documents the `.nii.gz` lazy-read caveat and when to use `.compute()` vs `.persist()`.

Closes #439.