### PR TITLE
feat(xarray): add `get_bounding_box` and speed up atlas mesh clipping

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,13 +14,13 @@ Current development version for the next ConfUSIus release.
 
 - New [`get_bounding_box`][confusius.xarray.get_bounding_box] returning a VoxelData
   array's world-space bounding box, one per pose for pose-dependent geometry
-  ([#445](https://github.com/confusius-tools/confusius/pull/445)).
+  ([#446](https://github.com/confusius-tools/confusius/pull/446)).
 
 ### :zap: Performance
 
 - [`get_atlas_mesh`][confusius.atlas.get_atlas_mesh] with `clip=True` no longer
   materializes the full world-coordinate grid of an oblique atlas
-  ([#445](https://github.com/confusius-tools/confusius/pull/445)).
+  ([#446](https://github.com/confusius-tools/confusius/pull/446)).
 - [`compute_compcor_confounds`][confusius.signal.compute_compcor_confounds] no
   longer computes a full SVD, extracting components several times faster on
   large recordings or broad noise masks

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,8 +12,10 @@ Current development version for the next ConfUSIus release.
 
 ### :sparkles: Enhancements
 
-- New [`get_bounding_box`][confusius.xarray.get_bounding_box] returning a VoxelData
-  array's world-space bounding box, one per pose for pose-dependent geometry
+- New [`get_bounding_box`][confusius.xarray.get_bounding_box], also available as
+  [`data.fusi.affine.bounding_box`][confusius.xarray.FUSIAffineAccessor.bounding_box],
+  returning a VoxelData array's world-space bounding box, one per pose for
+  pose-dependent geometry
   ([#446](https://github.com/confusius-tools/confusius/pull/446)).
 
 ### :zap: Performance

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,8 +10,17 @@ icon: lucide/history
 
 Current development version for the next ConfUSIus release.
 
+### :sparkles: Enhancements
+
+- New [`get_bounding_box`][confusius.xarray.get_bounding_box] returning a VoxelData
+  array's world-space bounding box, one per pose for pose-dependent geometry
+  ([#445](https://github.com/confusius-tools/confusius/pull/445)).
+
 ### :zap: Performance
 
+- [`get_atlas_mesh`][confusius.atlas.get_atlas_mesh] with `clip=True` no longer
+  materializes the full world-coordinate grid of an oblique atlas
+  ([#445](https://github.com/confusius-tools/confusius/pull/445)).
 - [`compute_compcor_confounds`][confusius.signal.compute_compcor_confounds] no
   longer computes a full SVD, extracting components several times faster on
   large recordings or broad noise masks

--- a/docs/user-guide/xarray.md
+++ b/docs/user-guide/xarray.md
@@ -499,6 +499,14 @@ registered_to_qform = pwd.fusi.affine.apply("world_to_qform")
 shifted = pwd.fusi.affine.apply(my_affine)
 ```
 
+[`bounding_box`][confusius.xarray.FUSIAffineAccessor.bounding_box] gives the extent of
+the data in world space, computed from the affine alone (exact for oblique geometry,
+and one bounding box per pose when the geometry is pose-dependent):
+
+```python
+bbox = pwd.fusi.affine.bounding_box  # Dims (bound, component), e.g. ("max", "x").
+```
+
 To replace a DataArray's voxel-to-world geometry outright (e.g. after computing a new
 affine by hand), use
 [`set_voxel_to_world`][confusius.xarray.FUSIAffineAccessor.set_voxel_to_world]:

--- a/src/confusius/atlas/_world_to_base_transform.py
+++ b/src/confusius/atlas/_world_to_base_transform.py
@@ -22,7 +22,7 @@ from confusius._utils.geometry import (
     has_voxel_to_world_index,
 )
 from confusius.registration.bspline import sample_displacement_field_like
-from confusius.xarray import create_voxeldata
+from confusius.xarray import create_voxeldata, get_bounding_box
 
 WorldToBaseTransform = npt.NDArray[np.float64] | xr.DataArray
 """Pull transform mapping the atlas's world coordinates back to base atlas space.
@@ -382,20 +382,21 @@ def _drop_vertices_outside_grid(
     faces : numpy.ndarray
         Faces whose three vertices all survived, reindexed into the new vertex array.
     """
-    dims = list(WORLD_DIMS)
     voxel_dims = list(get_voxel_to_world_spatial_dims(reference))
     spacing = reference.fusi.spacing
+    # Corner-mapped bounds: never materializes the lazily derived z/y/x coordinate
+    # grids of an oblique affine (#444). Rows are (min, max), columns z/y/x.
+    bounds = get_bounding_box(reference).values
     inside = np.ones(len(vertices), dtype=bool)
-    for axis, (dim, voxel_dim) in enumerate(zip(dims, voxel_dims, strict=True)):
-        coord = reference.coords[dim].values
+    for axis, voxel_dim in enumerate(voxel_dims):
         # Keep the same one-voxel margin the field interpolation is padded to, so a
         # vertex within `spacing` of a boundary (e.g. the anterior/posterior tips of the
         # Allen brain) is retained rather than clipped. `fusi.spacing` is keyed by voxel
         # dim (k/j/i), not world dim (z/y/x) -- look it up by the matching voxel dim.
         coord_spacing = spacing.get(voxel_dim)
         margin = coord_spacing if coord_spacing is not None else 0.0
-        inside &= (vertices[:, axis] >= coord.min() - margin) & (
-            vertices[:, axis] <= coord.max() + margin
+        inside &= (vertices[:, axis] >= bounds[0, axis] - margin) & (
+            vertices[:, axis] <= bounds[1, axis] + margin
         )
 
     keep_idx = np.where(inside)[0]

--- a/src/confusius/atlas/_world_to_base_transform.py
+++ b/src/confusius/atlas/_world_to_base_transform.py
@@ -385,18 +385,20 @@ def _drop_vertices_outside_grid(
     voxel_dims = list(get_voxel_to_world_spatial_dims(reference))
     spacing = reference.fusi.spacing
     # Corner-mapped bounds: never materializes the lazily derived z/y/x coordinate
-    # grids of an oblique affine (#444). Rows are (min, max), columns z/y/x.
-    bounds = get_bounding_box(reference).values
+    # grids of an oblique affine (#444).
+    bbox = get_bounding_box(reference)
     inside = np.ones(len(vertices), dtype=bool)
-    for axis, voxel_dim in enumerate(voxel_dims):
+    for axis, (dim, voxel_dim) in enumerate(zip(WORLD_DIMS, voxel_dims, strict=True)):
         # Keep the same one-voxel margin the field interpolation is padded to, so a
         # vertex within `spacing` of a boundary (e.g. the anterior/posterior tips of the
         # Allen brain) is retained rather than clipped. `fusi.spacing` is keyed by voxel
         # dim (k/j/i), not world dim (z/y/x) -- look it up by the matching voxel dim.
         coord_spacing = spacing.get(voxel_dim)
         margin = coord_spacing if coord_spacing is not None else 0.0
-        inside &= (vertices[:, axis] >= bounds[0, axis] - margin) & (
-            vertices[:, axis] <= bounds[1, axis] + margin
+        low = bbox.sel(bound="min", component=dim).item()
+        high = bbox.sel(bound="max", component=dim).item()
+        inside &= (vertices[:, axis] >= low - margin) & (
+            vertices[:, axis] <= high + margin
         )
 
     keep_idx = np.where(inside)[0]

--- a/src/confusius/xarray/__init__.py
+++ b/src/confusius/xarray/__init__.py
@@ -15,6 +15,7 @@ __all__ = [
     "apply_affine",
     "create_voxeldata",
     "db_scale",
+    "get_bounding_box",
     "get_relative_affine",
     "log_scale",
     "power_scale",
@@ -37,6 +38,7 @@ _ATTR_TO_MODULE = {
     "log_scale": "confusius.xarray.scale",
     "power_scale": "confusius.xarray.scale",
     "apply_affine": "confusius.xarray.affine",
+    "get_bounding_box": "confusius.xarray.affine",
     "get_relative_affine": "confusius.xarray.affine",
     "reindex_voxels": "confusius.xarray.affine",
     "reindex_voxels_like": "confusius.xarray.affine",
@@ -60,6 +62,7 @@ if TYPE_CHECKING:
     from confusius.xarray.affine import (
         FUSIAffineAccessor,
         apply_affine,
+        get_bounding_box,
         get_relative_affine,
         reindex_voxels,
         reindex_voxels_like,

--- a/src/confusius/xarray/affine.py
+++ b/src/confusius/xarray/affine.py
@@ -1,5 +1,6 @@
 """Xarray accessor for affine transform operations."""
 
+import itertools
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -19,6 +20,84 @@ from confusius._utils.geometry import (
 
 if TYPE_CHECKING:
     import numpy.typing as npt
+
+
+def get_bounding_box(data: xr.DataArray) -> xr.DataArray:
+    """Return the world-space bounding box of a VoxelData array.
+
+    Bounds are of voxel centers (the voxel coordinate values mapped through the
+    voxel-to-world affine), without any half-voxel expansion or margin. The result
+    is exact for any affine, including oblique ones, without materializing the
+    lazily derived world coordinates: each world coordinate is an affine function
+    of the voxel coordinates, so its extremes over the grid are attained at the
+    corners of the voxel-coordinate box.
+
+    Parameters
+    ----------
+    data : xarray.DataArray
+        VoxelData array, normalized with
+        [ensure_voxeldata][confusius.validation.ensure_voxeldata] (scalar-indexed
+        voxel dims are restored as singletons before computing the bounds).
+
+    Returns
+    -------
+    (2, 3) xarray.DataArray
+        Bounding box with dims `(bound, component)`, where `bound` is
+        `["min", "max"]` and `component` is `["z", "y", "x"]`, and a `units` attr
+        from the voxel-to-world index. Pose-dependent geometry adds a leading
+        `pose` dim carrying the input's `pose` coordinate, one bounding box per
+        pose.
+
+    Raises
+    ------
+    TypeError
+        If `data` is not an `xarray.DataArray`.
+    ValueError
+        If `data` is not a valid VoxelData array.
+
+    Examples
+    --------
+    >>> bbox = get_bounding_box(volume)
+    >>> bbox.sel(bound="min", component="z").item()
+    """
+    from confusius.validation import ensure_voxeldata
+
+    data = ensure_voxeldata(data)
+    voxel_dims = get_voxel_to_world_spatial_dims(data)
+    affine = get_voxel_to_world_affine(data)
+
+    # The 8 corners of the voxel-coordinate box, as homogeneous column vectors.
+    corners = np.array(
+        list(
+            itertools.product(
+                *(
+                    (data.coords[dim].values.min(), data.coords[dim].values.max())
+                    for dim in voxel_dims
+                )
+            )
+        ),
+        dtype=np.float64,
+    )
+    corners_h = np.hstack([corners, np.ones((len(corners), 1))]).T
+
+    # (npose, 4, 4) @ (4, 8) broadcasts to one corner set per pose.
+    world_corners = (affine @ corners_h)[..., :-1, :]
+    bounds = np.stack([world_corners.min(axis=-1), world_corners.max(axis=-1)], axis=-2)
+
+    coords: dict[str, npt.ArrayLike] = {
+        "bound": np.array(["min", "max"], dtype=np.str_),
+        "component": np.array(WORLD_DIMS, dtype=np.str_),
+    }
+    dims = ("bound", "component")
+    if affine.ndim == 3:
+        dims = (POSE_DIM, *dims)
+        coords[POSE_DIM] = data.coords[POSE_DIM].values
+    return xr.DataArray(
+        bounds,
+        dims=dims,
+        coords=coords,
+        attrs={"units": get_voxel_to_world_units(data)},
+    )
 
 
 def get_relative_affine(

--- a/src/confusius/xarray/affine.py
+++ b/src/confusius/xarray/affine.py
@@ -530,6 +530,40 @@ class FUSIAffineAccessor:
             return self._obj
         return result
 
+    @property
+    def bounding_box(self) -> xr.DataArray:
+        """World-space bounding box of the wrapped VoxelData array.
+
+        Bounds are of voxel centers, without any half-voxel expansion or margin. See
+        [get_bounding_box][confusius.xarray.affine.get_bounding_box] for details.
+
+        Returns
+        -------
+        (2, 3) xarray.DataArray
+            Bounding box with dims `(bound, component)`, where `bound` is
+            `["min", "max"]` and `component` is `["z", "y", "x"]`, and a `units` attr
+            from the voxel-to-world index. Pose-dependent geometry adds a leading
+            `pose` dim carrying the input's `pose` coordinate, one bounding box per
+            pose.
+
+        Raises
+        ------
+        ValueError
+            If `self` is not a valid VoxelData array.
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> import confusius  # noqa: F401
+        >>> from confusius.xarray import create_voxeldata
+        >>> data = create_voxeldata(
+        ...     np.zeros((2, 3, 4)), dims=("k", "j", "i"), spacing=(1.0, 1.0, 1.0)
+        ... )
+        >>> data.fusi.affine.bounding_box.sel(bound="max", component="x").item()
+        1.5
+        """
+        return get_bounding_box(self._obj)
+
     def to(self, other: xr.DataArray, via: str) -> "npt.NDArray[np.float64]":
         """Return the affine mapping `self`'s world space into `other`'s.
 

--- a/tests/unit/test_xarray/test_affine.py
+++ b/tests/unit/test_xarray/test_affine.py
@@ -133,3 +133,11 @@ def test_non_dataarray_raises():
     """A bare numpy array is rejected."""
     with pytest.raises(TypeError):
         get_bounding_box(np.zeros((2, 3, 4)))  # ty: ignore[invalid-argument-type]
+
+
+def test_accessor_matches_function(rng):
+    """The `.fusi.affine.bounding_box` property returns the same bounds."""
+    data = create_voxeldata(
+        rng.random((4, 5, 6)), dims=("k", "j", "i"), voxel_to_world=OBLIQUE_AFFINE
+    )
+    assert_allclose(data.fusi.affine.bounding_box.values, get_bounding_box(data).values)

--- a/tests/unit/test_xarray/test_affine.py
+++ b/tests/unit/test_xarray/test_affine.py
@@ -1,0 +1,135 @@
+"""Tests for `confusius.xarray.affine` helpers (`get_bounding_box`)."""
+
+import numpy as np
+import pytest
+import xarray as xr
+from numpy.testing import assert_allclose
+
+from confusius.xarray import create_voxeldata, get_bounding_box
+
+OBLIQUE_AFFINE = np.array(
+    [
+        [0.3, 0.1, 0.0, -1.2],
+        [0.05, 0.25, 0.02, 2.0],
+        [0.0, 0.04, 0.5, -0.7],
+        [0.0, 0.0, 0.0, 1.0],
+    ]
+)
+"""Oblique voxel-to-world affine whose world coordinates mix all voxel dims."""
+
+
+def _materialized_bounds(data: xr.DataArray) -> np.ndarray:
+    """Reference implementation: reduce the fully materialized world coordinates."""
+    return np.array(
+        [
+            [data.coords[dim].values.min() for dim in "zyx"],
+            [data.coords[dim].values.max() for dim in "zyx"],
+        ]
+    )
+
+
+def test_oblique_bounds_match_materialized_coordinates(rng):
+    """Corner-mapped bounds equal the full-grid reduction for an oblique affine."""
+    data = create_voxeldata(
+        rng.random((4, 5, 6)), dims=("k", "j", "i"), voxel_to_world=OBLIQUE_AFFINE
+    )
+    bbox = get_bounding_box(data)
+    assert bbox.dims == ("bound", "component")
+    assert list(bbox.coords["bound"].values) == ["min", "max"]
+    assert list(bbox.coords["component"].values) == ["z", "y", "x"]
+    assert_allclose(bbox.values, _materialized_bounds(data))
+
+
+def test_axis_aligned_bounds_match_coordinate_extremes(rng):
+    """Axis-aligned geometry reproduces the eager 1D coordinate min/max and units."""
+    data = create_voxeldata(
+        rng.random((4, 6, 8)),
+        dims=("k", "j", "i"),
+        spacing=(0.2, 0.1, 0.05),
+        origin=(1.0, 2.0, 3.0),
+    )
+    bbox = get_bounding_box(data)
+    assert_allclose(bbox.values, _materialized_bounds(data))
+    assert bbox.attrs["units"] == "mm"
+
+
+def test_irregular_voxel_coordinates(rng):
+    """Non-contiguous voxel coordinates still give exact bounds."""
+    data = create_voxeldata(
+        rng.random((3, 4, 3)),
+        dims=("k", "j", "i"),
+        k=[1, 5, 6],
+        j=[0, 1, 2, 9],
+        i=[0, 2, 3],
+        voxel_to_world=OBLIQUE_AFFINE,
+    )
+    assert_allclose(get_bounding_box(data).values, _materialized_bounds(data))
+
+
+def test_singleton_dim_slice(rng):
+    """A size-1 voxel dim (canonical 2D slice) keeps the output shape and is exact."""
+    data = create_voxeldata(
+        rng.random((1, 5, 6)), dims=("k", "j", "i"), voxel_to_world=OBLIQUE_AFFINE
+    )
+    bbox = get_bounding_box(data)
+    assert bbox.dims == ("bound", "component")
+    assert_allclose(bbox.values, _materialized_bounds(data))
+
+
+def test_scalar_isel_input_is_canonicalized(rng):
+    """A scalar-`isel` input gives the same bounds as its singleton-dim equivalent."""
+    data = create_voxeldata(
+        rng.random((4, 5, 6)), dims=("k", "j", "i"), voxel_to_world=OBLIQUE_AFFINE
+    )
+    assert_allclose(
+        get_bounding_box(data.isel(k=1)).values,
+        get_bounding_box(data.isel(k=[1])).values,
+    )
+
+
+def test_pose_dependent_bounds_per_pose(rng):
+    """Pose-dependent geometry yields one bounding box per pose, pose coord kept."""
+    shifted = OBLIQUE_AFFINE.copy()
+    shifted[:3, 3] += [5.0, -2.0, 1.5]
+    data = create_voxeldata(
+        rng.random((2, 3, 4, 5)),
+        dims=("pose", "k", "j", "i"),
+        pose=[10, 20],
+        voxel_to_world=np.stack([OBLIQUE_AFFINE, shifted]),
+    )
+    bbox = get_bounding_box(data)
+    assert bbox.dims == ("pose", "bound", "component")
+    assert list(bbox.coords["pose"].values) == [10, 20]
+    expected = np.stack(
+        [
+            np.stack(
+                [
+                    data.coords[dim].min(dim=("k", "j", "i")).values
+                    for dim in "zyx"
+                ],
+                axis=-1,
+            ),
+            np.stack(
+                [
+                    data.coords[dim].max(dim=("k", "j", "i")).values
+                    for dim in "zyx"
+                ],
+                axis=-1,
+            ),
+        ],
+        axis=1,
+    )
+    assert_allclose(bbox.values, expected)
+
+
+def test_non_voxeldata_raises():
+    """A DataArray without voxel-to-world geometry is rejected."""
+    plain = xr.DataArray(np.zeros((2, 3, 4)), dims=("z", "y", "x"))
+    with pytest.raises(ValueError):
+        get_bounding_box(plain)
+
+
+def test_non_dataarray_raises():
+    """A bare numpy array is rejected."""
+    with pytest.raises(TypeError):
+        get_bounding_box(np.zeros((2, 3, 4)))  # ty: ignore[invalid-argument-type]


### PR DESCRIPTION
## Summary

`get_atlas_mesh` with `clip=True` materialized the full lazy `z`/`y`/`x` coordinate grids of an atlas, only to reduce them to per-axis min/max (gigabytes and seconds on Allen-scale grids). Closes #444.

- New public `get_bounding_box(data)` in `confusius.xarray`: maps the 8 corners of the voxel-coordinate box through the voxel-to-world affine. The bounds are identical to the full-grid reduction (the extremes of an affine function over a box are at its corners) and cost O(1) instead of O(n_voxels). The output is a `(bound, component)` DataArray with a `units` attr, and one bounding box per pose for pose-dependent geometry. The input is normalized with `ensure_voxeldata`, so scalar-indexed voxel dims are restored before the computation.
- `_drop_vertices_outside_grid` now clips mesh vertices with these bounds. The one-voxel spacing margin is unchanged, so clipping results are identical.

## Timing

Wall time of `get_atlas_mesh(ds, "root")` on `allen_mouse_25um` (528 x 320 x 456 voxels), best of 3 runs after a warm-up call, on an i7-12700H (WSL2):

| Case | Before (8e48b52) | After | Speedup |
|---|---|---|---|
| Fetched atlas (axis-aligned affine) | 4.91 s | 0.007 s | ~700x |
| World rotated 10 degrees (oblique, post-registration geometry) | 5.08 s | 0.007 s | ~700x |

## Tests

- New `tests/unit/test_xarray/test_affine.py`: oblique, axis-aligned, irregular-coordinate, singleton-dim, and per-pose cases, each compared with a brute-force reference that reduces the materialized world coordinates; scalar-`isel` canonicalization; error paths for non-VoxelData and non-DataArray input.
- Full suite: 2688 passed.
