### PR TITLE
fix(plotting): honor a lone `vmin` or `vmax` under `auto_range`

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -23,7 +23,7 @@ Current development version for the next ConfUSIus release.
   [`plot_matrix`][confusius.plotting.plot_matrix] now honor a `vmin` or `vmax` passed
   on its own under `auto_range=True`: a lone bound sets the symmetric range to
   `[-|bound|, |bound|]`
-  ([#443](https://github.com/confusius-tools/confusius/pull/443)).
+  ([#445](https://github.com/confusius-tools/confusius/pull/445)).
 
 ### :books: Documentation
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,14 @@ Current development version for the next ConfUSIus release.
   large recordings or broad noise masks
   ([#434](https://github.com/confusius-tools/confusius/pull/434)).
 
+### :bug: Fixes
+
+- [`plot_stat_map`][confusius.plotting.plot_stat_map] and
+  [`plot_matrix`][confusius.plotting.plot_matrix] now honor a `vmin` or `vmax` passed
+  on its own under `auto_range=True`: a lone bound sets the symmetric range to
+  `[-|bound|, |bound|]`
+  ([#443](https://github.com/confusius-tools/confusius/pull/443)).
+
 ### :books: Documentation
 
 - Clarified when to use `.compute()` or `.persist()` before repeated partial reads from

--- a/docs/user-guide/visualization.md
+++ b/docs/user-guide/visualization.md
@@ -438,7 +438,8 @@ By default, `vmin` and `vmax` are taken from the full `stat_map`, and `auto_rang
 picks a suitable range + default colormap automatically:
 
 - Both positive and negative values: diverging, symmetric `[-m, m]` range
-  (`m = max(|vmin|, |vmax|)`), with `cmap="coolwarm"` by default.
+  (`m = max(|vmin|, |vmax|)` over the bounds you pass, or the largest magnitude in
+  `stat_map` when you pass neither), with `cmap="coolwarm"` by default.
 - Only non-negative values (for example R² or F-statistics): sequential `[0, vmax]`
   range, with `cmap="viridis"` by default.
 - Only non-positive values: sequential `[vmin, 0]` range, with `cmap="viridis_r"`

--- a/src/confusius/plotting/_utils.py
+++ b/src/confusius/plotting/_utils.py
@@ -2,9 +2,10 @@
 
 import warnings
 from collections.abc import Hashable, Sequence
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
+import numpy.typing as npt
 import xarray as xr
 
 from confusius._dims import VOXEL_DIMS, WORLD_DIMS
@@ -13,6 +14,7 @@ from confusius._utils.stack import find_stack_level
 
 if TYPE_CHECKING:
     from matplotlib.colorbar import Colorbar
+    from matplotlib.colors import Colormap
 
 
 def _relative_luminance(color: str) -> float:
@@ -146,6 +148,101 @@ def _style_colorbar(
     cbar.ax.yaxis.label.set_color(text_color)
     if label_fontsize is not None:
         cbar.ax.yaxis.label.set_fontsize(label_fontsize)
+
+
+_DIVERGING_CMAP = "coolwarm"
+"""Default colormap for data spanning both signs (see `_resolve_colormap_style`)."""
+
+_SEQUENTIAL_CMAP = "viridis"
+"""Default colormap for non-negative data (see `_resolve_colormap_style`)."""
+
+_SEQUENTIAL_CMAP_NEGATIVE = "viridis_r"
+"""Default colormap for non-positive data (see `_resolve_colormap_style`).
+
+Reversed relative to `_SEQUENTIAL_CMAP` so that, in both the non-negative and
+non-positive cases, values near zero map to the same end of the colormap (dark
+purple) and the most extreme magnitude maps to the other end (yellow).
+"""
+
+
+def _resolve_colormap_style(
+    data: "npt.NDArray[Any] | xr.DataArray",
+    vmin: float | None,
+    vmax: float | None,
+    cmap: "str | Colormap | None",
+    auto_range: bool,
+) -> tuple[float, float, "str | Colormap"]:
+    """Resolve `(vmin, vmax, cmap)` from the sign of `data` and the bounds given.
+
+    Shared by `plot_stat_map` and `plot_matrix` so both expose the same
+    `auto_range` semantics.
+
+    When `auto_range` is `True`, the sign of `data` determines the layout:
+
+    - Both positive and negative values: diverging, symmetric `[-m, m]` range
+      where `m = max(|vmin|, |vmax|)` over the bounds actually provided, falling
+      back to the largest magnitude in `data` when neither is given, with `cmap`
+      defaulting to `_DIVERGING_CMAP`.
+    - Only non-negative values: sequential `[0, vmax]` range, with `cmap`
+      defaulting to `_SEQUENTIAL_CMAP`.
+    - Only non-positive values: sequential `[vmin, 0]` range, with `cmap`
+      defaulting to `_SEQUENTIAL_CMAP_NEGATIVE`.
+
+    When `auto_range` is `False`, `vmin`/`vmax` are used directly with no
+    zero-anchoring, and `cmap` defaults to `_DIVERGING_CMAP` regardless of
+    `data`'s sign. In both cases, an explicitly provided `cmap` is always used
+    as-is.
+
+    Parameters
+    ----------
+    data : numpy.ndarray or xarray.DataArray
+        Values to be colormapped. Non-finite entries are ignored.
+    vmin : float, optional
+        Lower bound of the colormap. If not provided, falls back to the smallest
+        finite value in `data`, except in the diverging branch described above.
+    vmax : float, optional
+        Upper bound of the colormap. If not provided, falls back to the largest
+        finite value in `data`, except in the diverging branch described above.
+    cmap : str or matplotlib.colors.Colormap, optional
+        Colormap to use. If not provided, one is picked from the sign of `data`.
+    auto_range : bool
+        Whether to anchor the range on zero based on the sign of `data`.
+
+    Returns
+    -------
+    vmin : float
+        Resolved lower bound of the colormap.
+    vmax : float
+        Resolved upper bound of the colormap.
+    cmap : str or matplotlib.colors.Colormap
+        Resolved colormap.
+    """
+    values = np.asarray(data).ravel().astype(float)
+    values = values[np.isfinite(values)]
+    data_min = float(values.min()) if values.size > 0 else 0.0
+    data_max = float(values.max()) if values.size > 0 else 1.0
+
+    resolved_vmin = vmin if vmin is not None else data_min
+    resolved_vmax = vmax if vmax is not None else data_max
+
+    if not auto_range:
+        return (
+            resolved_vmin,
+            resolved_vmax,
+            cmap if cmap is not None else _DIVERGING_CMAP,
+        )
+
+    if data_min < 0 < data_max:
+        # A bound given on its own caps the symmetric range by itself: falling back
+        # to the data's own min/max for the missing one would drop it silently.
+        explicit = [abs(bound) for bound in (vmin, vmax) if bound is not None]
+        abs_max = max(explicit) if explicit else max(abs(data_min), abs(data_max))
+        return -abs_max, abs_max, cmap if cmap is not None else _DIVERGING_CMAP
+
+    if data_max > 0:
+        return 0.0, resolved_vmax, cmap if cmap is not None else _SEQUENTIAL_CMAP
+
+    return resolved_vmin, 0.0, cmap if cmap is not None else _SEQUENTIAL_CMAP_NEGATIVE
 
 
 def coerce_complex_to_magnitude(data: xr.DataArray, caller: str) -> xr.DataArray:

--- a/src/confusius/plotting/image.py
+++ b/src/confusius/plotting/image.py
@@ -546,8 +546,9 @@ def _resolve_stat_map_style(
     layout:
 
     - Both positive and negative values: diverging, symmetric `[-m, m]` range
-      where `m = max(|vmin|, |vmax|)` (using the resolved bounds above), with
-      `cmap` defaulting to `_STAT_MAP_DIVERGING_CMAP`.
+      where `m = max(|vmin|, |vmax|)` over the bounds actually provided, falling
+      back to the largest magnitude in `data` when neither is given, with `cmap`
+      defaulting to `_STAT_MAP_DIVERGING_CMAP`.
     - Only non-negative values: sequential `[0, vmax]` range, with `cmap`
       defaulting to `_STAT_MAP_SEQUENTIAL_CMAP`.
     - Only non-positive values: sequential `[vmin, 0]` range, with `cmap`
@@ -574,7 +575,10 @@ def _resolve_stat_map_style(
         )
 
     if data_min < 0 < data_max:
-        abs_max = max(abs(resolved_vmin), abs(resolved_vmax))
+        # A bound given on its own caps the symmetric range by itself: falling back
+        # to the data's own min/max for the missing one would drop it silently.
+        explicit = [abs(bound) for bound in (vmin, vmax) if bound is not None]
+        abs_max = max(explicit) if explicit else max(abs(data_min), abs(data_max))
         return -abs_max, abs_max, cmap if cmap is not None else _STAT_MAP_DIVERGING_CMAP
 
     if data_max > 0:
@@ -2006,22 +2010,27 @@ class VolumePlotter:
         vmin : float, optional
             Lower bound of the colormap. If not provided, defaults to the minimum
             value of `stat_map`, computed over the full array rather than just the
-            displayed slices. Ignored when `norm` is provided, or when
-            `auto_range=True` and `stat_map` has only non-negative values.
+            displayed slices. Ignored when `norm` is provided, when
+            `auto_range=True` and `stat_map` has only non-negative values, or when
+            `auto_range=True`, `stat_map` spans both signs and `vmax` is given on
+            its own (see `auto_range`).
         vmax : float, optional
             Upper bound of the colormap. If not provided, defaults to the maximum
             value of `stat_map`, computed over the full array rather than just the
-            displayed slices. Ignored when `norm` is provided, or when
-            `auto_range=True` and `stat_map` has only non-positive values.
+            displayed slices. Ignored when `norm` is provided, when
+            `auto_range=True` and `stat_map` has only non-positive values, or when
+            `auto_range=True`, `stat_map` spans both signs and `vmin` is given on
+            its own (see `auto_range`).
         auto_range : bool, default: True
             Whether to pick the colormap range and default colormap automatically
             based on the sign of `stat_map`:
 
             - Both positive and negative values: diverging, symmetric `[-m, m]`
-              range where `m = max(|vmin|, |vmax|)` (using the resolved bounds
-              above), with `cmap` defaulting to `"coolwarm"` — the right choice for
-              diverging statistics where the sign is meaningful (e.g. t-statistics,
-              correlation coefficients, PCA/ICA component maps).
+              range where `m = max(|vmin|, |vmax|)` over the bounds actually
+              provided, falling back to the largest magnitude in `stat_map` when
+              neither is given, with `cmap` defaulting to `"coolwarm"` — the right
+              choice for diverging statistics where the sign is meaningful (e.g.
+              t-statistics, correlation coefficients, PCA/ICA component maps).
             - Only non-negative values: sequential `[0, vmax]` range, with `cmap`
               defaulting to `"viridis"` — the right choice for non-diverging
               statistics where only magnitude matters (e.g. R², F-statistics).
@@ -3497,22 +3506,27 @@ def plot_stat_map(
     vmin : float, optional
         Lower bound of the colormap. If not provided, defaults to the minimum value
         of `stat_map`, computed over the full array rather than just the displayed
-        slices. Ignored when `norm` is provided, or when `auto_range=True` and
-        `stat_map` has only non-negative values.
+        slices. Ignored when `norm` is provided, when `auto_range=True` and
+        `stat_map` has only non-negative values, or when `auto_range=True`,
+        `stat_map` spans both signs and `vmax` is given on its own (see
+        `auto_range`).
     vmax : float, optional
         Upper bound of the colormap. If not provided, defaults to the maximum value
         of `stat_map`, computed over the full array rather than just the displayed
-        slices. Ignored when `norm` is provided, or when `auto_range=True` and
-        `stat_map` has only non-positive values.
+        slices. Ignored when `norm` is provided, when `auto_range=True` and
+        `stat_map` has only non-positive values, or when `auto_range=True`,
+        `stat_map` spans both signs and `vmin` is given on its own (see
+        `auto_range`).
     auto_range : bool, default: True
         Whether to pick the colormap range and default colormap automatically based
         on the sign of `stat_map`:
 
         - Both positive and negative values: diverging, symmetric `[-m, m]` range
-          where `m = max(|vmin|, |vmax|)` (using the resolved bounds above),
-          with `cmap` defaulting to `"coolwarm"` — the right choice for diverging
-          statistics where the sign is meaningful (e.g. t-statistics, correlation
-          coefficients, PCA/ICA component maps).
+          where `m = max(|vmin|, |vmax|)` over the bounds actually provided,
+          falling back to the largest magnitude in `stat_map` when neither is
+          given, with `cmap` defaulting to `"coolwarm"` — the right choice for
+          diverging statistics where the sign is meaningful (e.g. t-statistics,
+          correlation coefficients, PCA/ICA component maps).
         - Only non-negative values: sequential `[0, vmax]` range, with `cmap`
           defaulting to `"viridis"` — the right choice for non-diverging
           statistics where only magnitude matters (e.g. R², F-statistics).

--- a/src/confusius/plotting/image.py
+++ b/src/confusius/plotting/image.py
@@ -35,6 +35,7 @@ from confusius.plotting._hover import (
 from confusius.plotting._utils import (
     _auto_fg_color,
     _get_distinct_colors,
+    _resolve_colormap_style,
     _resolve_font_sizes,
     _style_colorbar,
     coerce_complex_to_magnitude,
@@ -513,86 +514,6 @@ def _resolve_norm(
     assert resolved_norm is not None
 
     return resolved_norm
-
-
-_STAT_MAP_DIVERGING_CMAP = "coolwarm"
-"""Default colormap for diverging statistical maps (see `plot_stat_map`)."""
-
-_STAT_MAP_SEQUENTIAL_CMAP = "viridis"
-"""Default colormap for non-negative statistical maps (see `plot_stat_map`)."""
-
-_STAT_MAP_SEQUENTIAL_CMAP_NEGATIVE = "viridis_r"
-"""Default colormap for non-positive statistical maps (see `plot_stat_map`).
-
-Reversed relative to `_STAT_MAP_SEQUENTIAL_CMAP` so that, in both the
-non-negative and non-positive cases, values near zero map to the same end of
-the colormap (dark purple) and the most extreme magnitude maps to the other
-end (yellow).
-"""
-
-
-def _resolve_stat_map_style(
-    data: xr.DataArray,
-    vmin: float | None,
-    vmax: float | None,
-    cmap: "str | Colormap | None",
-    auto_range: bool,
-) -> tuple[float, float, "str | Colormap"]:
-    """Resolve `(vmin, vmax, cmap)` for a statistical map.
-
-    `vmin`/`vmax` fall back to the actual min/max of `data` when not provided.
-
-    When `auto_range` is `True` (default), the sign of `data` determines the
-    layout:
-
-    - Both positive and negative values: diverging, symmetric `[-m, m]` range
-      where `m = max(|vmin|, |vmax|)` over the bounds actually provided, falling
-      back to the largest magnitude in `data` when neither is given, with `cmap`
-      defaulting to `_STAT_MAP_DIVERGING_CMAP`.
-    - Only non-negative values: sequential `[0, vmax]` range, with `cmap`
-      defaulting to `_STAT_MAP_SEQUENTIAL_CMAP`.
-    - Only non-positive values: sequential `[vmin, 0]` range, with `cmap`
-      defaulting to `_STAT_MAP_SEQUENTIAL_CMAP_NEGATIVE`.
-
-    When `auto_range` is `False`, the resolved `vmin`/`vmax` are used directly with
-    no zero-anchoring, and `cmap` defaults to `_STAT_MAP_DIVERGING_CMAP` regardless
-    of `data`'s sign. In both cases, an explicitly provided `cmap` is always used
-    as-is.
-    """
-    values = data.values.ravel().astype(float)
-    values = values[np.isfinite(values)]
-    data_min = float(values.min()) if len(values) > 0 else 0.0
-    data_max = float(values.max()) if len(values) > 0 else 1.0
-
-    resolved_vmin = vmin if vmin is not None else data_min
-    resolved_vmax = vmax if vmax is not None else data_max
-
-    if not auto_range:
-        return (
-            resolved_vmin,
-            resolved_vmax,
-            cmap if cmap is not None else _STAT_MAP_DIVERGING_CMAP,
-        )
-
-    if data_min < 0 < data_max:
-        # A bound given on its own caps the symmetric range by itself: falling back
-        # to the data's own min/max for the missing one would drop it silently.
-        explicit = [abs(bound) for bound in (vmin, vmax) if bound is not None]
-        abs_max = max(explicit) if explicit else max(abs(data_min), abs(data_max))
-        return -abs_max, abs_max, cmap if cmap is not None else _STAT_MAP_DIVERGING_CMAP
-
-    if data_max > 0:
-        return (
-            0.0,
-            resolved_vmax,
-            cmap if cmap is not None else _STAT_MAP_SEQUENTIAL_CMAP,
-        )
-
-    return (
-        resolved_vmin,
-        0.0,
-        cmap if cmap is not None else _STAT_MAP_SEQUENTIAL_CMAP_NEGATIVE,
-    )
 
 
 def _threshold_slices(
@@ -2118,7 +2039,7 @@ class VolumePlotter:
         >>> plotter = plotter.add_stat_map(t_map, threshold=3.0)
         """
         stat_map = stat_map.compute()
-        resolved_vmin, resolved_vmax, resolved_cmap = _resolve_stat_map_style(
+        resolved_vmin, resolved_vmax, resolved_cmap = _resolve_colormap_style(
             stat_map, vmin, vmax, cmap, auto_range
         )
         return self.add_volume(

--- a/src/confusius/plotting/matrix.py
+++ b/src/confusius/plotting/matrix.py
@@ -54,7 +54,8 @@ def _resolve_matrix_style(
     When `auto_range` is `True` (default), the sign of `values` determines the layout:
 
     - Both positive and negative values: diverging, symmetric `[-m, m]` range where
-      `m = max(|vmin|, |vmax|)` (using the resolved bounds above), with `cmap`
+      `m = max(|vmin|, |vmax|)` over the bounds actually provided, falling back to
+      the largest magnitude in `values` when neither is given, with `cmap`
       defaulting to `_MATRIX_DIVERGING_CMAP`.
     - Only non-negative values: sequential `[0, vmax]` range, with `cmap` defaulting
       to `_MATRIX_SEQUENTIAL_CMAP`.
@@ -80,7 +81,10 @@ def _resolve_matrix_style(
         )
 
     if data_min < 0 < data_max:
-        abs_max = max(abs(resolved_vmin), abs(resolved_vmax))
+        # A bound given on its own caps the symmetric range by itself: falling back
+        # to the data's own min/max for the missing one would drop it silently.
+        explicit = [abs(bound) for bound in (vmin, vmax) if bound is not None]
+        abs_max = max(explicit) if explicit else max(abs(data_min), abs(data_max))
         return -abs_max, abs_max, cmap if cmap is not None else _MATRIX_DIVERGING_CMAP
 
     if data_max > 0:
@@ -487,19 +491,22 @@ def plot_matrix(
         always used as-is regardless of `auto_range`.
     vmin : float, optional
         Lower bound of the colormap. If not provided, defaults to the minimum value
-        in `matrix`. Ignored when `auto_range` resolves to a range anchored at zero
-        (see below).
+        in `matrix`. Ignored when `auto_range=True` and `matrix` has only
+        non-negative values, or when `auto_range=True`, `matrix` spans both signs
+        and `vmax` is given on its own (see below).
     vmax : float, optional
         Upper bound of the colormap. If not provided, defaults to the maximum value
         in `matrix`. Ignored when `auto_range=True` and `matrix` has only
-        non-positive values.
+        non-positive values, or when `auto_range=True`, `matrix` spans both signs
+        and `vmin` is given on its own (see below).
     auto_range : bool, default: True
         Whether to pick the colormap range and default colormap automatically based
         on the sign of `matrix`:
 
         - Both positive and negative values: diverging, symmetric `[-m, m]` range
-          where `m = max(|vmin|, |vmax|)` (using the resolved bounds above), with
-          `cmap` defaulting to `"coolwarm"`.
+          where `m = max(|vmin|, |vmax|)` over the bounds actually provided,
+          falling back to the largest magnitude in `matrix` when neither is given,
+          with `cmap` defaulting to `"coolwarm"`.
         - Only non-negative values: sequential `[0, vmax]` range, with `cmap`
           defaulting to `"viridis"`.
         - Only non-positive values: sequential `[vmin, 0]` range, with `cmap`

--- a/src/confusius/plotting/matrix.py
+++ b/src/confusius/plotting/matrix.py
@@ -17,6 +17,7 @@ from confusius.glm._utils import resolve_contrast_vector
 from confusius.plotting._utils import (
     _auto_fg_color,
     _get_distinct_colors,
+    _resolve_colormap_style,
     _resolve_font_sizes,
     _style_colorbar,
 )
@@ -25,76 +26,6 @@ if TYPE_CHECKING:
     from matplotlib.axes import Axes
     from matplotlib.colors import Colormap
     from matplotlib.figure import Figure, SubFigure
-
-_MATRIX_DIVERGING_CMAP = "coolwarm"
-"""Default colormap for diverging matrices (see `plot_matrix`'s `auto_range`)."""
-
-_MATRIX_SEQUENTIAL_CMAP = "viridis"
-"""Default colormap for non-negative matrices (see `plot_matrix`'s `auto_range`)."""
-
-_MATRIX_SEQUENTIAL_CMAP_NEGATIVE = "viridis_r"
-"""Default colormap for non-positive matrices (see `plot_matrix`'s `auto_range`).
-
-Reversed relative to `_MATRIX_SEQUENTIAL_CMAP` so that, in both the non-negative and
-non-positive cases, values near zero map to the same end of the colormap.
-"""
-
-
-def _resolve_matrix_style(
-    values: npt.NDArray[Any],
-    vmin: float | None,
-    vmax: float | None,
-    cmap: "str | Colormap | None",
-    auto_range: bool,
-) -> tuple[float, float, "str | Colormap"]:
-    """Resolve `(vmin, vmax, cmap)` for a matrix, mirroring `plot_stat_map`'s auto_range.
-
-    `vmin`/`vmax` fall back to the actual min/max of `values` when not provided.
-
-    When `auto_range` is `True` (default), the sign of `values` determines the layout:
-
-    - Both positive and negative values: diverging, symmetric `[-m, m]` range where
-      `m = max(|vmin|, |vmax|)` over the bounds actually provided, falling back to
-      the largest magnitude in `values` when neither is given, with `cmap`
-      defaulting to `_MATRIX_DIVERGING_CMAP`.
-    - Only non-negative values: sequential `[0, vmax]` range, with `cmap` defaulting
-      to `_MATRIX_SEQUENTIAL_CMAP`.
-    - Only non-positive values: sequential `[vmin, 0]` range, with `cmap` defaulting
-      to `_MATRIX_SEQUENTIAL_CMAP_NEGATIVE`.
-
-    When `auto_range` is `False`, the resolved `vmin`/`vmax` are used directly with no
-    zero-anchoring, and `cmap` defaults to `_MATRIX_DIVERGING_CMAP` regardless of
-    `values`'s sign. In both cases, an explicitly provided `cmap` is always used as-is.
-    """
-    finite = values[np.isfinite(values)]
-    data_min = float(finite.min()) if finite.size > 0 else 0.0
-    data_max = float(finite.max()) if finite.size > 0 else 1.0
-
-    resolved_vmin = vmin if vmin is not None else data_min
-    resolved_vmax = vmax if vmax is not None else data_max
-
-    if not auto_range:
-        return (
-            resolved_vmin,
-            resolved_vmax,
-            cmap if cmap is not None else _MATRIX_DIVERGING_CMAP,
-        )
-
-    if data_min < 0 < data_max:
-        # A bound given on its own caps the symmetric range by itself: falling back
-        # to the data's own min/max for the missing one would drop it silently.
-        explicit = [abs(bound) for bound in (vmin, vmax) if bound is not None]
-        abs_max = max(explicit) if explicit else max(abs(data_min), abs(data_max))
-        return -abs_max, abs_max, cmap if cmap is not None else _MATRIX_DIVERGING_CMAP
-
-    if data_max > 0:
-        return 0.0, resolved_vmax, cmap if cmap is not None else _MATRIX_SEQUENTIAL_CMAP
-
-    return (
-        resolved_vmin,
-        0.0,
-        cmap if cmap is not None else _MATRIX_SEQUENTIAL_CMAP_NEGATIVE,
-    )
 
 
 def _validate_matrix(matrix: "npt.NDArray[Any] | xr.DataArray") -> npt.NDArray[Any]:
@@ -579,7 +510,7 @@ def plot_matrix(
         )
 
     masked = _mask_triangle(values, triangle)
-    vmin, vmax, cmap = _resolve_matrix_style(values, vmin, vmax, cmap, auto_range)
+    vmin, vmax, cmap = _resolve_colormap_style(values, vmin, vmax, cmap, auto_range)
 
     text_color = fg_color if fg_color is not None else _auto_fg_color(bg_color)
     title_fontsize, label_fontsize, tick_fontsize = _resolve_font_sizes(fontsize)

--- a/src/confusius/xarray/plotting.py
+++ b/src/confusius/xarray/plotting.py
@@ -945,22 +945,28 @@ class FUSIPlotAccessor:
         vmin : float, optional
             Lower bound of the colormap. If not provided, defaults to the minimum
             value of this DataArray, computed over the full array rather than just
-            the displayed slices. Ignored when `norm` is provided, or when
-            `auto_range` resolves to a range anchored at zero (see below).
+            the displayed slices. Ignored when `norm` is provided, when
+            `auto_range=True` and this DataArray has only non-negative values, or
+            when `auto_range=True`, this DataArray spans both signs and `vmax` is
+            given on its own (see `auto_range`).
         vmax : float, optional
             Upper bound of the colormap. If not provided, defaults to the maximum
             value of this DataArray, computed over the full array rather than just
-            the displayed slices. Ignored when `norm` is provided, or when
-            `auto_range=True` and this DataArray has only non-positive values.
+            the displayed slices. Ignored when `norm` is provided, when
+            `auto_range=True` and this DataArray has only non-positive values, or
+            when `auto_range=True`, this DataArray spans both signs and `vmin` is
+            given on its own (see `auto_range`).
         auto_range : bool, default: True
             Whether to pick the colormap range and default colormap automatically
             based on the sign of this DataArray:
 
             - Both positive and negative values: diverging, symmetric `[-m, m]`
-              range where `m = max(|vmin|, |vmax|)` (using the resolved bounds
-              above), with `cmap` defaulting to `"coolwarm"` — the right choice
-              for diverging statistics where the sign is meaningful (e.g.
-              t-statistics, correlation coefficients, PCA/ICA component maps).
+              range where `m = max(|vmin|, |vmax|)` over the bounds actually
+              provided, falling back to the largest magnitude in this DataArray
+              when neither is given, with `cmap` defaulting to `"coolwarm"` — the
+              right choice for diverging statistics where the sign is meaningful
+              (e.g. t-statistics, correlation coefficients, PCA/ICA component
+              maps).
             - Only non-negative values: sequential `[0, vmax]` range, with `cmap`
               defaulting to `"viridis"` — the right choice for non-diverging
               statistics where only magnitude matters (e.g. R², F-statistics).

--- a/tests/unit/test_plotting/test_image_stat_map.py
+++ b/tests/unit/test_plotting/test_image_stat_map.py
@@ -176,18 +176,19 @@ class TestPlotStatMap:
         assert norm.vmax == 5.0
         assert norm.vmin == -5.0
 
-    def test_vmax_alone_does_not_cap_the_range_when_data_min_is_larger(
-        self, sample_voxeldata_3d, matplotlib_pyplot
+    @pytest.mark.parametrize("bound", [{"vmax": 5.0}, {"vmin": -5.0}])
+    def test_a_lone_bound_caps_the_symmetric_range(
+        self, bound, sample_voxeldata_3d, matplotlib_pyplot
     ):
-        """vmin defaults to the data's actual min when not given, so a lone vmax
-        smaller than |data min| does not shrink the symmetric range."""
+        """A bound given on its own sets the symmetric range by itself, rather than
+        losing to the data's own min/max on the side left out."""
         stat_map = _signed_stat_map(sample_voxeldata_3d)  # min=-10, max=10
         plotter = plot_stat_map(
-            stat_map, bg_volume=sample_voxeldata_3d, slice_mode="z", vmax=5.0
+            stat_map, bg_volume=sample_voxeldata_3d, slice_mode="z", **bound
         )
         norm = _axes(plotter).ravel()[0].collections[-1].norm
-        assert norm.vmax == 10.0
-        assert norm.vmin == -10.0
+        assert norm.vmax == 5.0
+        assert norm.vmin == -5.0
 
     def test_auto_range_uses_sequential_range_and_viridis_for_nonneg_data(
         self, sample_voxeldata_3d, matplotlib_pyplot

--- a/tests/unit/test_plotting/test_matrix.py
+++ b/tests/unit/test_plotting/test_matrix.py
@@ -123,6 +123,16 @@ class TestPlotMatrixBehaviour:
         assert image.norm.vmax == pytest.approx(1.0)
         assert image.cmap.name == "coolwarm"
 
+    @pytest.mark.parametrize("bound", [{"vmax": 0.5}, {"vmin": -0.5}])
+    def test_a_lone_bound_caps_the_symmetric_range(self, bound, matplotlib_pyplot):
+        """A bound given on its own sets the symmetric range by itself, rather than
+        losing to the matrix's own min/max on the side left out."""
+        matrix = np.array([[1.0, -0.8], [-0.8, 1.0]])
+        _, ax = plot_matrix(matrix, **bound)
+        image = ax.collections[0]
+        assert image.norm.vmin == pytest.approx(-0.5)
+        assert image.norm.vmax == pytest.approx(0.5)
+
     def test_non_negative_matrix_gets_sequential_range(self, matplotlib_pyplot):
         """A non-negative matrix gets a [0, vmax] range and a sequential cmap."""
         matrix = np.array([[0.2, 0.8], [0.8, 0.2]])


### PR DESCRIPTION
Closes #443.

## Fix

With `auto_range=True` and data spanning both signs, the symmetric range is now built only from the bounds the caller actually passed: a lone `vmin` or `vmax` sets the range to `[-|bound|, |bound|]`. The data's own magnitude is used only when neither bound is given.

## Also in this PR

`_resolve_stat_map_style` and `_resolve_matrix_style` were identical apart from their input type and their colormap constant names, whose values were the same three strings. They are now a single `_resolve_colormap_style` in `confusius/plotting/_utils.py` with one set of colormap constants, so the two paths can no longer drift (net 51 lines removed).

## Behavior change

Code that passed a lone `vmin` or `vmax` on sign-spanning data and relied on it being ignored will see a different colormap range. `docs/examples/05_connectivity/02_atlas_seed_map.py` and `docs/examples/06_glm/01_first_level.py` both pass a lone `vmax` and now get the range their prose already claimed ("fixing the colormap to a shared range"), so only the CI-built gallery images change.

A lone `vmin=0` or `vmax=0` on sign-spanning data now resolves to a degenerate `[0, 0]` range, which matplotlib expands to `[-0.1, 0.1]`. That input asks for a symmetric range capped at magnitude zero, so it is left as is rather than falling back to the data, which is exactly the silent-drop behavior this PR removes.
